### PR TITLE
[None][model] Add single-gpu LTX-2.3 pipeline.

### DIFF
--- a/examples/visual_gen/configs/ltx23-4gpu.yaml
+++ b/examples/visual_gen/configs/ltx23-4gpu.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 4-GPU LTX-2.3 AudioVideo parallel config (precision-agnostic - picks up
+# whatever checkpoint is passed via --model_path). Phase-2: enable after
+# single-GPU BF16 parity. Shared by offline examples and trtllm-serve.
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 2
+  ulysses_size: 2
+  async_ulysses: true
+torch_compile_config:
+  enable: true
+cuda_graph_config:
+  enable: true

--- a/examples/visual_gen/configs/ltx23-t2v-bf16-1gpu.yaml
+++ b/examples/visual_gen/configs/ltx23-t2v-bf16-1gpu.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU LTX-2.3 text-to-video with audio, BF16 (Phase-0 parity target).
+# No quantization, eager transformer, no CUDA graph / torch.compile.
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+torch_compile_config:
+  enable: false
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/configs/ltx23-t2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/ltx23-t2v-fp4-1gpu.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU LTX-2.3 text-to-video with audio, NVFP4 / Blackwell (Phase-2).
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
+quant_config:
+  quant_algo: NVFP4
+  dynamic: true
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/configs/ltx23-t2v-fp8-1gpu.yaml
+++ b/examples/visual_gen/configs/ltx23-t2v-fp8-1gpu.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU LTX-2.3 text-to-video with audio, FP8 (Phase-2, enable after BF16 parity).
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
+quant_config:
+  quant_algo: FP8_BLOCK_SCALES
+  dynamic: true
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/models/ltx23.py
+++ b/examples/visual_gen/models/ltx23.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""LTX-2.3 Text-to-Video generation with audio.
+
+Usage:
+    python ltx23.py
+    python ltx23.py --visual_gen_args ../configs/ltx23-t2v-bf16-1gpu.yaml
+"""
+
+import argparse
+
+from tensorrt_llm import VisualGen, VisualGenArgs
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LTX-2.3 Text-to-Video example")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="Lightricks/LTX-2.3",
+        help="Model path or HuggingFace Hub ID",
+    )
+    parser.add_argument(
+        "--visual_gen_args",
+        dest="visual_gen_args",
+        type=str,
+        default=None,
+        help="Path to YAML config (same as trtllm-serve --visual_gen_args)",
+    )
+    parser.add_argument(
+        "--text_encoder_path",
+        type=str,
+        default=None,
+        help=(
+            "Gemma3 text encoder path. Overrides pipeline_config.text_encoder_path "
+            "from --visual_gen_args when set."
+        ),
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="ltx23_t2v_output.mp4",
+        help="Path to save the output video",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="A cinematic shot of a cat walking through a field of flowers",
+        help="Text prompt",
+    )
+    parser.add_argument("--height", type=int, default=512)
+    parser.add_argument("--width", type=int, default=768)
+    parser.add_argument("--num_frames", type=int, default=121)
+    parser.add_argument("--frame_rate", type=float, default=24.0)
+    parser.add_argument("--num_inference_steps", type=int, default=40)
+    parser.add_argument("--guidance_scale", type=float, default=4.0)
+    args = parser.parse_args()
+
+    # LTX-2.3 requires pipeline_config.text_encoder_path for the Gemma3 text
+    # encoder. The YAML path is preferred for production configs; the default
+    # below keeps this script runnable as a minimal offline example.
+    extra_args = (
+        VisualGenArgs.from_yaml(args.visual_gen_args) if args.visual_gen_args else VisualGenArgs()
+    )
+    text_encoder_path = args.text_encoder_path
+    if text_encoder_path is None and not args.visual_gen_args:
+        text_encoder_path = "google/gemma-3-12b-it"
+    if text_encoder_path is not None:
+        extra_args.pipeline_config = {
+            **extra_args.pipeline_config,
+            "text_encoder_path": text_encoder_path,
+        }
+    visual_gen = VisualGen(model=args.model, args=extra_args)
+
+    # --- Model-specific: T2V request construction ---
+    # Start from LTX-2.3 defaults and override the main request shape explicitly.
+    params = visual_gen.default_params
+    params.height = args.height
+    params.width = args.width
+    params.num_frames = args.num_frames
+    params.frame_rate = args.frame_rate
+    params.num_inference_steps = args.num_inference_steps
+    params.guidance_scale = args.guidance_scale
+
+    output = visual_gen.generate(
+        inputs=args.prompt,
+        params=params,
+    )
+
+    output.save(args.output_path)
+    print(f"Saved: {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/_torch/visual_gen/models/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/__init__.py
@@ -36,6 +36,7 @@ from ..pipeline_registry import AutoPipeline, register_pipeline
 from .cosmos3 import Cosmos3OmniMoTPipeline
 from .flux import Flux2Pipeline, FluxPipeline
 from .ltx2 import LTX2Pipeline  # noqa: F401
+from .ltx23 import LTX23Pipeline  # noqa: F401
 from .qwen_image import QwenImageEditPlusPipeline, QwenImagePipeline
 from .qwen_image_layered import QwenImageLayeredPipeline
 from .wan import WanImageToVideoPipeline, WanPipeline

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+
+from .pipeline_ltx23 import LTX23Pipeline
+
+__all__ = [
+    "LTX23Pipeline",
+]

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/connector.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/connector.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 ("V2") embeddings connector + split feature extractor.
+
+Differences from LTX-2 that this module encodes (all verified against the
+LTX-2.3 checkpoint weight shapes):
+
+* Feature extraction is **split per modality and happens before the connector**
+  (``caption_proj_before_connector=True``):
+    - ``video_aggregate_embed``: Linear(3840*49 -> 4096, bias=True)
+    - ``audio_aggregate_embed``: Linear(3840*49 -> 2048, bias=True)
+  vs LTX-2's single shared ``aggregate_embed`` Linear(3840*49 -> 3840, bias=False).
+
+* Two separate connectors with distinct dims / depth / gating:
+    - video: 32 heads x 128 = 4096, 8 layers, gated, 128 registers
+    - audio: 32 heads x 64  = 2048, 8 layers, gated, 128 registers
+  vs LTX-2's single 30x128=3840, 2-layer, ungated connector consuming a shared
+  projection.
+
+The ``Embeddings1DConnector`` nn.Module itself is structurally identical to
+LTX-2 (it already supports configurable heads/dim/layers/registers and gated
+attention), so we reuse it and only provide V2 configurators + the split
+feature extractor here.
+"""
+
+import math
+
+import torch
+
+from ...ltx2.ltx2_core.connector import Embeddings1DConnector
+from ...ltx2.ltx2_core.rope import LTXRopeType
+
+# Gemma-3-12b-it exposes 49 hidden states (48 transformer layers + embeddings),
+# each of width ``caption_channels`` (3840). The feature extractor flattens all
+# of them, matching the checkpoint's [out, 3840*49] projection weights.
+_NUM_GEMMA_HIDDEN_STATES = 49
+
+
+def _transformer_cfg(config: dict) -> dict:
+    return config.get("transformer", config)
+
+
+class LTX23GemmaFeaturesExtractor(torch.nn.Module):
+    """Split Gemma feature extractor (video + audio), pre-connector.
+
+    Maps to checkpoint keys ``text_embedding_projection.video_aggregate_embed``
+    and ``text_embedding_projection.audio_aggregate_embed``.
+    """
+
+    def __init__(
+        self,
+        caption_channels: int = 3840,
+        video_dim: int = 4096,
+        audio_dim: int = 2048,
+        num_hidden_states: int = _NUM_GEMMA_HIDDEN_STATES,
+    ) -> None:
+        super().__init__()
+        in_features = caption_channels * num_hidden_states
+        # Per-modality norm rescale reference: the flattened, per-token-RMS'd
+        # features are rescaled by sqrt(out_dim / embedding_dim) before each
+        # projection (ltx-core FeatureExtractorV2._rescale_norm). embedding_dim
+        # is the Gemma hidden width (caption_channels), NOT the flattened size.
+        self.embedding_dim = caption_channels
+        self.video_aggregate_embed = torch.nn.Linear(in_features, video_dim, bias=True)
+        self.audio_aggregate_embed = torch.nn.Linear(in_features, audio_dim, bias=True)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """x: flattened Gemma features [..., caption_channels * num_hidden_states].
+
+        Returns (video_features -> video_dim, audio_features -> audio_dim).
+        Applies the modality-specific ``sqrt(out_dim / embedding_dim)`` rescale
+        (matching ltx-core ``FeatureExtractorV2``) before each projection.
+        """
+        v_scale = math.sqrt(self.video_aggregate_embed.out_features / self.embedding_dim)
+        a_scale = math.sqrt(self.audio_aggregate_embed.out_features / self.embedding_dim)
+        return (
+            self.video_aggregate_embed(x * v_scale),
+            self.audio_aggregate_embed(x * a_scale),
+        )
+
+    @classmethod
+    def from_config(cls, config: dict) -> "LTX23GemmaFeaturesExtractor":
+        cfg = _transformer_cfg(config)
+        return cls(
+            caption_channels=cfg.get("caption_channels", 3840),
+            video_dim=cfg.get("cross_attention_dim", 4096),
+            audio_dim=cfg.get("audio_cross_attention_dim", 2048),
+        )
+
+
+def _build_connector(
+    cfg: dict,
+    num_attention_heads: int,
+    attention_head_dim: int,
+) -> Embeddings1DConnector:
+    # LTX-2.3 default is SPLIT (matches ltx-core); the 2.3 checkpoint sets this
+    # explicitly, so the default only guards future/partial configs.
+    rope_type = LTXRopeType(cfg.get("rope_type", "split"))
+    double_precision_rope = cfg.get("frequencies_precision", False) == "float64"
+    return Embeddings1DConnector(
+        attention_head_dim=attention_head_dim,
+        num_attention_heads=num_attention_heads,
+        num_layers=cfg.get("connector_num_layers", 8),
+        positional_embedding_max_pos=cfg.get(
+            "connector_positional_embedding_max_pos", [4096]
+        ),
+        num_learnable_registers=cfg.get("connector_num_learnable_registers", 128),
+        rope_type=rope_type,
+        double_precision_rope=double_precision_rope,
+        apply_gated_attention=cfg.get("connector_apply_gated_attention", True),
+    )
+
+
+class LTX23VideoConnectorConfigurator:
+    """Video connector: 32 x 128 = 4096, 8 layers, gated, 128 registers."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> Embeddings1DConnector:
+        cfg = _transformer_cfg(config)
+        return _build_connector(
+            cfg,
+            num_attention_heads=cfg.get("connector_num_attention_heads", 32),
+            attention_head_dim=cfg.get("connector_attention_head_dim", 128),
+        )
+
+
+class LTX23AudioConnectorConfigurator:
+    """Audio connector: 32 x 64 = 2048, 8 layers, gated, 128 registers."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> Embeddings1DConnector:
+        cfg = _transformer_cfg(config)
+        return _build_connector(
+            cfg,
+            num_attention_heads=cfg.get("audio_connector_num_attention_heads", 32),
+            attention_head_dim=cfg.get("audio_connector_attention_head_dim", 64),
+        )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/modality.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/modality.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 modality bundle.
+
+Extends the LTX-2 ``Modality`` with an explicit ``sigma`` field. The two are
+kept distinct on purpose:
+
+* ``timesteps`` may vary per latent token (conditioned / masked generation) and
+  drives the per-token AdaLN modulation (MSA / MLP / text-CA query).
+* ``sigma`` is the *global* current denoising value. It derives the
+  ``prompt_timestep`` that drives the sigma-dependent text-context (K/V)
+  modulation via ``prompt_scale_shift_table``. This is the LTX-2.3-specific
+  conditioning that makes text K/V step-varying (so it cannot be cached like
+  LTX-2's static text K/V).
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class LTX23Modality:
+    """Input data for a single modality (video or audio) in the LTX-2.3 transformer."""
+
+    latent: torch.Tensor  # (B, T, D): packed latent tokens
+    timesteps: torch.Tensor  # (B,) or (B, T): per-batch or per-token timesteps
+    sigma: torch.Tensor  # (B,) global current denoising value (drives prompt cond)
+    positions: torch.Tensor  # (B, n_dims, T)[, 2]: index grid
+    context: torch.Tensor  # connector text embeddings (already inner_dim)
+    enabled: bool = True
+    context_mask: torch.Tensor | None = None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/video_vae_ltx23.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/video_vae_ltx23.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 ("V2") video VAE decoder.
+
+LTX-2.3 reuses LTX-2's VAE *primitives* (ResnetBlock3D / UNetMidBlock3D /
+DepthToSpaceUpsample / convs) and forward/tiled-decode machinery, but its
+decoder channel recipe differs in one structural way that LTX-2's ``VideoDecoder``
+cannot express:
+
+* In LTX-2, only ``res_x_y`` and ``compress_all`` change channels; the spatial
+  upsamplers ``compress_time`` / ``compress_space`` keep channels unchanged.
+* In LTX-2.3, **``compress_time`` and ``compress_space`` also reduce channels by
+  their ``multiplier``** (exactly like ``compress_all``), i.e. their internal
+  conv emits ``in * prod(stride) // multiplier`` channels and the depth-to-space
+  rearrange yields ``in // multiplier``.
+
+Consequently the ``conv_in`` feature width is ``latent_channels`` times the
+product of **every** compress/res_x_y multiplier (reversed order), not just the
+``compress_all`` ones. For the LTX-2.3 checkpoint recipe
+(compress_all=2, compress_all=1, compress_time=2, compress_space=2) that is
+``128 * (2*1*2*2) = 1024`` -- matching ``conv_in.conv.weight [1024, 128, 3,3,3]``.
+
+We subclass LTX-2's ``VideoDecoder`` so all of its ``forward`` / ``tiled_decode``
+/ per-channel-statistics / tiling logic is inherited unchanged, and rebuild only
+the channel-bearing modules (``conv_in``, ``up_blocks``, ``conv_norm_out``,
+``conv_out``) with the corrected channel flow. LTX-2.3 also uses a single shared
+``spatial_padding_mode`` config key (vs LTX-2's per-role decoder/encoder keys).
+"""
+
+from typing import List, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from ...ltx2.ltx2_core.normalization import PixelNorm
+from ...ltx2.ltx2_core.video_vae.convolution import make_conv_nd
+from ...ltx2.ltx2_core.video_vae.enums import NormLayerType, PaddingModeType
+from ...ltx2.ltx2_core.video_vae.resnet import ResnetBlock3D, UNetMidBlock3D
+from ...ltx2.ltx2_core.video_vae.sampling import DepthToSpaceUpsample
+from ...ltx2.ltx2_core.video_vae.video_vae import VideoDecoder
+
+# Spatial/temporal strides per compress block (LTX-2.3 == LTX-2 spatially; the
+# only difference is the channel reduction below).
+_COMPRESS_STRIDES = {
+    "compress_time": (2, 1, 1),
+    "compress_space": (1, 2, 2),
+    "compress_all": (2, 2, 2),
+}
+
+
+def _channel_multiplier(block_name: str, block_config: dict) -> int:
+    """Factor by which this block reduces channels in the forward pass.
+
+    Used to pre-size ``conv_in`` (the reversed product of these factors). Blocks
+    that do not change channels (``res_x`` / ``attn_res_x``) return 1.
+    """
+    if block_name == "res_x_y":
+        return block_config.get("multiplier", 2)
+    if block_name in _COMPRESS_STRIDES:
+        return block_config.get("multiplier", 1)
+    return 1
+
+
+def _make_ltx23_decoder_block(
+    block_name: str,
+    block_config: dict,
+    in_channels: int,
+    dims: int,
+    norm_layer: NormLayerType,
+    timestep_conditioning: bool,
+    norm_num_groups: int,
+    spatial_padding_mode: PaddingModeType,
+) -> Tuple[nn.Module, int]:
+    """Like LTX-2's ``_make_decoder_block`` but compress_time/space reduce channels."""
+    out_channels = in_channels
+    if block_name == "res_x":
+        block = UNetMidBlock3D(
+            dims=dims,
+            in_channels=in_channels,
+            num_layers=block_config["num_layers"],
+            resnet_eps=1e-6,
+            resnet_groups=norm_num_groups,
+            norm_layer=norm_layer,
+            inject_noise=block_config.get("inject_noise", False),
+            timestep_conditioning=timestep_conditioning,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "attn_res_x":
+        block = UNetMidBlock3D(
+            dims=dims,
+            in_channels=in_channels,
+            num_layers=block_config["num_layers"],
+            resnet_groups=norm_num_groups,
+            norm_layer=norm_layer,
+            inject_noise=block_config.get("inject_noise", False),
+            timestep_conditioning=timestep_conditioning,
+            attention_head_dim=block_config["attention_head_dim"],
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name == "res_x_y":
+        multiplier = block_config.get("multiplier", 2)
+        out_channels = in_channels // multiplier
+        block = ResnetBlock3D(
+            dims=dims,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            eps=1e-6,
+            groups=norm_num_groups,
+            norm_layer=norm_layer,
+            inject_noise=block_config.get("inject_noise", False),
+            timestep_conditioning=False,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    elif block_name in _COMPRESS_STRIDES:
+        # LTX-2.3: compress_* reduces channels by `multiplier` (LTX-2 only did
+        # this for compress_all). out = in // multiplier; the internal conv emits
+        # in * prod(stride) // multiplier.
+        multiplier = block_config.get("multiplier", 1)
+        out_channels = in_channels // multiplier
+        block = DepthToSpaceUpsample(
+            dims=dims,
+            in_channels=in_channels,
+            stride=_COMPRESS_STRIDES[block_name],
+            residual=block_config.get("residual", False),
+            out_channels_reduction_factor=multiplier,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+    else:
+        raise ValueError(f"unknown decoder block: {block_name}")
+    return block, out_channels
+
+
+class LTX23VideoDecoder(VideoDecoder):
+    """LTX-2.3 video decoder: LTX-2 primitives, LTX-2.3 channel recipe."""
+
+    def __init__(
+        self,
+        convolution_dimensions: int = 3,
+        in_channels: int = 128,
+        out_channels: int = 3,
+        decoder_blocks: List[Tuple[str, Union[int, dict]]] = [],
+        patch_size: int = 4,
+        norm_layer: NormLayerType = NormLayerType.PIXEL_NORM,
+        causal: bool = False,
+        timestep_conditioning: bool = False,
+        spatial_padding_mode: PaddingModeType = PaddingModeType.REFLECT,
+    ):
+        # Build the LTX-2 decoder first so every non-block attribute
+        # (per_channel_statistics, downscale factors, decode params) and all
+        # inherited forward/tiled_decode methods are set up. Its conv_in/up_blocks
+        # use LTX-2 channel math (wrong for LTX-2.3); we overwrite them below.
+        super().__init__(
+            convolution_dimensions=convolution_dimensions,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            decoder_blocks=decoder_blocks,
+            patch_size=patch_size,
+            norm_layer=norm_layer,
+            causal=causal,
+            timestep_conditioning=timestep_conditioning,
+            decoder_spatial_padding_mode=spatial_padding_mode,
+        )
+
+        dims = convolution_dimensions
+        patched_out_channels = out_channels * patch_size**2
+
+        # conv_in width = latent_channels * product of all channel multipliers
+        # (reversed order), so the whole decoder narrows back down to `in_channels`.
+        feature_channels = in_channels
+        for block_name, block_params in list(reversed(decoder_blocks)):
+            cfg = block_params if isinstance(block_params, dict) else {}
+            feature_channels *= _channel_multiplier(block_name, cfg)
+
+        self.conv_in = make_conv_nd(
+            dims=dims,
+            in_channels=in_channels,
+            out_channels=feature_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+        up_blocks = nn.ModuleList([])
+        fc = feature_channels
+        for block_name, block_params in list(reversed(decoder_blocks)):
+            cfg = {"num_layers": block_params} if isinstance(block_params, int) else block_params
+            block, fc = _make_ltx23_decoder_block(
+                block_name=block_name,
+                block_config=cfg,
+                in_channels=fc,
+                dims=dims,
+                norm_layer=norm_layer,
+                timestep_conditioning=timestep_conditioning,
+                norm_num_groups=self._norm_num_groups,
+                spatial_padding_mode=spatial_padding_mode,
+            )
+            up_blocks.append(block)
+        self.up_blocks = up_blocks
+
+        if norm_layer == NormLayerType.GROUP_NORM:
+            self.conv_norm_out = nn.GroupNorm(
+                num_channels=fc, num_groups=self._norm_num_groups, eps=1e-6
+            )
+        elif norm_layer == NormLayerType.PIXEL_NORM:
+            self.conv_norm_out = PixelNorm()
+        self.conv_act = nn.SiLU()
+        self.conv_out = make_conv_nd(
+            dims=dims,
+            in_channels=fc,
+            out_channels=patched_out_channels,
+            kernel_size=3,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+        # LTX-2.3 checkpoint has timestep_conditioning=False; keep the branch
+        # correct anyway (rebuild sized to the corrected final channels).
+        if timestep_conditioning:
+            from ...ltx2.ltx2_core.timestep_embedding import (
+                PixArtAlphaCombinedTimestepSizeEmbeddings,
+            )
+
+            self.last_time_embedder = PixArtAlphaCombinedTimestepSizeEmbeddings(
+                embedding_dim=fc * 2, size_emb_dim=0
+            )
+            self.last_scale_shift_table = nn.Parameter(torch.empty(2, fc))
+
+
+class LTX23VideoDecoderConfigurator:
+    """Create an ``LTX23VideoDecoder`` from the native LTX-2.3 config dict."""
+
+    @classmethod
+    def from_config(cls, config: dict) -> LTX23VideoDecoder:
+        vae = config.get("vae", {})
+        # LTX-2.3 uses a single shared `spatial_padding_mode` key (LTX-2 split it
+        # into decoder_/encoder_ variants).
+        padding_mode = vae.get(
+            "spatial_padding_mode", vae.get("decoder_spatial_padding_mode", "reflect")
+        )
+        return LTX23VideoDecoder(
+            convolution_dimensions=vae.get("dims", 3),
+            in_channels=vae.get("latent_channels", 128),
+            out_channels=vae.get("out_channels", 3),
+            decoder_blocks=vae.get("decoder_blocks", []),
+            patch_size=vae.get("patch_size", 4),
+            norm_layer=NormLayerType(vae.get("norm_layer", "pixel_norm")),
+            causal=vae.get("causal_decoder", False),
+            timestep_conditioning=vae.get("timestep_conditioning", False),
+            spatial_padding_mode=PaddingModeType(padding_mode),
+        )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/vocoder_ltx23.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/ltx23_core/vocoder_ltx23.py
@@ -1,0 +1,640 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 vocoder: BigVGAN-v2 (AMP1) + bandwidth-extension (BWE) -> 48 kHz.
+
+LTX-2 ships a HiFi-GAN vocoder (``ResBlock1`` + LeakyReLU, 24 kHz). LTX-2.3
+replaces it with a BigVGAN-v2 generator using SnakeBeta activations and
+anti-aliased ``Activation1d`` resampling, wrapped in a ``VocoderWithBWE`` that
+re-analyzes the 16 kHz output with a causal mel-STFT, predicts a residual with a
+second BigVGAN generator, and adds a Hann-sinc-resampled skip to reach 48 kHz.
+
+This is a faithful port of the upstream Lightricks ``ltx_core`` vocoder
+(``packages/ltx-core/src/ltx_core/model/audio_vae/vocoder.py``) restricted to
+the AMP1 path LTX-2.3 uses. Every module name matches the checkpoint's
+``vocoder.vocoder.*`` / ``vocoder.bwe_generator.*`` / ``vocoder.mel_stft.*``
+keys so weights load without remapping.
+
+Numerical contract (do not "optimize" away):
+* SnakeBeta is log-scale: ``alpha=exp(alpha)``, ``beta=exp(beta)``.
+* The whole ``VocoderWithBWE`` forward runs in fp32 (bf16 accumulation
+  degrades spectral metrics 40-90% across the ~108 sequential convs).
+* The BWE generator has ``apply_final_activation=False`` (residual, no clamp).
+"""
+
+import contextlib
+import math
+from collections.abc import Iterator
+from typing import List
+
+import einops
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+LRELU_SLOPE = 0.1
+
+
+def get_padding(kernel_size: int, dilation: int = 1) -> int:
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+def _check_config_value(cfg: dict, key: str, expected) -> None:
+    actual = cfg.get(key)
+    if actual != expected:
+        raise ValueError(
+            f"LTX-2.3 vocoder config mismatch: expected {key}={expected!r}, got {actual!r}"
+        )
+
+
+@contextlib.contextmanager
+def _module_in_fp32(module: nn.Module, *, enabled: bool) -> Iterator[None]:
+    """Temporarily cast *module* to float32, restoring its dtype on exit (MPS path)."""
+    if not enabled:
+        yield
+        return
+    module_dtype = next(module.parameters()).dtype
+    module.float()
+    try:
+        yield
+    finally:
+        module.to(module_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Anti-aliased resampling helpers (Kaiser-sinc filters) for BigVGAN v2.
+# Adopted from https://github.com/NVIDIA/BigVGAN
+# ---------------------------------------------------------------------------
+
+
+def _sinc(x: torch.Tensor) -> torch.Tensor:
+    return torch.where(
+        x == 0,
+        torch.tensor(1.0, device=x.device, dtype=x.dtype),
+        torch.sin(math.pi * x) / math.pi / x,
+    )
+
+
+def kaiser_sinc_filter1d(cutoff: float, half_width: float, kernel_size: int) -> torch.Tensor:
+    even = kernel_size % 2 == 0
+    half_size = kernel_size // 2
+    delta_f = 4 * half_width
+    amplitude = 2.285 * (half_size - 1) * math.pi * delta_f + 7.95
+    if amplitude > 50.0:
+        beta = 0.1102 * (amplitude - 8.7)
+    elif amplitude >= 21.0:
+        beta = 0.5842 * (amplitude - 21) ** 0.4 + 0.07886 * (amplitude - 21.0)
+    else:
+        beta = 0.0
+    window = torch.kaiser_window(kernel_size, beta=beta, periodic=False)
+    time = (
+        torch.arange(-half_size, half_size) + 0.5
+        if even
+        else torch.arange(kernel_size) - half_size
+    )
+    if cutoff == 0:
+        filter_ = torch.zeros_like(time)
+    else:
+        filter_ = 2 * cutoff * window * _sinc(2 * cutoff * time)
+        filter_ /= filter_.sum()
+    return filter_.view(1, 1, kernel_size)
+
+
+class LowPassFilter1d(nn.Module):
+    def __init__(
+        self,
+        cutoff: float = 0.5,
+        half_width: float = 0.6,
+        stride: int = 1,
+        padding: bool = True,
+        padding_mode: str = "replicate",
+        kernel_size: int = 12,
+    ) -> None:
+        super().__init__()
+        if cutoff < -0.0:
+            raise ValueError("Minimum cutoff must be larger than zero.")
+        if cutoff > 0.5:
+            raise ValueError("A cutoff above 0.5 does not make sense.")
+        self.kernel_size = kernel_size
+        self.even = kernel_size % 2 == 0
+        self.pad_left = kernel_size // 2 - int(self.even)
+        self.pad_right = kernel_size // 2
+        self.stride = stride
+        self.padding = padding
+        self.padding_mode = padding_mode
+        self.register_buffer("filter", kaiser_sinc_filter1d(cutoff, half_width, kernel_size))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _, n_channels, _ = x.shape
+        if self.padding:
+            x = F.pad(x, (self.pad_left, self.pad_right), mode=self.padding_mode)
+        return F.conv1d(
+            x, self.filter.expand(n_channels, -1, -1), stride=self.stride, groups=n_channels
+        )
+
+
+class UpSample1d(nn.Module):
+    def __init__(
+        self,
+        ratio: int = 2,
+        kernel_size: int | None = None,
+        persistent: bool = True,
+        window_type: str = "kaiser",
+    ) -> None:
+        super().__init__()
+        self.ratio = ratio
+        self.stride = ratio
+
+        if window_type == "hann":
+            # Hann-windowed sinc (equivalent to torchaudio.functional.resample);
+            # used for the BWE skip connection. Filter is not stored in checkpoint.
+            rolloff = 0.99
+            lowpass_filter_width = 6
+            width = math.ceil(lowpass_filter_width / rolloff)
+            self.kernel_size = 2 * width * ratio + 1
+            self.pad = width
+            self.pad_left = 2 * width * ratio
+            self.pad_right = self.kernel_size - ratio
+            time_axis = (torch.arange(self.kernel_size) / ratio - width) * rolloff
+            time_clamped = time_axis.clamp(-lowpass_filter_width, lowpass_filter_width)
+            window = torch.cos(time_clamped * math.pi / lowpass_filter_width / 2) ** 2
+            sinc_filter = (torch.sinc(time_axis) * window * rolloff / ratio).view(1, 1, -1)
+        else:
+            # Kaiser-windowed sinc (BigVGAN default).
+            self.kernel_size = int(6 * ratio // 2) * 2 if kernel_size is None else kernel_size
+            self.pad = self.kernel_size // ratio - 1
+            self.pad_left = self.pad * self.stride + (self.kernel_size - self.stride) // 2
+            self.pad_right = self.pad * self.stride + (self.kernel_size - self.stride + 1) // 2
+            sinc_filter = kaiser_sinc_filter1d(
+                cutoff=0.5 / ratio,
+                half_width=0.6 / ratio,
+                kernel_size=self.kernel_size,
+            )
+
+        self.register_buffer("filter", sinc_filter, persistent=persistent)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _, n_channels, _ = x.shape
+        x = F.pad(x, (self.pad, self.pad), mode="replicate")
+        filt = self.filter.to(dtype=x.dtype, device=x.device).expand(n_channels, -1, -1)
+        x = self.ratio * F.conv_transpose1d(x, filt, stride=self.stride, groups=n_channels)
+        return x[..., self.pad_left : -self.pad_right]
+
+
+class DownSample1d(nn.Module):
+    def __init__(self, ratio: int = 2, kernel_size: int | None = None) -> None:
+        super().__init__()
+        self.ratio = ratio
+        self.kernel_size = int(6 * ratio // 2) * 2 if kernel_size is None else kernel_size
+        self.lowpass = LowPassFilter1d(
+            cutoff=0.5 / ratio,
+            half_width=0.6 / ratio,
+            stride=ratio,
+            kernel_size=self.kernel_size,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lowpass(x)
+
+
+class Activation1d(nn.Module):
+    def __init__(
+        self,
+        activation: nn.Module,
+        up_ratio: int = 2,
+        down_ratio: int = 2,
+        up_kernel_size: int = 12,
+        down_kernel_size: int = 12,
+    ) -> None:
+        super().__init__()
+        self.act = activation
+        self.upsample = UpSample1d(up_ratio, up_kernel_size)
+        self.downsample = DownSample1d(down_ratio, down_kernel_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.upsample(x)
+        x = self.act(x)
+        return self.downsample(x)
+
+
+class Snake(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        alpha: float = 1.0,
+        alpha_trainable: bool = True,
+        alpha_logscale: bool = True,
+    ) -> None:
+        super().__init__()
+        self.alpha_logscale = alpha_logscale
+        self.alpha = nn.Parameter(
+            torch.zeros(in_features) if alpha_logscale else torch.ones(in_features) * alpha
+        )
+        self.alpha.requires_grad = alpha_trainable
+        self.eps = 1e-9
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        alpha = self.alpha.unsqueeze(0).unsqueeze(-1)
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+        return x + (1.0 / (alpha + self.eps)) * torch.sin(x * alpha).pow(2)
+
+
+class SnakeBeta(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        alpha: float = 1.0,
+        alpha_trainable: bool = True,
+        alpha_logscale: bool = True,
+    ) -> None:
+        super().__init__()
+        self.alpha_logscale = alpha_logscale
+        self.alpha = nn.Parameter(
+            torch.zeros(in_features) if alpha_logscale else torch.ones(in_features) * alpha
+        )
+        self.alpha.requires_grad = alpha_trainable
+        self.beta = nn.Parameter(
+            torch.zeros(in_features) if alpha_logscale else torch.ones(in_features) * alpha
+        )
+        self.beta.requires_grad = alpha_trainable
+        self.eps = 1e-9
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        alpha = self.alpha.unsqueeze(0).unsqueeze(-1)
+        beta = self.beta.unsqueeze(0).unsqueeze(-1)
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+            beta = torch.exp(beta)
+        return x + (1.0 / (beta + self.eps)) * torch.sin(x * alpha).pow(2)
+
+
+class AMPBlock1(nn.Module):
+    """BigVGAN anti-aliased multi-periodicity residual block."""
+
+    def __init__(
+        self,
+        channels: int,
+        kernel_size: int = 3,
+        dilation: tuple[int, int, int] = (1, 3, 5),
+        activation: str = "snake",
+    ) -> None:
+        super().__init__()
+        act_cls = SnakeBeta if activation == "snakebeta" else Snake
+        self.convs1 = nn.ModuleList(
+            [
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[i],
+                    padding=get_padding(kernel_size, dilation[i]),
+                )
+                for i in range(3)
+            ]
+        )
+        self.convs2 = nn.ModuleList(
+            [
+                nn.Conv1d(
+                    channels, channels, kernel_size, 1, dilation=1, padding=get_padding(kernel_size, 1)
+                )
+                for _ in range(3)
+            ]
+        )
+        self.acts1 = nn.ModuleList([Activation1d(act_cls(channels)) for _ in range(len(self.convs1))])
+        self.acts2 = nn.ModuleList([Activation1d(act_cls(channels)) for _ in range(len(self.convs2))])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for c1, c2, a1, a2 in zip(self.convs1, self.convs2, self.acts1, self.acts2, strict=True):
+            xt = a1(x)
+            xt = c1(xt)
+            xt = a2(xt)
+            xt = c2(xt)
+            x = x + xt
+        return x
+
+
+def _make_resblock(
+    resblock: str,
+    ch: int,
+    kernel_size: int,
+    dilations: List[int],
+    activation: str,
+) -> nn.Module:
+    if resblock == "AMP1":
+        return AMPBlock1(ch, kernel_size, dilations, activation=activation)
+    # HiFi-GAN fallback (unused by LTX-2.3, kept for parity); lazily import to
+    # avoid a hard dependency on the ltx2 audio_vae package.
+    from ...ltx2.ltx2_core.audio_vae.resnet import ResBlock1
+
+    return ResBlock1(ch, kernel_size, dilations)
+
+
+class Vocoder(nn.Module):
+    """Mel-spectrogram -> waveform generator (HiFi-GAN "1" or BigVGAN "AMP1")."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        resblock_kernel_sizes: List[int] | None = None,
+        upsample_rates: List[int] | None = None,
+        upsample_kernel_sizes: List[int] | None = None,
+        resblock_dilation_sizes: List[List[int]] | None = None,
+        upsample_initial_channel: int = 1024,
+        resblock: str = "1",
+        output_sampling_rate: int = 24000,
+        activation: str = "snake",
+        use_tanh_at_final: bool = True,
+        apply_final_activation: bool = True,
+        use_bias_at_final: bool = True,
+    ) -> None:
+        super().__init__()
+
+        if resblock_kernel_sizes is None:
+            resblock_kernel_sizes = [3, 7, 11]
+        if upsample_rates is None:
+            upsample_rates = [6, 5, 2, 2, 2]
+        if upsample_kernel_sizes is None:
+            upsample_kernel_sizes = [16, 15, 8, 4, 4]
+        if resblock_dilation_sizes is None:
+            resblock_dilation_sizes = [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+
+        self.output_sampling_rate = output_sampling_rate
+        self.num_kernels = len(resblock_kernel_sizes)
+        self.num_upsamples = len(upsample_rates)
+        self.use_tanh_at_final = use_tanh_at_final
+        self.apply_final_activation = apply_final_activation
+        self.is_amp = resblock == "AMP1"
+
+        # Stereo checkpoints: 128 input channels (2 stereo x 64 mel), 2 out.
+        self.conv_pre = nn.Conv1d(
+            in_channels=128,
+            out_channels=upsample_initial_channel,
+            kernel_size=7,
+            stride=1,
+            padding=3,
+        )
+
+        self.ups = nn.ModuleList(
+            nn.ConvTranspose1d(
+                upsample_initial_channel // (2**i),
+                upsample_initial_channel // (2 ** (i + 1)),
+                kernel_size,
+                stride,
+                padding=(kernel_size - stride) // 2,
+            )
+            for i, (stride, kernel_size) in enumerate(
+                zip(upsample_rates, upsample_kernel_sizes, strict=True)
+            )
+        )
+
+        final_channels = upsample_initial_channel // (2 ** len(upsample_rates))
+        self.resblocks = nn.ModuleList()
+        for i in range(len(upsample_rates)):
+            ch = upsample_initial_channel // (2 ** (i + 1))
+            for kernel_size, dilations in zip(
+                resblock_kernel_sizes, resblock_dilation_sizes, strict=True
+            ):
+                self.resblocks.append(
+                    _make_resblock(resblock, ch, kernel_size, dilations, activation)
+                )
+
+        if self.is_amp:
+            self.act_post: nn.Module = Activation1d(SnakeBeta(final_channels))
+        else:
+            self.act_post = nn.LeakyReLU()
+
+        self.conv_post = nn.Conv1d(
+            in_channels=final_channels,
+            out_channels=2,
+            kernel_size=7,
+            stride=1,
+            padding=3,
+            bias=use_bias_at_final,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # (B, C, time, mel_bins) -> (B, C, mel_bins, time)
+        x = x.transpose(2, 3)
+        if x.dim() == 4:  # stereo
+            assert x.shape[1] == 2, "Input must have 2 channels for stereo"
+            x = einops.rearrange(x, "b s c t -> b (s c) t")
+
+        x = self.conv_pre(x)
+
+        for i in range(self.num_upsamples):
+            if not self.is_amp:
+                x = F.leaky_relu(x, LRELU_SLOPE)
+            x = self.ups[i](x)
+            start = i * self.num_kernels
+            end = start + self.num_kernels
+            block_outputs = torch.stack(
+                [self.resblocks[idx](x) for idx in range(start, end)],
+                dim=0,
+            )
+            x = block_outputs.mean(dim=0)
+
+        x = self.act_post(x)
+        x = self.conv_post(x)
+
+        if self.apply_final_activation:
+            x = torch.tanh(x) if self.use_tanh_at_final else torch.clamp(x, -1, 1)
+        return x
+
+
+class _STFTFn(nn.Module):
+    """STFT as a convolution with precomputed DFT x Hann-window bases (from checkpoint)."""
+
+    def __init__(self, filter_length: int, hop_length: int, win_length: int) -> None:
+        super().__init__()
+        self.hop_length = hop_length
+        self.win_length = win_length
+        n_freqs = filter_length // 2 + 1
+        self.register_buffer("forward_basis", torch.zeros(n_freqs * 2, 1, filter_length))
+        self.register_buffer("inverse_basis", torch.zeros(n_freqs * 2, 1, filter_length))
+
+    def forward(self, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if y.dim() == 2:
+            y = y.unsqueeze(1)  # (B, 1, T)
+        left_pad = max(0, self.win_length - self.hop_length)  # causal: left-only
+        y = F.pad(y, (left_pad, 0))
+        spec = F.conv1d(y, self.forward_basis, stride=self.hop_length, padding=0)
+        n_freqs = spec.shape[1] // 2
+        real, imag = spec[:, :n_freqs], spec[:, n_freqs:]
+        magnitude = torch.sqrt(real**2 + imag**2)
+        phase = torch.atan2(imag.float(), real.float()).to(real.dtype)
+        return magnitude, phase
+
+
+class MelSTFT(nn.Module):
+    """Causal log-mel spectrogram; buffers (mel_basis, stft_fn.*) loaded from checkpoint."""
+
+    def __init__(
+        self,
+        filter_length: int,
+        hop_length: int,
+        win_length: int,
+        n_mel_channels: int,
+    ) -> None:
+        super().__init__()
+        self.stft_fn = _STFTFn(filter_length, hop_length, win_length)
+        n_freqs = filter_length // 2 + 1
+        self.register_buffer("mel_basis", torch.zeros(n_mel_channels, n_freqs))
+
+    def mel_spectrogram(
+        self, y: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        magnitude, phase = self.stft_fn(y)
+        energy = torch.norm(magnitude, dim=1)
+        mel = torch.matmul(self.mel_basis.to(magnitude.dtype), magnitude)
+        log_mel = torch.log(torch.clamp(mel, min=1e-5))
+        return log_mel, magnitude, phase, energy
+
+
+class VocoderWithBWE(nn.Module):
+    """BigVGAN vocoder + residual bandwidth extension to a higher sample rate."""
+
+    def __init__(
+        self,
+        vocoder: Vocoder,
+        bwe_generator: Vocoder,
+        mel_stft: MelSTFT,
+        input_sampling_rate: int,
+        output_sampling_rate: int,
+        hop_length: int,
+    ) -> None:
+        super().__init__()
+        self.vocoder = vocoder
+        self.bwe_generator = bwe_generator
+        self.mel_stft = mel_stft
+        self.input_sampling_rate = input_sampling_rate
+        self.output_sampling_rate = output_sampling_rate
+        self.hop_length = hop_length
+        # Sinc skip filter is not stored in the checkpoint (persistent=False);
+        # materialize on CPU so it exists even under meta-device construction.
+        with torch.device("cpu"):
+            self.resampler = UpSample1d(
+                ratio=output_sampling_rate // input_sampling_rate,
+                persistent=False,
+                window_type="hann",
+            )
+
+    @property
+    def conv_pre(self) -> nn.Conv1d:
+        return self.vocoder.conv_pre
+
+    @property
+    def conv_post(self) -> nn.Conv1d:
+        return self.vocoder.conv_post
+
+    def _compute_mel(self, audio: torch.Tensor) -> torch.Tensor:
+        batch, n_channels, _ = audio.shape
+        flat = audio.reshape(batch * n_channels, -1)  # (B*C, T)
+        mel, _, _, _ = self.mel_stft.mel_spectrogram(flat)  # (B*C, n_mels, T_frames)
+        return mel.reshape(batch, n_channels, mel.shape[1], mel.shape[2])
+
+    def forward(self, mel_spec: torch.Tensor) -> torch.Tensor:
+        input_dtype = mel_spec.dtype
+        device_type = mel_spec.device.type
+        module_dtype = next(self.parameters()).dtype
+        fp32_ctx = (
+            _module_in_fp32(self, enabled=module_dtype != torch.float32)
+            if device_type == "mps"
+            else torch.autocast(device_type=device_type, dtype=torch.float32)
+        )
+
+        with fp32_ctx:
+            x = self.vocoder(mel_spec.float())
+            _, _, length_low_rate = x.shape
+            output_length = (
+                length_low_rate * self.output_sampling_rate // self.input_sampling_rate
+            )
+
+            remainder = length_low_rate % self.hop_length
+            if remainder != 0:
+                x = F.pad(x, (0, self.hop_length - remainder))
+
+            mel = self._compute_mel(x)  # (B, C, n_mels, T_frames)
+            mel_for_bwe = mel.transpose(2, 3)  # (B, C, T_frames, mel_bins)
+            residual = self.bwe_generator(mel_for_bwe)
+            skip = self.resampler(x)
+            assert residual.shape == skip.shape, f"residual {residual.shape} != skip {skip.shape}"
+
+            return torch.clamp(residual + skip, -1, 1)[..., :output_length].to(input_dtype)
+
+
+def _vocoder_from_config(
+    cfg: dict,
+    apply_final_activation: bool = True,
+    output_sampling_rate: int | None = None,
+) -> Vocoder:
+    return Vocoder(
+        resblock_kernel_sizes=cfg.get("resblock_kernel_sizes", [3, 7, 11]),
+        upsample_rates=cfg.get("upsample_rates", [6, 5, 2, 2, 2]),
+        upsample_kernel_sizes=cfg.get("upsample_kernel_sizes", [16, 15, 8, 4, 4]),
+        resblock_dilation_sizes=cfg.get(
+            "resblock_dilation_sizes", [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+        ),
+        upsample_initial_channel=cfg.get("upsample_initial_channel", 1024),
+        resblock=cfg.get("resblock", "1"),
+        output_sampling_rate=(
+            output_sampling_rate
+            if output_sampling_rate is not None
+            else cfg.get("output_sampling_rate", 24000)
+        ),
+        activation=cfg.get("activation", "snake"),
+        use_tanh_at_final=cfg.get("use_tanh_at_final", True),
+        apply_final_activation=apply_final_activation,
+        use_bias_at_final=cfg.get("use_bias_at_final", True),
+    )
+
+
+class LTX23VocoderConfigurator:
+    """Build the LTX-2.3 ``VocoderWithBWE`` from the native checkpoint config.
+
+    Auto-detects: a nested ``vocoder`` + ``bwe`` config => VocoderWithBWE (2.3);
+    a flat config => plain HiFi-GAN Vocoder (pre-2.3, kept for parity).
+    """
+
+    @classmethod
+    def from_config(cls, config: dict):
+        cfg = config.get("vocoder", {})
+
+        if "bwe" not in cfg:
+            _check_config_value(cfg, "resblock", "1")
+            _check_config_value(cfg, "stereo", True)
+            return _vocoder_from_config(cfg)
+
+        vocoder_cfg = cfg.get("vocoder", {})
+        bwe_cfg = cfg["bwe"]
+
+        _check_config_value(vocoder_cfg, "resblock", "AMP1")
+        _check_config_value(vocoder_cfg, "stereo", True)
+        _check_config_value(vocoder_cfg, "activation", "snakebeta")
+        _check_config_value(bwe_cfg, "resblock", "AMP1")
+        _check_config_value(bwe_cfg, "stereo", True)
+        _check_config_value(bwe_cfg, "activation", "snakebeta")
+
+        vocoder = _vocoder_from_config(
+            vocoder_cfg,
+            output_sampling_rate=bwe_cfg["input_sampling_rate"],
+        )
+        bwe_generator = _vocoder_from_config(
+            bwe_cfg,
+            apply_final_activation=False,
+            output_sampling_rate=bwe_cfg["output_sampling_rate"],
+        )
+        mel_stft = MelSTFT(
+            filter_length=bwe_cfg["n_fft"],
+            hop_length=bwe_cfg["hop_length"],
+            win_length=bwe_cfg["n_fft"],
+            n_mel_channels=bwe_cfg["num_mels"],
+        )
+        return VocoderWithBWE(
+            vocoder=vocoder,
+            bwe_generator=bwe_generator,
+            mel_stft=mel_stft,
+            input_sampling_rate=bwe_cfg["input_sampling_rate"],
+            output_sampling_rate=bwe_cfg["output_sampling_rate"],
+            hop_length=bwe_cfg["hop_length"],
+        )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/pipeline_ltx23.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/pipeline_ltx23.py
@@ -1,0 +1,813 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 ("V2") text-to-video pipeline (Phase-0: BF16, 1 GPU, eager, video-only).
+
+This is a *separate* pipeline from ``LTX2Pipeline`` (it does not subclass it),
+matching the reviewer guidance: the two share the module-level helpers and the
+reusable native components, but LTX-2.3 diverges in ways that live inside the
+text path and denoise loop:
+
+* Text features: all 49 Gemma hidden states are stacked, **per-token RMS
+  normalized** (``text_encoder_norm_type=per_token_rms``, not LTX-2's masked
+  min-max), then projected by a **split** feature extractor
+  (``video_aggregate_embed`` / ``audio_aggregate_embed``) before the connectors.
+* The transformer needs a global ``sigma`` per step for the sigma-driven text
+  cross-attention K/V modulation (``prompt_adaln_single`` /
+  ``prompt_scale_shift_table``), so the text K/V cannot be pre-projected once
+  like LTX-2 — it is (re)projected inside each denoise step.
+
+Phase-0 scope (agreed): text-to-video only, plain CFG, BF16, single GPU, eager.
+Audio VAE + BigVGAN-v2 BWE vocoder (48 kHz) and the optimization stack
+(FP8/NVFP4, CUDA graph, torch.compile, Ulysses) are added in later phases.
+
+Reused verbatim from LTX-2 (same numerical contract):
+* ``self.denoise`` — CFG is applied in x0-space in LTX-2.3, which is
+  algebraically identical to velocity-space CFG for rectified flow
+  (x0 = sample - v*sigma is affine in v), so the base CFG combine is exact.
+* ``self.decode_latents`` + tiled video VAE decode + ``postprocess_video_tensor``.
+* The RoPE / patchifier / scheduler / shape utilities.
+"""
+
+import copy
+import os
+import time
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from transformers import Gemma3ForConditionalGeneration, GemmaTokenizerFast
+
+from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
+from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
+from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent, register_pipeline
+from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
+from tensorrt_llm.logger import logger
+
+
+def _ltx_bench_emit(msg: str) -> None:
+    """Perf-only: surface a bench line regardless of logger routing.
+
+    The pipeline runs inside the DiffusionClient worker, whose ``logger.info``
+    output does not always reach the driver stdout. Print (flushed) is reliably
+    captured, and we also append to ``LTX_BENCH_FILE`` when set so the A/B runner
+    can read the numbers straight from a file.
+    """
+    print(msg, flush=True)
+    path = os.environ.get("LTX_BENCH_FILE")
+    if path:
+        try:
+            with open(path, "a") as f:
+                f.write(msg + "\n")
+        except OSError:
+            pass
+
+# Reuse the LTX-2 native components + module-level loaders (shared utilities).
+from ..ltx2.ltx2_core.audio_vae import AudioDecoderConfigurator, decode_audio
+from ..ltx2.ltx2_core.patchifier import AudioPatchifier, VideoLatentPatchifier, get_pixel_coords
+from ..ltx2.ltx2_core.rope import LTXRopeType
+from ..ltx2.ltx2_core.scheduler_adapter import NativeSchedulerAdapter
+from ..ltx2.ltx2_core.types import (
+    VIDEO_SCALE_FACTORS,
+    AudioLatentShape,
+    VideoLatentShape,
+    VideoPixelShape,
+)
+from ..ltx2.ltx2_core.video_vae import TilingConfig
+from ..ltx2.pipeline_ltx2 import (
+    _find_safetensors_files,
+    _load_component_weights,
+    _load_ltx2_transformer_weights,
+    _prefetch_ltx2_safetensors_files,
+    _read_safetensors_config,
+)
+from ..ltx2.transformer_ltx2 import LTXModelType
+from .ltx23_core.connector import (
+    LTX23AudioConnectorConfigurator,
+    LTX23GemmaFeaturesExtractor,
+    LTX23VideoConnectorConfigurator,
+)
+from .ltx23_core.video_vae_ltx23 import LTX23VideoDecoderConfigurator
+from .ltx23_core.vocoder_ltx23 import LTX23VocoderConfigurator
+from .ltx23_core.modality import LTX23Modality
+from .transformer_ltx23 import LTX23Model
+
+# Gemma-3-12b-it exposes 49 hidden states (48 layers + embeddings). The split
+# feature extractor's [out, 3840*49] weights expect all of them stacked.
+_NUM_GEMMA_HIDDEN_STATES = 49
+
+
+@register_pipeline(
+    "LTX23Pipeline",
+    hf_ids=["Lightricks/LTX-2.3"],
+    defaults={"text_encoder_path": "google/gemma-3-12b-it"},
+    doc="Lightricks LTX-2.3 audio-video generation (Phase-0: video-only, BF16).",
+)
+class LTX23Pipeline(BasePipeline):
+    """Text-to-video pipeline for the LTX-2.3 checkpoint (native single-file safetensors)."""
+
+    # LTX-2.3 stores the transformer under this prefix; the connectors live
+    # under the same prefix and are loaded as separate pipeline components, so
+    # they are excluded from the transformer state dict.
+    _TRANSFORMER_PREFIX = "model.diffusion_model."
+    _TRANSFORMER_EXCLUDE_PREFIXES = [
+        "audio_embeddings_connector.",
+        "video_embeddings_connector.",
+    ]
+
+    def __init__(self, model_config):
+        super().__init__(model_config)
+
+    @property
+    def dtype(self):
+        return self.pipeline_config.torch_dtype
+
+    @classmethod
+    def resolve_variant(cls, config):
+        # Phase-0: single-stage only (no spatial upsampler / distilled LoRA path).
+        return cls
+
+    @property
+    def default_warmup_resolutions(self):
+        return [(512, 768)]
+
+    @property
+    def default_warmup_num_frames(self):
+        return [121]
+
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        self.forward(
+            prompt="warmup",
+            negative_prompt="",
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=steps,
+            guidance_scale=4.0,
+            seed=42,
+        )
+
+    # ------------------------------------------------------------------
+    # Transformer init + weight loading
+    # ------------------------------------------------------------------
+
+    def _init_transformer(self) -> None:
+        attn_cfg = getattr(self.pipeline_config, "attention", None)
+        if attn_cfg is not None and getattr(attn_cfg, "quant_attention_config", None) is not None:
+            raise NotImplementedError("Quantized attention is not yet supported for LTX-2.3.")
+
+        model_config = self.pipeline_config.model_configs["transformer"]
+        cfg = model_config.pretrained_config
+
+        rope_type = LTXRopeType(getattr(cfg, "rope_type", "interleaved"))
+        double_precision_rope = getattr(cfg, "frequencies_precision", False) == "float64"
+        apply_gated_attention = getattr(cfg, "apply_gated_attention", False)
+
+        self.transformer_in_channels = getattr(cfg, "in_channels", 128)
+        self.audio_in_channels = getattr(cfg, "audio_in_channels", 128)
+        self.audio_out_channels = getattr(cfg, "audio_out_channels", 128)
+
+        logger.info(
+            f"LTX-2.3 transformer config: rope_type={rope_type.value}, "
+            f"double_precision_rope={double_precision_rope}, "
+            f"apply_gated_attention={apply_gated_attention} (AudioVideo)"
+        )
+
+        # Phase-1: AudioVideo. The dual-stream block + bidirectional A<->V
+        # cross-attention are already implemented; enabling the audio stream
+        # here makes the transformer emit (video_velocity, audio_velocity).
+        self.transformer = LTX23Model(
+            model_type=LTXModelType.AudioVideo,
+            num_attention_heads=getattr(cfg, "num_attention_heads", 32),
+            attention_head_dim=getattr(cfg, "attention_head_dim", 128),
+            in_channels=self.transformer_in_channels,
+            out_channels=getattr(cfg, "out_channels", 128),
+            num_layers=getattr(cfg, "num_layers", 48),
+            cross_attention_dim=getattr(cfg, "cross_attention_dim", 4096),
+            audio_num_attention_heads=getattr(cfg, "audio_num_attention_heads", 32),
+            audio_attention_head_dim=getattr(cfg, "audio_attention_head_dim", 64),
+            audio_in_channels=self.audio_in_channels,
+            audio_out_channels=self.audio_out_channels,
+            audio_cross_attention_dim=getattr(cfg, "audio_cross_attention_dim", 2048),
+            audio_positional_embedding_max_pos=getattr(
+                cfg, "audio_positional_embedding_max_pos", [20]
+            ),
+            norm_eps=float(getattr(cfg, "norm_eps", 1e-6)),
+            caption_channels=getattr(cfg, "caption_channels", 3840),
+            positional_embedding_theta=float(getattr(cfg, "positional_embedding_theta", 10000.0)),
+            positional_embedding_max_pos=getattr(
+                cfg, "positional_embedding_max_pos", [20, 2048, 2048]
+            ),
+            timestep_scale_multiplier=getattr(cfg, "timestep_scale_multiplier", 1000),
+            use_middle_indices_grid=getattr(cfg, "use_middle_indices_grid", True),
+            rope_type=rope_type,
+            double_precision_rope=double_precision_rope,
+            apply_gated_attention=apply_gated_attention,
+            model_config=model_config,
+        )
+        self.transformer._transformer_config = vars(cfg)
+
+    def load_transformer_weights(self, checkpoint_dir: str) -> Dict[str, torch.Tensor]:
+        logger.info("Loading LTX-2.3 transformer weights (native checkpoint)")
+        return _load_ltx2_transformer_weights(
+            checkpoint_dir,
+            self._TRANSFORMER_PREFIX,
+            exclude_prefixes=self._TRANSFORMER_EXCLUDE_PREFIXES,
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        if self.transformer is not None and hasattr(self.transformer, "load_weights"):
+            logger.info("Loading transformer weights...")
+            self.transformer.load_weights(weights.get("transformer", weights))
+            logger.info("Transformer weights loaded successfully.")
+
+    # ------------------------------------------------------------------
+    # Component loading
+    # ------------------------------------------------------------------
+
+    def load_standard_components(
+        self,
+        checkpoint_dir: str,
+        device: torch.device,
+        skip_components: Optional[list] = None,
+        *,
+        text_encoder_path: str = "",
+        **kwargs,
+    ) -> None:
+        skip_components = skip_components or []
+        dtype = self.pipeline_config.torch_dtype
+
+        needs_text = (
+            PipelineComponent.TOKENIZER not in skip_components
+            or PipelineComponent.TEXT_ENCODER not in skip_components
+        )
+        if needs_text and not text_encoder_path:
+            raise ValueError(
+                "text_encoder_path is required for the Gemma3 tokenizer/encoder. "
+                "Set the LTX-2.3 pipeline_config 'text_encoder_path' entry."
+            )
+
+        if PipelineComponent.TOKENIZER not in skip_components:
+            logger.info(f"Loading tokenizer (Gemma3) from {text_encoder_path}...")
+            self.tokenizer = GemmaTokenizerFast.from_pretrained(text_encoder_path)
+            self.tokenizer.padding_side = "left"
+            if self.tokenizer.pad_token is None:
+                self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        if PipelineComponent.TEXT_ENCODER not in skip_components:
+            logger.info(f"Loading text encoder (Gemma3) from {text_encoder_path}...")
+            self.text_encoder = Gemma3ForConditionalGeneration.from_pretrained(
+                text_encoder_path,
+                torch_dtype=dtype,
+            ).to(device)
+
+        native_config = self.pipeline_config.extra_attrs.get("monolithic_safetensors_config")
+        sft_paths = _find_safetensors_files(checkpoint_dir)
+        _prefetch_ltx2_safetensors_files(sft_paths)
+        if native_config is None and sft_paths:
+            native_config = _read_safetensors_config(sft_paths[0])
+        if native_config is None:
+            raise ValueError(
+                "LTX-2.3 native checkpoint requires embedded 'config' metadata in the "
+                f"safetensors file(s) at {checkpoint_dir}."
+            )
+        self._native_config = native_config
+
+        self._load_native_components(native_config, sft_paths, device, dtype, skip_components)
+
+        if PipelineComponent.SCHEDULER not in skip_components:
+            self.scheduler = NativeSchedulerAdapter()
+
+    def _load_native_components(
+        self,
+        config: Dict[str, Any],
+        sft_paths: List[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        skip_components: Optional[list] = None,
+    ) -> None:
+        skip_components = skip_components or []
+
+        # Video decoder (config-driven; the LTX-2 VAE configurator reads the
+        # LTX-2.3 decoder_blocks recipe from the same native config).
+        if PipelineComponent.VAE not in skip_components:
+            logger.info("Loading native video decoder...")
+            self.video_decoder = LTX23VideoDecoderConfigurator.from_config(config)
+            _load_component_weights(sft_paths, self.video_decoder, ["vae.decoder.", "vae."])
+            self.video_decoder = self.video_decoder.to(device=device, dtype=dtype)
+
+        # Split feature extractor (video + audio projections) + video connector.
+        # Phase-0 is video-only, so the audio connector is skipped; the audio
+        # projection weights are still loaded (both keys live under
+        # text_embedding_projection.*) and simply unused this phase.
+        logger.info("Loading native text feature extractor + video connector...")
+        self.feature_extractor = LTX23GemmaFeaturesExtractor.from_config(config)
+        _load_component_weights(sft_paths, self.feature_extractor, "text_embedding_projection.")
+        self.feature_extractor = self.feature_extractor.to(device=device, dtype=dtype)
+
+        self.video_connector = LTX23VideoConnectorConfigurator.from_config(config)
+        _load_component_weights(
+            sft_paths,
+            self.video_connector,
+            "model.diffusion_model.video_embeddings_connector.",
+        )
+        self.video_connector = self.video_connector.to(device=device, dtype=dtype)
+
+        # Audio connector (32 x 64 = 2048, 8 layers, gated) consuming its own
+        # audio projection from the split feature extractor.
+        self.audio_connector = LTX23AudioConnectorConfigurator.from_config(config)
+        _load_component_weights(
+            sft_paths,
+            self.audio_connector,
+            "model.diffusion_model.audio_embeddings_connector.",
+        )
+        self.audio_connector = self.audio_connector.to(device=device, dtype=dtype)
+
+        # Audio VAE decoder (reused verbatim from LTX-2; config-driven and
+        # matches the LTX-2.3 audio_vae recipe). Latent -> mel spectrogram.
+        if PipelineComponent.VAE not in skip_components:
+            logger.info("Loading native audio decoder...")
+            self.audio_decoder = AudioDecoderConfigurator.from_config(config)
+            _load_component_weights(
+                sft_paths, self.audio_decoder, ["audio_vae.decoder.", "audio_vae."]
+            )
+            self.audio_decoder = self.audio_decoder.to(device=device, dtype=dtype)
+
+            # Vocoder (BigVGAN-v2 AMP1 + BWE -> 48 kHz). Kept in fp32: the BWE
+            # forward runs fp32 regardless, and bf16 accumulation degrades the
+            # spectral output across the ~108 sequential convs.
+            logger.info("Loading native vocoder (BigVGAN-v2 + BWE)...")
+            self.vocoder = LTX23VocoderConfigurator.from_config(config)
+            _load_component_weights(sft_paths, self.vocoder, "vocoder.")
+            self.vocoder = self.vocoder.to(device=device, dtype=torch.float32)
+
+        # Patchifier (structural, no weights).
+        t_cfg = self.transformer._transformer_config
+        patch_size = t_cfg.get("patch_size", 1)
+        self.video_patchifier = VideoLatentPatchifier(patch_size=patch_size)
+
+        # Audio decode-side properties (mirror LTX-2). The audio VAE decoder
+        # exposes the patchifier and the mel/sample-rate metadata; the *output*
+        # sample rate is the vocoder's (48 kHz via BWE), not the VAE's 16 kHz.
+        # These are only meaningful when the audio decoder was loaded (skipped
+        # alongside the VAE component in transformer-only loads / unit tests).
+        if PipelineComponent.VAE not in skip_components:
+            self.audio_patchifier = self.audio_decoder.patchifier
+            self.audio_sampling_rate = self.audio_decoder.sample_rate
+            self.audio_hop_length = self.audio_decoder.mel_hop_length
+            self.audio_mel_bins = self.audio_decoder.mel_bins
+
+    # ------------------------------------------------------------------
+    # Text encoding (LTX-2.3: per-token RMS over stacked Gemma states)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _per_token_rms_pack(hidden_states: List[torch.Tensor], eps: float = 1e-6) -> torch.Tensor:
+        """Stack all Gemma hidden states, per-token RMS normalize, flatten.
+
+        ``hidden_states``: tuple of ``num_layers+1`` tensors ``[B, S, 3840]``.
+        Returns ``[B, S, 3840 * num_states]`` to feed the split feature
+        extractor's ``[out, 3840*49]`` projections.
+
+        LTX-2.3 uses ``text_encoder_norm_type='per_token_rms'`` with
+        ``caption_proj_input_norm=False`` (the norm is applied here, before the
+        projection, not inside caption projection). We normalize each token's
+        hidden vector per layer by its RMS over the hidden dim — the placement
+        the vLLM-Omni reference documents (unflatten -> per_token_rms -> project).
+
+        NOTE (Phase-0 validation target): the exact reduction axis for
+        per_token_rms (per-layer hidden dim vs. flattened across all layers) is
+        the first thing to check against a reference render if colors/structure
+        look off. Isolated here for that reason.
+        """
+        stacked = torch.stack(hidden_states, dim=-1)  # [B, S, 3840, num_states]
+        # RMS over the hidden dim (3840), per token and per layer.
+        rms = torch.sqrt(stacked.float().pow(2).mean(dim=2, keepdim=True) + eps)
+        normed = (stacked.float() / rms).to(dtype=stacked.dtype)
+        return normed.flatten(2, 3)  # [B, S, 3840 * num_states]
+
+    def _encode_prompt(
+        self,
+        prompt: Union[str, List[str]],
+        num_videos_per_prompt: int = 1,
+        max_sequence_length: int = 1024,
+    ):
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        batch_size = len(prompt)
+        prompt = [p.strip() for p in prompt]
+
+        text_inputs = self.tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(self.device)
+        prompt_attention_mask = text_inputs.attention_mask.to(self.device)
+
+        outputs = self.text_encoder(
+            input_ids=text_input_ids,
+            attention_mask=prompt_attention_mask,
+            output_hidden_states=True,
+        )
+        prompt_embeds = self._per_token_rms_pack(outputs.hidden_states)
+        prompt_embeds = prompt_embeds.to(dtype=self.dtype)
+
+        _, seq_len, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+        prompt_attention_mask = prompt_attention_mask.view(batch_size, -1)
+        prompt_attention_mask = prompt_attention_mask.repeat(num_videos_per_prompt, 1)
+        return prompt_embeds, prompt_attention_mask
+
+    def _process_connectors(self, prompt_embeds: torch.Tensor, attention_mask: torch.Tensor):
+        """Split feature extractor -> video + audio connectors.
+
+        Returns ``(video_embeds, audio_embeds, video_mask)``. The connector
+        (register-augmented) mask is shared across modalities in LTX-2.3.
+        """
+        additive_mask = (1 - attention_mask.to(prompt_embeds.dtype)) * -1000000.0
+        additive_mask = additive_mask.unsqueeze(1).unsqueeze(1)  # [B, 1, 1, S]
+
+        video_proj, audio_proj = self.feature_extractor(prompt_embeds)
+        video_embeds, video_mask = self.video_connector(video_proj, additive_mask)
+        audio_embeds, _ = self.audio_connector(audio_proj, additive_mask)
+        return video_embeds, audio_embeds, video_mask
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    @property
+    def default_generation_params(self):
+        return {
+            "height": 512,
+            "width": 768,
+            "num_inference_steps": 40,
+            "guidance_scale": 4.0,
+            "max_sequence_length": 1024,
+            "num_frames": 121,
+            "frame_rate": 24.0,
+        }
+
+    @property
+    def extra_param_specs(self):
+        return {
+            "output_type": ExtraParamSchema(
+                type="str",
+                default="pt",
+                description="Output type: 'pt' for tensors, 'latent' for raw latents.",
+            ),
+            "guidance_rescale": ExtraParamSchema(
+                type="float",
+                default=0.0,
+                description="Guidance rescale factor to prevent overexposure.",
+            ),
+        }
+
+    def infer(self, req):
+        extra = req.params.extra_params or {}
+        return self.forward(
+            prompt=req.prompt,
+            negative_prompt=req.params.negative_prompt,
+            height=req.params.height,
+            width=req.params.width,
+            num_frames=req.params.num_frames,
+            frame_rate=req.params.frame_rate,
+            num_inference_steps=req.params.num_inference_steps,
+            guidance_scale=req.params.guidance_scale,
+            seed=req.params.seed,
+            output_type=extra.get("output_type", "pt"),
+            guidance_rescale=extra.get("guidance_rescale", 0.0),
+            max_sequence_length=req.params.max_sequence_length,
+        )
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        prompt: Union[str, List[str]],
+        seed: int,
+        negative_prompt: Optional[Union[str, List[str]]] = None,
+        height: int = 512,
+        width: int = 768,
+        num_frames: int = 121,
+        frame_rate: float = 24.0,
+        num_inference_steps: int = 40,
+        guidance_scale: float = 4.0,
+        guidance_rescale: float = 0.0,
+        output_type: str = "pt",
+        max_sequence_length: int = 1024,
+    ):
+        pipeline_start = time.time()
+        timer = CudaPhaseTimer()
+        timer.mark_pre_start()
+        generator = torch.Generator(device=self.device).manual_seed(seed)
+
+        do_cfg = guidance_scale > 1.0
+
+        # ---- 1. Encode prompts -----------------------------------------
+        logger.info("Encoding prompts...")
+        prompt_embeds, prompt_attention_mask = self._encode_prompt(
+            prompt, num_videos_per_prompt=1, max_sequence_length=max_sequence_length
+        )
+        neg_prompt_embeds = neg_prompt_attention_mask = None
+        if do_cfg:
+            negative_prompt = negative_prompt or ""
+            neg_prompt_embeds, neg_prompt_attention_mask = self._encode_prompt(
+                negative_prompt, num_videos_per_prompt=1, max_sequence_length=max_sequence_length
+            )
+
+        # ---- 2. Connectors (feature extractor + video/audio connectors) -
+        if do_cfg:
+            combined_embeds = torch.cat([neg_prompt_embeds, prompt_embeds], dim=0)
+            combined_mask = torch.cat([neg_prompt_attention_mask, prompt_attention_mask], dim=0)
+            video_embeds_combined, audio_embeds_combined, connector_mask_combined = (
+                self._process_connectors(combined_embeds, combined_mask)
+            )
+            neg_video_embeds, video_embeds = video_embeds_combined.chunk(2, dim=0)
+            neg_audio_embeds, audio_embeds = audio_embeds_combined.chunk(2, dim=0)
+            neg_connector_mask, connector_mask = connector_mask_combined.chunk(2, dim=0)
+        else:
+            video_embeds, audio_embeds, connector_mask = self._process_connectors(
+                prompt_embeds, prompt_attention_mask
+            )
+            neg_video_embeds = neg_audio_embeds = neg_connector_mask = None
+
+        # ---- 3. Latent shape + noise -----------------------------------
+        logger.info("Preparing latents...")
+        pixel_shape = VideoPixelShape(
+            batch=1, frames=num_frames, height=height, width=width, fps=frame_rate
+        )
+        video_shape = VideoLatentShape.from_pixel_shape(
+            pixel_shape, latent_channels=self.transformer_in_channels
+        )
+        # Audio latent grid is derived from the same pixel timeline so the two
+        # streams stay temporally aligned (mel bins are pre-patch, hence // 4).
+        audio_shape = AudioLatentShape.from_video_pixel_shape(
+            pixel_shape,
+            channels=getattr(self.audio_decoder, "z_channels", 8),
+            mel_bins=self.audio_mel_bins // 4,
+            sample_rate=self.audio_sampling_rate,
+            hop_length=self.audio_hop_length,
+        )
+        self.transformer.configure_audio_ulysses(audio_shape.frames)
+
+        latents = torch.randn(
+            video_shape.to_torch_shape(),
+            generator=generator,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        latents = self.video_patchifier.patchify(latents)
+
+        audio_latents = torch.randn(
+            audio_shape.to_torch_shape(),
+            generator=generator,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        audio_latents = self.audio_patchifier.patchify(audio_latents)
+
+        # ---- 4. Position embeddings (RoPE) -----------------------------
+        video_positions = self.video_patchifier.get_patch_grid_bounds(
+            video_shape, device=self.device
+        )
+        video_positions = get_pixel_coords(
+            video_positions.float(), VIDEO_SCALE_FACTORS, causal_fix=True
+        )
+        video_positions[:, 0, ...] = video_positions[:, 0, ...] / frame_rate
+        video_positions = video_positions.to(self.dtype)
+        audio_positions = self.audio_patchifier.get_patch_grid_bounds(
+            audio_shape, device=self.device
+        )
+
+        # ---- 5. Scheduler (video + lockstep audio) ---------------------
+        # Both streams share one sigma schedule (derived from the video latent)
+        # and step together; the deep copy keeps an independent step index.
+        latents_5d = torch.randn(video_shape.to_torch_shape(), device=self.device)
+        self.scheduler.set_timesteps(num_inference_steps, latent=latents_5d)
+        audio_scheduler = copy.deepcopy(self.scheduler)
+        audio_scheduler.set_timesteps(num_inference_steps, latent=latents_5d)
+        timesteps = self.scheduler.timesteps
+
+        # ---- 6. Text cache (sigma-independent; no static K/V) ----------
+        # Batched CFG: cache is [neg, cond] to align with the base denoise
+        # loop's [uncond, cond] latent stacking.
+        if do_cfg:
+            v_ctx = torch.cat([neg_video_embeds, video_embeds])
+            a_ctx = torch.cat([neg_audio_embeds, audio_embeds])
+            v_mask = (
+                torch.cat([neg_connector_mask, connector_mask])
+                if connector_mask is not None
+                else None
+            )
+        else:
+            v_ctx, a_ctx, v_mask = video_embeds, audio_embeds, connector_mask
+
+        text_cache = self.transformer.prepare_text_cache(
+            video_context=v_ctx,
+            video_context_mask=v_mask,
+            video_positions=video_positions,
+            audio_context=a_ctx,
+            audio_context_mask=v_mask,
+            audio_positions=audio_positions,
+            dtype=self.dtype,
+        )
+
+        # ---- 7. Joint (video + audio) denoising loop -------------------
+        def _run_transformer(v_latents, a_latents, timestep_val, v_context, a_context, mask):
+            v_latents_f32 = v_latents.float()
+            v_latents_bf = v_latents.to(self.dtype)
+            a_latents_f32 = a_latents.float()
+            a_latents_bf = a_latents.to(self.dtype)
+
+            video_mod = LTX23Modality(
+                latent=v_latents_bf,
+                timesteps=timestep_val,
+                sigma=timestep_val,  # LTX-2.3: global current sigma drives prompt_adaln
+                positions=video_positions,
+                context=v_context,
+                context_mask=mask,
+            )
+            audio_mod = LTX23Modality(
+                latent=a_latents_bf,
+                timesteps=timestep_val,
+                sigma=timestep_val,
+                positions=audio_positions,
+                context=a_context,
+                context_mask=mask,
+            )
+            vel_v, vel_a = self.transformer(
+                video=video_mod,
+                audio=audio_mod,
+                text_cache=text_cache,
+                timestep=timestep_val.new_tensor(0.0),
+            )
+            # x0 prediction (rectified flow): x0 = sample - v * sigma.
+            sigma = timestep_val.float()
+            while sigma.dim() < vel_v.dim():
+                sigma = sigma.unsqueeze(-1)
+            dn_v = v_latents_f32 - vel_v.float() * sigma
+
+            sigma_a = timestep_val.float()
+            while sigma_a.dim() < vel_a.dim():
+                sigma_a = sigma_a.unsqueeze(-1)
+            dn_a = a_latents_f32 - vel_a.float() * sigma_a
+            return dn_v, dn_a
+
+        # Perf-only: accumulate transformer (DiT) GPU time per forward call so we
+        # can isolate it from scheduler/CFG-combine cost. Guarded by LTX_BENCH=1.
+        _bench = os.environ.get("LTX_BENCH", "0") == "1"
+        _bench_events: List[tuple] = []
+        if _bench:
+            _ltx_bench_emit(
+                f"[LTX_BENCH] enabled (steps={len(timesteps)}, "
+                f"FREEZE_TEXT_KV={os.environ.get('LTX23_FREEZE_TEXT_KV', '0')})"
+            )
+
+        def forward_fn(
+            video_latents,
+            extra_stream_latents,
+            step_index,
+            timestep,
+            encoder_hidden_states,
+            extra_tensors,
+        ):
+            if _bench and torch.cuda.is_available():
+                ev0 = torch.cuda.Event(enable_timing=True)
+                ev1 = torch.cuda.Event(enable_timing=True)
+                ev0.record()
+                dn_v, dn_a = _run_transformer(
+                    video_latents,
+                    extra_stream_latents["audio"],
+                    timestep,
+                    encoder_hidden_states,
+                    extra_tensors.get("audio_embeds", audio_embeds),
+                    extra_tensors.get("attention_mask", connector_mask),
+                )
+                ev1.record()
+                _bench_events.append((ev0, ev1))
+                return dn_v, {"audio": dn_a}
+            dn_v, dn_a = _run_transformer(
+                video_latents,
+                extra_stream_latents["audio"],
+                timestep,
+                encoder_hidden_states,
+                extra_tensors.get("audio_embeds", audio_embeds),
+                extra_tensors.get("attention_mask", connector_mask),
+            )
+            return dn_v, {"audio": dn_a}
+
+        # Perf-only A/B: re-prime the frozen text-K/V cache each generation so it
+        # rebuilds on step 0 (see LTX23_FREEZE_TEXT_KV in transformer_ltx23.py).
+        if os.environ.get("LTX23_FREEZE_TEXT_KV", "0") == "1" and hasattr(
+            self.transformer, "reset_text_kv_cache"
+        ):
+            self.transformer.reset_text_kv_cache()
+
+        if _bench:
+            _ltx_bench_emit(
+                f"LTX_BENCH workload: video_latents={tuple(latents.shape)} "
+                f"audio_latents={tuple(audio_latents.shape)} "
+                f"do_cfg={do_cfg} (LTX23)"
+            )
+
+        timer.mark_denoise_start()
+        if _bench and torch.cuda.is_available():
+            torch.cuda.synchronize()
+            _denoise_t0 = time.time()
+        result = self.denoise(
+            latents=latents,
+            scheduler=self.scheduler,
+            prompt_embeds=video_embeds,
+            neg_prompt_embeds=neg_video_embeds,
+            guidance_scale=guidance_scale,
+            forward_fn=forward_fn,
+            timesteps=timesteps,
+            guidance_rescale=guidance_rescale,
+            extra_cfg_tensors=(
+                {
+                    "audio_embeds": (audio_embeds, neg_audio_embeds),
+                    "attention_mask": (connector_mask, neg_connector_mask),
+                }
+                if do_cfg
+                else None
+            ),
+            extra_streams={"audio": (audio_latents, audio_scheduler)},
+        )
+        latents, extra_stream_latents = result
+        audio_latents = extra_stream_latents["audio"]
+
+        if _bench and torch.cuda.is_available():
+            torch.cuda.synchronize()
+            _denoise_dt = time.time() - _denoise_t0
+            _n_steps = len(timesteps)
+            _freeze = os.environ.get("LTX23_FREEZE_TEXT_KV", "0") == "1"
+            # Authoritative denoise-phase wall time (includes scheduler + CFG).
+            _ltx_bench_emit(f"Denoising done: {_denoise_dt:.4f}s")
+            _ltx_bench_emit(
+                f"LTX_BENCH denoise: {_denoise_dt:.4f}s over {_n_steps} steps "
+                f"= {_denoise_dt / max(_n_steps, 1):.4f}s/step "
+                f"(FREEZE_TEXT_KV={int(_freeze)})"
+            )
+            if _bench_events:
+                _trans_ms = sum(e0.elapsed_time(e1) for e0, e1 in _bench_events)
+                _calls = len(_bench_events)
+                _ltx_bench_emit(
+                    f"LTX_BENCH transformer: {_trans_ms / 1000:.4f}s total over "
+                    f"{_calls} forward calls = {_trans_ms / max(_calls, 1):.2f}ms/call "
+                    f"(FREEZE_TEXT_KV={int(_freeze)})"
+                )
+
+        timer.mark_post_start()
+
+        # ---- 8. Decode video + audio -----------------------------------
+        logger.info("Decoding video and audio...")
+        decode_start = time.time()
+
+        def decode_video_fn(vid_latents):
+            vid_latents = self.video_patchifier.unpatchify(vid_latents, video_shape)
+            if output_type == "latent":
+                return vid_latents
+            vid_latents = vid_latents.to(self.dtype)
+            tiling_config = TilingConfig.default()
+            chunks = list(
+                self.video_decoder.tiled_decode(vid_latents, tiling_config, generator=generator)
+            )
+            video = torch.cat(chunks, dim=2)
+            return postprocess_video_tensor(video)
+
+        def decode_audio_fn(aud_latents):
+            aud_latents = self.audio_patchifier.unpatchify(aud_latents, audio_shape)
+            if output_type == "latent":
+                return aud_latents
+            # Audio VAE runs in the model dtype; the vocoder/BWE stay fp32.
+            aud_latents = aud_latents.to(self.dtype)
+            return decode_audio(aud_latents, self.audio_decoder, self.vocoder)
+
+        decoded = self.decode_latents(
+            latents=latents,
+            decode_fn=decode_video_fn,
+            extra_latents={"audio": (audio_latents, decode_audio_fn)},
+        )
+        if isinstance(decoded, (tuple, list)):
+            video, audio = decoded[0], decoded[1]
+        else:
+            video, audio = decoded, None
+
+        if self.rank == 0:
+            logger.info(f"Decoding completed in {time.time() - decode_start:.2f}s")
+            logger.info(f"Total pipeline time: {time.time() - pipeline_start:.2f}s")
+
+        timer.mark_end()
+        return timer.fill(
+            PipelineOutput(
+                video=video,
+                audio=audio,
+                frame_rate=float(frame_rate),
+                audio_sample_rate=(
+                    int(self.vocoder.output_sampling_rate) if audio is not None else None
+                ),
+            )
+        )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/text_conditioning_ltx23.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/text_conditioning_ltx23.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 text conditioning cache.
+
+Deliberately distinct from LTX-2's ``TextCache``: it caches only the
+**sigma-independent** connector outputs (context, mask, positional embeddings).
+
+It intentionally has NO ``video_kv`` / ``audio_kv`` fields. LTX-2 pre-projects a
+static per-block text K/V once (because its text cross-attention K/V never
+changes across the denoise loop). LTX-2.3's text K/V is modulated by
+``prompt_scale_shift_table`` using a sigma-derived ``prompt_timestep`` and is
+therefore step-varying, so it must be (re)projected inside each denoise step.
+Omitting the K/V fields here makes it structurally impossible to accidentally
+reuse a stale LTX-2-style static K/V.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class LTX23TextConditioning:
+    """Step-invariant, connector-processed text conditioning."""
+
+    video_context: torch.Tensor | None = None
+    video_mask: torch.Tensor | None = None
+    video_pe: tuple[torch.Tensor, torch.Tensor] | None = None
+    video_cross_pe: tuple[torch.Tensor, torch.Tensor] | None = None
+
+    audio_context: torch.Tensor | None = None
+    audio_mask: torch.Tensor | None = None
+    audio_pe: tuple[torch.Tensor, torch.Tensor] | None = None
+    audio_cross_pe: tuple[torch.Tensor, torch.Tensor] | None = None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx23/transformer_ltx23.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx23/transformer_ltx23.py
@@ -1,0 +1,817 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+"""LTX-2.3 ("V2") transformer.
+
+Ported from LTX-2 (``LTXModel`` / ``BasicAVTransformerBlock``) with the
+version-specific changes verified against the LTX-2.3 checkpoint:
+
+* 9-slot per-block AdaLN (MSA [0:3], MLP [3:6], **text-cross-attn [6:9]**) plus a
+  per-block ``prompt_scale_shift_table [2, dim]`` that modulates the text-context
+  (K/V) using a sigma-derived ``prompt_timestep`` (video + audio).
+* ``adaln_single`` embedding_coefficient 6 -> 9; new ``prompt_adaln_single``
+  (coeff 2) produces ``prompt_timestep`` from sigma (video + audio).
+* ``caption_projection`` -> ``nn.Identity`` (LTX-2.3 projects to inner_dim in the
+  ``text_embedding_projection`` feature extractor *before* the connector).
+* Text K/V is projected **per denoise step** from the prompt-modulated context
+  (no static per-block K/V cache like LTX-2).
+* Audio<->video cross-attention is byte-for-byte identical to LTX-2 (5-slot
+  ``scale_shift_table_a2v_ca_*`` + the ``av_ca_*`` AdaLN singles) and is reused.
+
+Perf (Phase-0b): the video+audio self-attention, FFN, and audio<->video
+cross-attention conditioning now use the same fused AdaLN C++ ops as LTX-2
+(``apply_fused_rmsnorm_shift_scale`` / ``apply_fused_gate_resid_rmsnorm`` /
+``apply_fused_gate_resid``), which collapse the RMSNorm + shift/scale + gate +
+residual elementwise chains into single kernel launches. This is gated by
+``self._fuse_adaln`` (only when the inner dims are supported, and overridable via
+``LTX23_DISABLE_FUSE=1``); on unsupported dims / when disabled the helpers fall
+back to the eager math, so the result is unchanged. The only remaining eager
+conditioning is the text cross-attention query shift/scale + gate and the
+sigma-driven prompt K/V modulation (both LTX-2.3-specific; no norm/residual to
+fuse). CUDA graph / Ulysses / fp8 remain out of scope here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import replace
+
+import torch
+import torch.nn as nn
+
+from tensorrt_llm._torch.modules.mlp import MLP
+from tensorrt_llm._torch.utils import gelu_tanh
+
+from ..ltx2.ltx2_core.adaln import AdaLayerNormSingle
+from ..ltx2.ltx2_core.utils_ltx2 import (
+    apply_fused_gate_resid,
+    apply_fused_gate_resid_rmsnorm,
+    apply_fused_rmsnorm_shift_scale,
+    apply_shift_scale,
+    is_fused_adaln_supported_dim,
+)
+from ..ltx2.transformer_ltx2 import (
+    LTX2Attention,
+    LTXModel,
+    TransformerConfig,
+)
+from .text_conditioning_ltx23 import LTX23TextConditioning
+
+# ---------------------------------------------------------------------------
+# Perf-only instrumentation (env-guarded; NO behavior change when unset).
+#
+# The defining LTX-2.3 cost is that each denoise step re-projects the text
+# cross-attention K/V from the sigma-modulated prompt context, whereas LTX-2
+# projects it once and caches it. These flags exist to *measure* that overhead:
+#
+#   LTX23_FREEZE_TEXT_KV=1  Compute each block's text K/V once (first step) and
+#                           reuse it, mimicking LTX-2's static cache. This makes
+#                           the output NUMERICALLY WRONG -- it is a perf A/B knob
+#                           only, to isolate the recompute cost via wall-clock.
+#   LTX23_NVTX=1            Wrap the text-K/V recompute in an NVTX range so nsys
+#                           can attribute GPU time to it directly.
+# ---------------------------------------------------------------------------
+_FREEZE_TEXT_KV = os.environ.get("LTX23_FREEZE_TEXT_KV", "0") == "1"
+_NVTX = os.environ.get("LTX23_NVTX", "0") == "1"
+
+# Perf A/B: force the eager (pre-fusion) AdaLN path even when the fused kernels
+# are supported. LTX23_DISABLE_FUSE=1 reproduces the original unfused behavior so
+# the fused-vs-eager speedup can be measured in the SAME build (one env var
+# apart). Numerically identical either way -- this only changes kernel fusion.
+_DISABLE_FUSE = os.environ.get("LTX23_DISABLE_FUSE", "0") == "1"
+
+
+@contextlib.contextmanager
+def _nvtx_range(name: str):
+    """Env-guarded NVTX range (no-op unless LTX23_NVTX=1). Used to attribute
+    per-step GPU time to each transformer sub-block under nsys."""
+    if _NVTX:
+        torch.cuda.nvtx.range_push(name)
+        try:
+            yield
+        finally:
+            torch.cuda.nvtx.range_pop()
+    else:
+        yield
+
+
+def _get_ada_values(
+    scale_shift_table: torch.Tensor,
+    batch_size: int,
+    timestep: torch.Tensor,
+    indices: slice,
+) -> tuple[torch.Tensor, ...]:
+    """Per-slot AdaLN modulators for ``indices``: one [B, T, D] tensor per slot.
+
+    Broadcast-adds ``scale_shift_table[indices]`` to the reshaped timestep
+    embedding, matching the LTX reference ``get_ada_values``.
+    """
+    num_ada_params = scale_shift_table.shape[0]
+    return (
+        scale_shift_table[indices]
+        .unsqueeze(0)
+        .unsqueeze(0)
+        .to(device=timestep.device, dtype=timestep.dtype)
+        + timestep.reshape(batch_size, timestep.shape[1], num_ada_params, -1)[:, :, indices, :]
+    ).unbind(dim=2)
+
+
+def _get_ada_table_ts_pairs(
+    scale_shift_table: torch.Tensor,
+    batch_size: int,
+    timestep: torch.Tensor,
+    indices: slice,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], ...]:
+    """Pair-form companion to ``_get_ada_values`` (matches LTX-2).
+
+    Returns one ``(table_slice, ts_slice)`` pair per slot in ``indices`` *without*
+    materializing the broadcast-add. The fused AdaLN kernels fold ``table + ts``
+    (and the cast) internally, so passing the pair directly avoids the loose
+    add/cast elementwise kernels the combined form would emit.
+
+    Each pair is ``(table_slice [D], ts_slice [B, T, D])``.
+    """
+    num_ada_params = scale_shift_table.shape[0]
+    ts_reshaped = timestep.reshape(batch_size, timestep.shape[1], num_ada_params, -1)
+    return tuple(
+        (scale_shift_table[i], ts_reshaped[:, :, i, :])
+        for i in range(*indices.indices(num_ada_params))
+    )
+
+
+def _get_av_ca_ada_values(
+    scale_shift_table: torch.Tensor,
+    batch_size: int,
+    scale_shift_timestep: torch.Tensor,
+    gate_timestep: torch.Tensor,
+    num_scale_shift_values: int = 4,
+) -> tuple[torch.Tensor, ...]:
+    """AV cross-attention modulators from a [5, D] table.
+
+    Returns (scale_a2v, shift_a2v, scale_v2a, shift_v2a, gate) — identical
+    layout to LTX-2's ``_get_av_ca_ada_values``.
+    """
+    ss_table = scale_shift_table[:num_scale_shift_values, :]
+    gate_table = scale_shift_table[num_scale_shift_values:, :]
+    num_gate = scale_shift_table.shape[0] - num_scale_shift_values
+
+    ss_vals = (
+        ss_table.unsqueeze(0).unsqueeze(0).to(
+            device=scale_shift_timestep.device, dtype=scale_shift_timestep.dtype
+        )
+        + scale_shift_timestep.reshape(
+            batch_size, scale_shift_timestep.shape[1], num_scale_shift_values, -1
+        )
+    ).unbind(dim=2)
+    gate_vals = (
+        gate_table.unsqueeze(0).unsqueeze(0).to(
+            device=gate_timestep.device, dtype=gate_timestep.dtype
+        )
+        + gate_timestep.reshape(batch_size, gate_timestep.shape[1], num_gate, -1)
+    ).unbind(dim=2)
+    return (*ss_vals, gate_vals[0])
+
+
+def _get_av_ca_ada_table_ts_pairs(
+    scale_shift_table: torch.Tensor,
+    batch_size: int,
+    scale_shift_timestep: torch.Tensor,
+    gate_timestep: torch.Tensor,
+    num_scale_shift_values: int = 4,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], ...]:
+    """Pair-form companion to ``_get_av_ca_ada_values`` (matches LTX-2).
+
+    Returns ``(scale_a2v, shift_a2v, scale_v2a, shift_v2a, gate)`` where each entry
+    is a ``(table_slice [D], ts_slice [B, T, D])`` pair. The first
+    ``num_scale_shift_values`` slots use ``scale_shift_timestep``; the gate slot
+    uses ``gate_timestep``. The fused AdaLN kernels fold ``table + ts`` internally.
+    """
+    num_ada_params = scale_shift_table.shape[0]
+    num_gate_values = num_ada_params - num_scale_shift_values
+    ss_table = scale_shift_table[:num_scale_shift_values, :]
+    gate_table = scale_shift_table[num_scale_shift_values:, :]
+    ss_ts = scale_shift_timestep.reshape(
+        batch_size, scale_shift_timestep.shape[1], num_scale_shift_values, -1
+    )
+    gate_ts = gate_timestep.reshape(batch_size, gate_timestep.shape[1], num_gate_values, -1)
+    ss_pairs = tuple((ss_table[i], ss_ts[:, :, i, :]) for i in range(num_scale_shift_values))
+    gate_pairs = tuple((gate_table[i], gate_ts[:, :, i, :]) for i in range(num_gate_values))
+    return (*ss_pairs, *gate_pairs)
+
+
+class LTX23TransformerBlock(nn.Module):
+    """Dual-stream (audio/video) LTX-2.3 block, eager reference-parity forward."""
+
+    def __init__(
+        self,
+        idx: int,
+        video: TransformerConfig | None = None,
+        audio: TransformerConfig | None = None,
+        rope_type=None,
+        norm_eps: float = 1e-6,
+        config=None,
+    ):
+        super().__init__()
+        self.idx = idx
+        self.norm_eps = norm_eps
+        dtype = config.torch_dtype if config is not None else None
+
+        # Fused AdaLN is only valid when the (per-modality) inner dims are
+        # supported by the fused kernels; otherwise the helpers fall back to the
+        # eager path (numerically identical). Matches LTX-2's per-block gate.
+        video_supports_fused_adaln = video is None or is_fused_adaln_supported_dim(video.dim)
+        audio_supports_fused_adaln = audio is None or is_fused_adaln_supported_dim(audio.dim)
+        self._fuse_adaln = (
+            video_supports_fused_adaln and audio_supports_fused_adaln and not _DISABLE_FUSE
+        )
+
+        if video is not None:
+            self.attn1 = LTX2Attention(
+                query_dim=video.dim,
+                heads=video.heads,
+                dim_head=video.d_head,
+                context_dim=None,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=video.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.attn1",
+                enable_sequence_parallel=False,
+            )
+            self.attn2 = LTX2Attention(
+                query_dim=video.dim,
+                context_dim=video.context_dim,
+                heads=video.heads,
+                dim_head=video.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=video.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.attn2",
+                enable_sequence_parallel=False,
+            )
+            self.ff = MLP(
+                hidden_size=video.dim,
+                intermediate_size=video.dim * 4,
+                bias=True,
+                activation=gelu_tanh,
+                dtype=dtype,
+                config=config,
+                layer_idx=idx,
+            )
+            self.scale_shift_table = nn.Parameter(torch.empty(9, video.dim))
+            self.prompt_scale_shift_table = nn.Parameter(torch.empty(2, video.dim))
+
+        if audio is not None:
+            self.audio_attn1 = LTX2Attention(
+                query_dim=audio.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                context_dim=None,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=audio.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.audio_attn1",
+                enable_sequence_parallel=False,
+            )
+            self.audio_attn2 = LTX2Attention(
+                query_dim=audio.dim,
+                context_dim=audio.context_dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=audio.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.audio_attn2",
+                enable_sequence_parallel=False,
+            )
+            self.audio_ff = MLP(
+                hidden_size=audio.dim,
+                intermediate_size=audio.dim * 4,
+                bias=True,
+                activation=gelu_tanh,
+                dtype=dtype,
+                config=config,
+                layer_idx=idx,
+            )
+            self.audio_scale_shift_table = nn.Parameter(torch.empty(9, audio.dim))
+            self.audio_prompt_scale_shift_table = nn.Parameter(torch.empty(2, audio.dim))
+
+        if audio is not None and video is not None:
+            self.audio_to_video_attn = LTX2Attention(
+                query_dim=video.dim,
+                context_dim=audio.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=video.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.audio_to_video_attn",
+                enable_sequence_parallel=False,
+            )
+            self.video_to_audio_attn = LTX2Attention(
+                query_dim=audio.dim,
+                context_dim=video.dim,
+                heads=audio.heads,
+                dim_head=audio.d_head,
+                rope_type=rope_type,
+                norm_eps=norm_eps,
+                apply_gated_attention=audio.apply_gated_attention,
+                config=config,
+                layer_idx=idx,
+                module_name=f"transformer_blocks.{idx}.video_to_audio_attn",
+                enable_sequence_parallel=False,
+            )
+            self.scale_shift_table_a2v_ca_audio = nn.Parameter(torch.empty(5, audio.dim))
+            self.scale_shift_table_a2v_ca_video = nn.Parameter(torch.empty(5, video.dim))
+
+    def _text_cross_attention(
+        self,
+        x_normed: torch.Tensor,
+        context: torch.Tensor,
+        attn: LTX2Attention,
+        scale_shift_table: torch.Tensor,
+        prompt_scale_shift_table: torch.Tensor,
+        timestep: torch.Tensor,
+        prompt_timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        """LTX-2.3 text cross-attention with query + sigma-driven K/V modulation.
+
+        Mirrors ltx-core ``apply_cross_attention_adaln``:
+          attn_input = x_normed * (1 + scale_q) + shift_q          # slots [6:9]
+          enc        = context  * (1 + scale_kv) + shift_kv        # prompt table
+          out        = attn(attn_input, K/V from enc) * gate
+        """
+        batch_size = x_normed.shape[0]
+        shift_q, scale_q, gate = _get_ada_values(
+            scale_shift_table, batch_size, timestep, slice(6, 9)
+        )
+        attn_input = apply_shift_scale(x_normed, scale_q, shift_q)
+
+        # Perf-only A/B path: reuse the first step's text K/V instead of
+        # recomputing it (see LTX23_FREEZE_TEXT_KV). Keyed by query batch so CFG
+        # cond/uncond (same shape) reuse without a shape crash. Numerically wrong
+        # by design -- used solely to time the recompute we skip here.
+        if _FREEZE_TEXT_KV:
+            cache = getattr(attn, "_frozen_text_kv", None)
+            if cache is None:
+                cache = {}
+                attn._frozen_text_kv = cache
+            hit = cache.get(batch_size)
+            if hit is not None:
+                out = attn(attn_input, pre_projected_kv=hit, timestep=timestep)
+                return out * gate
+
+        if _NVTX:
+            torch.cuda.nvtx.range_push("ltx23_text_kv_recompute")
+        shift_kv, scale_kv = (
+            prompt_scale_shift_table[None, None].to(
+                device=x_normed.device, dtype=x_normed.dtype
+            )
+            + prompt_timestep.reshape(batch_size, prompt_timestep.shape[1], 2, -1)
+        ).unbind(dim=2)
+        enc = apply_shift_scale(context, scale_kv, shift_kv)
+        # Project K/V from the *modulated* context this step (no static cache).
+        k, v = attn.project_kv(enc)
+        if _NVTX:
+            torch.cuda.nvtx.range_pop()
+        if _FREEZE_TEXT_KV:
+            attn._frozen_text_kv[batch_size] = (k, v)
+        out = attn(attn_input, context=enc, pre_projected_kv=(k, v), timestep=timestep)
+        return out * gate
+
+    def forward(
+        self,
+        video,
+        audio,
+        video_prompt_timestep: torch.Tensor | None = None,
+        audio_prompt_timestep: torch.Tensor | None = None,
+    ):
+        vx = video.x if video is not None else None
+        ax = audio.x if audio is not None else None
+        run_vx = video is not None and video.enabled and vx.numel() > 0
+        run_ax = audio is not None and audio.enabled and ax.numel() > 0
+        run_a2v = run_vx and audio is not None and ax is not None and ax.numel() > 0
+        run_v2a = run_ax and video is not None and vx is not None and vx.numel() > 0
+
+        # --- Video self-attention + text cross-attention ---
+        if run_vx:
+            # Pair-form MSA modulators (slot 0=shift, 1=scale, 2=gate); the fused
+            # kernels fold table+ts internally.
+            vshift_msa, vscale_msa, vgate_msa = _get_ada_table_ts_pairs(
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(0, 3)
+            )
+            norm_vx = apply_fused_rmsnorm_shift_scale(
+                vx, vscale_msa[0], vscale_msa[1], vshift_msa[0], vshift_msa[1],
+                self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_video_self_attn"):
+                v_msa = self.attn1(norm_vx, pe=video.positional_embeddings, timestep=video.timesteps)
+            # Fused gate-residual + RMSNorm: vx <- vx + v_msa*gate_msa; then rms_norm
+            # for the text cross-attn query (its slot-[6:9] shift/scale is applied
+            # inside _text_cross_attention).
+            vx, attn2_q_input = apply_fused_gate_resid_rmsnorm(
+                vx, v_msa, vgate_msa[0], vgate_msa[1], self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_video_text_cross_attn"):
+                vx = vx + self._text_cross_attention(
+                    attn2_q_input,
+                    video.context,
+                    self.attn2,
+                    self.scale_shift_table,
+                    self.prompt_scale_shift_table,
+                    video.timesteps,
+                    video_prompt_timestep,
+                )
+
+        # --- Audio self-attention + text cross-attention ---
+        if run_ax:
+            ashift_msa, ascale_msa, agate_msa = _get_ada_table_ts_pairs(
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(0, 3)
+            )
+            norm_ax = apply_fused_rmsnorm_shift_scale(
+                ax, ascale_msa[0], ascale_msa[1], ashift_msa[0], ashift_msa[1],
+                self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_audio_self_attn"):
+                a_msa = self.audio_attn1(norm_ax, pe=audio.positional_embeddings, timestep=audio.timesteps)
+            ax, audio_attn2_q_input = apply_fused_gate_resid_rmsnorm(
+                ax, a_msa, agate_msa[0], agate_msa[1], self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_audio_text_cross_attn"):
+                ax = ax + self._text_cross_attention(
+                    audio_attn2_q_input,
+                    audio.context,
+                    self.audio_attn2,
+                    self.audio_scale_shift_table,
+                    self.audio_prompt_scale_shift_table,
+                    audio.timesteps,
+                    audio_prompt_timestep,
+                )
+
+        # --- Bidirectional audio <-> video cross-attention (identical to LTX-2) ---
+        if run_a2v or run_v2a:
+            if _NVTX:
+                torch.cuda.nvtx.range_push("ltx23_av_cross_attn")
+            vx_pre, ax_pre = vx, ax
+            if run_a2v:
+                scale_v_a2v, shift_v_a2v, _, _, gate_a2v = _get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                )
+                a2v_vx = apply_fused_rmsnorm_shift_scale(
+                    vx_pre, scale_v_a2v[0], scale_v_a2v[1], shift_v_a2v[0], shift_v_a2v[1],
+                    self.norm_eps, self._fuse_adaln,
+                )
+                scale_a_a2v, shift_a_a2v, _, _, _ = _get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                )
+                a2v_ax = apply_fused_rmsnorm_shift_scale(
+                    ax_pre, scale_a_a2v[0], scale_a_a2v[1], shift_a_a2v[0], shift_a_a2v[1],
+                    self.norm_eps, self._fuse_adaln,
+                )
+                k_a2v, v_a2v = self.audio_to_video_attn.project_kv(
+                    a2v_ax, pe=audio.cross_positional_embeddings
+                )
+                a2v_out = self.audio_to_video_attn(
+                    a2v_vx,
+                    pre_projected_kv=(k_a2v, v_a2v),
+                    pe=video.cross_positional_embeddings,
+                    timestep=video.timesteps,
+                )
+                vx = apply_fused_gate_resid(vx, a2v_out, gate_a2v[0], gate_a2v[1], self._fuse_adaln)
+
+            if run_v2a:
+                _, _, scale_a_v2a, shift_a_v2a, gate_v2a = _get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                )
+                v2a_ax = apply_fused_rmsnorm_shift_scale(
+                    ax_pre, scale_a_v2a[0], scale_a_v2a[1], shift_a_v2a[0], shift_a_v2a[1],
+                    self.norm_eps, self._fuse_adaln,
+                )
+                _, _, scale_v_v2a, shift_v_v2a, _ = _get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                )
+                v2a_vx = apply_fused_rmsnorm_shift_scale(
+                    vx_pre, scale_v_v2a[0], scale_v_v2a[1], shift_v_v2a[0], shift_v_v2a[1],
+                    self.norm_eps, self._fuse_adaln,
+                )
+                k_v2a, v_v2a = self.video_to_audio_attn.project_kv(
+                    v2a_vx, pe=video.cross_positional_embeddings
+                )
+                v2a_out = self.video_to_audio_attn(
+                    v2a_ax,
+                    pre_projected_kv=(k_v2a, v_v2a),
+                    pe=audio.cross_positional_embeddings,
+                    timestep=audio.timesteps,
+                )
+                ax = apply_fused_gate_resid(ax, v2a_out, gate_v2a[0], gate_v2a[1], self._fuse_adaln)
+
+            if _NVTX:
+                torch.cuda.nvtx.range_pop()
+
+        # --- Video FFN ---
+        if run_vx:
+            vshift_mlp, vscale_mlp, vgate_mlp = _get_ada_table_ts_pairs(
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, 6)
+            )
+            vx_scaled = apply_fused_rmsnorm_shift_scale(
+                vx, vscale_mlp[0], vscale_mlp[1], vshift_mlp[0], vshift_mlp[1],
+                self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_video_ffn"):
+                vx = apply_fused_gate_resid(
+                    vx, self.ff(vx_scaled), vgate_mlp[0], vgate_mlp[1], self._fuse_adaln
+                )
+
+        # --- Audio FFN ---
+        if run_ax:
+            ashift_mlp, ascale_mlp, agate_mlp = _get_ada_table_ts_pairs(
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, 6)
+            )
+            ax_scaled = apply_fused_rmsnorm_shift_scale(
+                ax, ascale_mlp[0], ascale_mlp[1], ashift_mlp[0], ashift_mlp[1],
+                self.norm_eps, self._fuse_adaln,
+            )
+            with _nvtx_range("ltx23_audio_ffn"):
+                ax = apply_fused_gate_resid(
+                    ax, self.audio_ff(ax_scaled), agate_mlp[0], agate_mlp[1], self._fuse_adaln
+                )
+
+        return (
+            replace(video, x=vx) if video is not None else None,
+            replace(audio, x=ax) if audio is not None else None,
+        )
+
+
+class LTX23Model(LTXModel):
+    """LTX-2.3 transformer. Reuses LTXModel machinery; overrides V2-specific parts.
+
+    The embeddings connectors and split feature extractor are pipeline-level
+    components (matching LTX-2, where the transformer weight load excludes the
+    ``*_embeddings_connector.`` prefixes). This model therefore owns only the
+    diffusion transformer itself and receives already-connector-processed text
+    context in ``prepare_text_cache``.
+    """
+
+    # -- Init overrides ------------------------------------------------------
+
+    def _init_video(self, in_channels, out_channels, caption_channels, norm_eps):
+        self.patchify_proj = self._make_linear(in_channels, self.inner_dim)
+        self.adaln_single = AdaLayerNormSingle(
+            self.inner_dim, embedding_coefficient=9, make_linear=self._make_linear
+        )
+        self.prompt_adaln_single = AdaLayerNormSingle(
+            self.inner_dim, embedding_coefficient=2, make_linear=self._make_linear
+        )
+        # caption projection happens before the connector (text_embedding_projection),
+        # so the in-transformer projection is bypassed.
+        self.caption_projection = nn.Identity()
+        self.scale_shift_table = nn.Parameter(torch.empty(2, self.inner_dim))
+        self.norm_out = nn.LayerNorm(self.inner_dim, elementwise_affine=False, eps=norm_eps)
+        self.proj_out = self._make_linear(self.inner_dim, out_channels)
+
+    def _init_audio(self, in_channels, out_channels, caption_channels, norm_eps):
+        self.audio_patchify_proj = self._make_linear(in_channels, self.audio_inner_dim)
+        self.audio_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim, embedding_coefficient=9, make_linear=self._make_linear
+        )
+        self.audio_prompt_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim, embedding_coefficient=2, make_linear=self._make_linear
+        )
+        self.audio_caption_projection = nn.Identity()
+        self.audio_scale_shift_table = nn.Parameter(torch.empty(2, self.audio_inner_dim))
+        self.audio_norm_out = nn.LayerNorm(
+            self.audio_inner_dim, elementwise_affine=False, eps=norm_eps
+        )
+        self.audio_proj_out = self._make_linear(self.audio_inner_dim, out_channels)
+
+    def _init_transformer_blocks(
+        self,
+        num_layers,
+        attention_head_dim,
+        cross_attention_dim,
+        audio_attention_head_dim,
+        audio_cross_attention_dim,
+        norm_eps,
+        apply_gated_attention,
+    ):
+        video_config = (
+            TransformerConfig(
+                dim=self.inner_dim,
+                heads=self.num_attention_heads,
+                d_head=attention_head_dim,
+                context_dim=cross_attention_dim,
+                apply_gated_attention=apply_gated_attention,
+            )
+            if self.model_type.is_video_enabled()
+            else None
+        )
+        audio_config = (
+            TransformerConfig(
+                dim=self.audio_inner_dim,
+                heads=self.audio_num_attention_heads,
+                d_head=audio_attention_head_dim,
+                context_dim=audio_cross_attention_dim,
+                apply_gated_attention=apply_gated_attention,
+            )
+            if self.model_type.is_audio_enabled()
+            else None
+        )
+        self.transformer_blocks = nn.ModuleList(
+            [
+                LTX23TransformerBlock(
+                    idx=idx,
+                    video=video_config,
+                    audio=audio_config,
+                    rope_type=self.rope_type,
+                    norm_eps=norm_eps,
+                    config=self.model_config,
+                )
+                for idx in range(num_layers)
+            ]
+        )
+
+    def reset_text_kv_cache(self) -> None:
+        """Clear the perf-only frozen text-K/V cache (see LTX23_FREEZE_TEXT_KV).
+
+        No-op unless a prior forward ran under ``LTX23_FREEZE_TEXT_KV=1``. Call at
+        the start of each generation so the cache re-primes on step 0.
+        """
+        for block in self.transformer_blocks:
+            for name in ("attn2", "audio_attn2"):
+                attn = getattr(block, name, None)
+                if attn is not None and hasattr(attn, "_frozen_text_kv"):
+                    attn._frozen_text_kv = {}
+
+    # -- Text conditioning (no static K/V) -----------------------------------
+
+    def _compute_prompt_timestep(self, adaln, sigma, batch_size, dtype):
+        """prompt_timestep from the global sigma (drives context K/V modulation)."""
+        sigma_scaled = sigma * self.timestep_scale_multiplier
+        prompt_ts, _ = adaln(sigma_scaled.flatten(), hidden_dtype=dtype)
+        return prompt_ts.view(batch_size, -1, prompt_ts.shape[-1])
+
+    def prepare_text_cache(
+        self,
+        *,
+        video_context: torch.Tensor | None = None,
+        video_context_mask: torch.Tensor | None = None,
+        video_positions: torch.Tensor | None = None,
+        audio_context: torch.Tensor | None = None,
+        audio_context_mask: torch.Tensor | None = None,
+        audio_positions: torch.Tensor | None = None,
+        dtype: torch.dtype,
+    ) -> LTX23TextConditioning:
+        """Compute step-invariant text conditioning. No per-block K/V (step-varying).
+
+        ``*_context`` are the connector outputs (the pipeline runs the split
+        feature extractor + the video/audio embeddings connectors before calling
+        this). caption_projection is Identity, so the preprocessor passes the
+        connector output through unchanged.
+        """
+        out = LTX23TextConditioning()
+
+        if video_context is not None:
+            v_ctx, v_mask, v_pe, v_cross_pe = self.video_args_preprocessor.prepare_text_cache(
+                video_context, video_context_mask, video_positions, dtype
+            )
+            # NOTE (LTX-2.3): unlike LTX-2 we deliberately do NOT pre-project a
+            # static per-block text K/V here. The K/V is modulated by the
+            # sigma-derived prompt_timestep and is therefore step-varying, so it
+            # is (re)projected inside each denoise step (see block forward).
+            out.video_context = v_ctx
+            out.video_mask = v_mask
+
+        if audio_context is not None:
+            a_ctx, a_mask, a_pe, a_cross_pe = self.audio_args_preprocessor.prepare_text_cache(
+                audio_context, audio_context_mask, audio_positions, dtype
+            )
+            if self._audio_pad > 0:
+                a_pe = self._pad_pe(a_pe, self._audio_pad, seq_dim=1)
+                a_cross_pe = self._pad_pe(a_cross_pe, self._audio_pad, seq_dim=1)
+            out.audio_context = a_ctx
+            out.audio_mask = a_mask
+        else:
+            a_pe = a_cross_pe = None
+
+        # Build sharded-local PE in the form the attention consumer expects
+        # (identical to LTX-2; one-time reshape/shard so the denoise loop has no
+        # PE reshape work). fuse flags are read off the constructed attentions.
+        fuse_video = self.transformer_blocks[0].attn1.fuse_qk_norm_rope
+        fuse_audio = (
+            self.transformer_blocks[0].audio_attn1.fuse_qk_norm_rope
+            if hasattr(self.transformer_blocks[0], "audio_attn1")
+            else True
+        )
+        if video_context is not None:
+            out.video_pe = self._make_pe_local(v_pe, is_audio=False, fuse=fuse_video)
+            out.video_cross_pe = self._make_pe_local(v_cross_pe, is_audio=False, fuse=fuse_video)
+        if audio_context is not None:
+            out.audio_pe = self._make_pe_local(a_pe, is_audio=True, fuse=fuse_audio)
+            out.audio_cross_pe = self._make_pe_local(a_cross_pe, is_audio=True, fuse=fuse_audio)
+        return out
+
+    # -- Forward -------------------------------------------------------------
+
+    def forward(
+        self,
+        video,
+        audio,
+        *,
+        text_cache: LTX23TextConditioning,
+        timestep: torch.Tensor | None = None,
+        step_index=None,
+    ):
+        video_args = (
+            self.video_args_preprocessor.prepare(
+                video,
+                text_cache.video_context,
+                text_cache.video_mask,
+                text_cache.video_pe,
+                text_cache.video_cross_pe,
+            )
+            if video is not None
+            else None
+        )
+        audio_args = (
+            self.audio_args_preprocessor.prepare(
+                audio,
+                text_cache.audio_context,
+                text_cache.audio_mask,
+                text_cache.audio_pe,
+                text_cache.audio_cross_pe,
+            )
+            if audio is not None
+            else None
+        )
+
+        video_prompt_ts = (
+            self._compute_prompt_timestep(
+                self.prompt_adaln_single, video.sigma, video.latent.shape[0], video.latent.dtype
+            )
+            if video is not None
+            else None
+        )
+        audio_prompt_ts = (
+            self._compute_prompt_timestep(
+                self.audio_prompt_adaln_single,
+                audio.sigma,
+                audio.latent.shape[0],
+                audio.latent.dtype,
+            )
+            if audio is not None
+            else None
+        )
+
+        for block in self.transformer_blocks:
+            video_args, audio_args = block(
+                video_args,
+                audio_args,
+                video_prompt_timestep=video_prompt_ts,
+                audio_prompt_timestep=audio_prompt_ts,
+            )
+
+        vx = (
+            self._process_output(
+                self.scale_shift_table,
+                self.norm_out,
+                self.proj_out,
+                video_args.x,
+                video_args.embedded_timestep,
+            )
+            if video_args is not None
+            else None
+        )
+        ax = (
+            self._process_output(
+                self.audio_scale_shift_table,
+                self.audio_norm_out,
+                self.audio_proj_out,
+                audio_args.x,
+                audio_args.embedded_timestep,
+            )
+            if audio_args is not None
+            else None
+        )
+        return vx, ax

--- a/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
@@ -33,6 +33,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from tensorrt_llm.logger import logger
+
 if TYPE_CHECKING:
     from .config import DiffusionPipelineConfig
     from .pipeline import BasePipeline

--- a/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
@@ -34,6 +34,50 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from tensorrt_llm.logger import logger
 
+
+# --- LTX-2.3 ("V2") detection (added for LTX23Pipeline) ---------------------
+# LTX-2.3 text-projection signature. All keys must match and cross_attention_adaln
+# must be True. LTX-2 ("V1") has none of these keys.
+_LTX23_TEXT_CONFIG = {
+    "caption_proj_before_connector": True,
+    "caption_projection_first_linear": False,
+    "caption_projection_second_linear": False,
+    "caption_proj_input_norm": False,
+}
+
+
+def _detect_native_ltx_pipeline(config: dict) -> str:
+    """Return 'LTX2Pipeline' or 'LTX23Pipeline' from native safetensors config."""
+    transformer = config.get("transformer", {})
+    expected = set(_LTX23_TEXT_CONFIG)
+    present = expected.intersection(transformer)
+
+    if not present:
+        if transformer.get("cross_attention_adaln", False):
+            raise ValueError(
+                "Ambiguous LTX checkpoint: cross_attention_adaln=True without "
+                "the LTX-2.3 text-projection configuration."
+            )
+        return "LTX2Pipeline"
+
+    missing = expected - set(transformer)
+    mismatched = {
+        k: transformer[k]
+        for k, v in _LTX23_TEXT_CONFIG.items()
+        if k in transformer and transformer[k] != v
+    }
+    if missing or mismatched:
+        raise ValueError(
+            "Unsupported/partial LTX text-projection config: "
+            f"missing={sorted(missing)}, mismatched={mismatched}"
+        )
+    if transformer.get("cross_attention_adaln") is not True:
+        raise ValueError(
+            "LTX V2 text projection found without cross_attention_adaln=True."
+        )
+    return "LTX23Pipeline"
+# --- end LTX-2.3 detection ---------------------------------------------------
+
 if TYPE_CHECKING:
     from .config import DiffusionPipelineConfig
     from .pipeline import BasePipeline
@@ -227,10 +271,11 @@ class AutoPipeline:
             return None
 
         if "transformer" in config and ("vae" in config or "audio_vae" in config):
+            detected = _detect_native_ltx_pipeline(config)
             logger.info(
-                "AutoPipeline: Detected LTX-2 native checkpoint "
+                f"AutoPipeline: Detected {detected} native checkpoint "
                 f"(safetensors metadata) at {checkpoint_dir}"
             )
-            return "LTX2Pipeline"
+            return detected
 
         return None

--- a/tests/integration/defs/examples/visual_gen/test_ltx23_visual_gen.py
+++ b/tests/integration/defs/examples/visual_gen/test_ltx23_visual_gen.py
@@ -1,0 +1,631 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end LPIPS/audio-faithfulness integration tests for LTX-2.3.
+
+This is the LTX-2.3 counterpart to the LTX-2 blocks in the upstream
+``tests/integration/defs/examples/visual_gen/test_visual_gen.py`` (the
+``test_ltx2_lpips_against_golden`` family). It closes the last untested layer:
+the unit tests confirm wiring + numerics, but not that a *full render* looks and
+sounds right against a frozen golden.
+
+LTX-2.3 emits **audio + video**, so quality is checked on two axes:
+
+- **Video** — decoded pixels vs a golden MP4 via the shared LPIPS eval script
+  (``scripts/visualgen_eval/visual_gen_lpips_score_eval.py``), exactly like every
+  other visual_gen model. LPIPS is a *visual-only* metric.
+- **Audio** — LPIPS says nothing about the soundtrack, so the audio waveform is
+  compared to a golden WAV with a self-contained **log-mel L1** distance. This is
+  the standard perceptual proxy for "does it sound like the reference" and needs
+  no extra model download (unlike LPIPS's AlexNet weights).
+
+Both goldens are frozen media, mirroring upstream's golden-media zip. Generation
+is deterministic (fixed seed + ``torch.use_deterministic_algorithms`` + forced
+eager), so a matching kernel stack reproduces the golden to within the
+cross-host drift margin baked into the thresholds.
+
+Running outside the CI harness (e.g. inside a plain container on a GPU node):
+
+    # 1. Freeze a golden from the current (known-good) build:
+    LTX23_MODEL_PATH=/path/LTX-2.3 LTX23_TEXT_ENCODER_PATH=/path/gemma-3-12b-it \\
+        LTX23_GOLDEN_DIR=/raid/ltx23_golden \\
+        python test_ltx23_visual_gen.py --make-golden
+
+    # 2. Score a fresh render against that golden (video LPIPS + audio mel-L1):
+    LTX23_MODEL_PATH=... LTX23_TEXT_ENCODER_PATH=... LTX23_GOLDEN_DIR=/raid/ltx23_golden \\
+        python test_ltx23_visual_gen.py --score
+
+The pytest entry points (``test_ltx23_*``) use the same helpers but resolve
+paths + goldens through the CI harness (``llm_models_root`` / the golden zip).
+"""
+
+import contextlib
+import json
+import math
+import os
+import subprocess
+import sys
+import wave
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Path + golden resolution.
+#
+# In CI this file lives at tests/integration/defs/examples/visual_gen/, so the
+# repo root is five levels up and models come from ``llm_models_root()``. Outside
+# CI (standalone container run) those are absent, so every path is overridable by
+# env var -- matching the convention already used by test_ltx23_pipeline.py.
+# ---------------------------------------------------------------------------
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", ".."))
+VISUAL_GEN_LPIPS_EVAL_SCRIPT = os.path.join(
+    REPO_ROOT, "scripts", "visualgen_eval", "visual_gen_lpips_score_eval.py"
+)
+
+
+def _llm_models_root():
+    """Best-effort models root: CI harness first, then env var, else ''."""
+    try:  # pragma: no cover - CI-only path
+        from defs import conftest
+
+        return str(conftest.llm_models_root())
+    except Exception:
+        return os.environ.get("LLM_MODELS_ROOT", "")
+
+
+_MODELS_ROOT = _llm_models_root()
+_LTX23_BASE = os.path.join(_MODELS_ROOT, "LTX-2.3") if _MODELS_ROOT else ""
+_GEMMA3_DEFAULT = os.path.join(_MODELS_ROOT, "gemma", "gemma-3-12b-it") if _MODELS_ROOT else ""
+
+LTX23_MODEL_PATH = os.environ.get("LTX23_MODEL_PATH", _LTX23_BASE)
+LTX23_TEXT_ENCODER_PATH = os.environ.get("LTX23_TEXT_ENCODER_PATH", _GEMMA3_DEFAULT)
+
+# Golden media. In CI these are shipped in the golden dir alongside the other
+# visual_gen goldens; LTX23_GOLDEN_DIR overrides for a standalone node run.
+LTX23_GOLDEN_DIR = os.environ.get(
+    "LTX23_GOLDEN_DIR",
+    os.path.join(os.path.dirname(__file__), "golden", "visual_gen_lpips"),
+)
+LTX23_GOLDEN_VIDEO = os.path.join(LTX23_GOLDEN_DIR, "ltx23_lpips_golden_video.mp4")
+LTX23_GOLDEN_AUDIO = os.path.join(LTX23_GOLDEN_DIR, "ltx23_audio_golden.wav")
+
+# ---------------------------------------------------------------------------
+# Deterministic LPIPS render config (small on purpose -- mirrors LTX-2's reduced
+# 49-frame / 8-step LPIPS setting so the golden is cheap to reproduce while still
+# exercising the full A/V decode + vocoder + BWE path).
+# ---------------------------------------------------------------------------
+LTX23_LPIPS_PROMPT = (
+    "A cinematic close-up of a golden retriever puppy running through a sunlit "
+    "meadow of wildflowers, gentle breeze, birds chirping"
+)
+LTX23_LPIPS_HEIGHT = 512
+LTX23_LPIPS_WIDTH = 768
+LTX23_LPIPS_NUM_FRAMES = 49
+LTX23_LPIPS_NUM_INFERENCE_STEPS = 8
+LTX23_LPIPS_GUIDANCE_SCALE = 5.0
+LTX23_LPIPS_FRAME_RATE = 24.0
+LTX23_LPIPS_SEED = 42
+
+# Thresholds. The video LPIPS gate matches every other visual_gen model (0.05,
+# which absorbs the ~0.04 cross-B200-host kernel drift upstream measured). The
+# audio log-mel-L1 gate is calibrated from the first golden run on the target
+# stack; deterministic same-host reruns land near 0 and the margin covers
+# cross-host drift. Override with LTX23_AUDIO_MEL_L1_THRESHOLD after calibration.
+LTX23_LPIPS_THRESHOLD = 0.05
+LTX23_AUDIO_MEL_L1_THRESHOLD = float(os.environ.get("LTX23_AUDIO_MEL_L1_THRESHOLD", "0.10"))
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (mirrors of the upstream test_visual_gen.py utilities).
+# ---------------------------------------------------------------------------
+def _skip_if_missing(path, label, is_dir=False):
+    exists = os.path.isdir(path) if is_dir else os.path.exists(path)
+    if not exists:
+        pytest.skip(f"{label} not found: {path}")
+
+
+@contextlib.contextmanager
+def _lpips_deterministic_algorithms():
+    """Deterministic numerics for reproducible golden comparison.
+
+    Same recipe as upstream: pin the cuBLAS workspace and enable deterministic
+    algorithms so a fresh render reproduces the golden on a matching stack.
+    """
+    prev_det = torch.are_deterministic_algorithms_enabled()
+    prev_warn = torch.is_deterministic_algorithms_warn_only_enabled()
+    prev_cublas = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    try:
+        os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        yield
+    finally:
+        torch.use_deterministic_algorithms(prev_det, warn_only=prev_warn)
+        if prev_cublas is None:
+            os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        else:
+            os.environ["CUBLAS_WORKSPACE_CONFIG"] = prev_cublas
+
+
+def _save_lpips_video_mp4(video, output_path, frame_rate):
+    """Encode with H.264 (never a silent codec fallback).
+
+    LPIPS compares decoded pixels; a cv2/mp4v fallback would measure codec
+    artifacts instead of model output, so refuse rather than mask the failure
+    (this is the exact footgun that produced a spurious LPIPS on wan22 upstream).
+    Raises RuntimeError (not pytest.fail) so the standalone driver reports it
+    cleanly too.
+    """
+    from tensorrt_llm.media.encoding import save_video
+
+    try:
+        save_video(video, output_path, frame_rate=frame_rate)
+    except RuntimeError as err:
+        if "MP4 format requires ffmpeg" not in str(err):
+            raise
+        raise RuntimeError(
+            "ffmpeg is unavailable for LPIPS video encoding; refusing to fall back "
+            "to another codec because the golden comparison would measure codec "
+            f"artifacts instead of model output: {err}"
+        ) from err
+    assert os.path.isfile(output_path), f"LTX-2.3 did not produce video {output_path}"
+
+
+def _lpips_script_available():
+    return os.path.isfile(VISUAL_GEN_LPIPS_EVAL_SCRIPT)
+
+
+def _run_lpips_eval(tmp_dir, sample_id, prompt, reference_path, generated_path):
+    """Score generated vs golden video with the shared LPIPS eval script.
+
+    Reuses ``scripts/visualgen_eval/visual_gen_lpips_score_eval.py`` (the same
+    script every visual_gen model uses) in "rescore existing media" mode --
+    reference/generated paths only, no re-generation. Raises FileNotFoundError if
+    the script is absent (caller decides skip vs. warn); RuntimeError on failure.
+    """
+    if not _lpips_script_available():
+        raise FileNotFoundError(f"LPIPS eval script not found: {VISUAL_GEN_LPIPS_EVAL_SCRIPT}")
+
+    dataset_path = os.path.join(tmp_dir, f"{sample_id}_dataset.json")
+    output_json = os.path.join(tmp_dir, f"{sample_id}_lpips_results.json")
+    with open(dataset_path, "w", encoding="utf-8") as fh:
+        json.dump(
+            {
+                "samples": [
+                    {
+                        "id": sample_id,
+                        "media_type": "video",
+                        "prompt": prompt,
+                        "reference_video_path": str(reference_path),
+                        "generated_video_path": str(generated_path),
+                    }
+                ]
+            },
+            fh,
+            indent=2,
+        )
+
+    env = os.environ.copy()
+    env.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}{os.pathsep}{env['PYTHONPATH']}" if env.get("PYTHONPATH") else REPO_ROOT
+    )
+    with _lpips_deterministic_algorithms():
+        result = subprocess.run(
+            [
+                sys.executable,
+                VISUAL_GEN_LPIPS_EVAL_SCRIPT,
+                "--dataset",
+                str(dataset_path),
+                "--output-json",
+                str(output_json),
+                "--json",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise RuntimeError(f"LPIPS eval script failed for {sample_id}:\n{result.stdout}")
+
+    with open(output_json, encoding="utf-8") as fh:
+        scores = json.load(fh)
+    score = float(scores["mean_lpips_score"])
+    print(f"\n[E2E {sample_id} video LPIPS] score: {score:.6f}")
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Audio faithfulness: log-mel L1 distance (self-contained; no external model).
+#
+# LPIPS is a visual metric, so the LTX-2.3 soundtrack needs its own gate. Log-mel
+# L1 is the standard perceptual proxy: mismatched pitch/timbre/timing shows up as
+# large per-bin differences, while deterministic reruns land near zero. The mel
+# filterbank is built here (HTK formula) to avoid a librosa/torchaudio dependency.
+# ---------------------------------------------------------------------------
+def _wav_to_mono(audio):
+    """Any audio tensor/array -> 1-D float32 mono torch tensor in roughly [-1, 1]."""
+    a = torch.as_tensor(audio, dtype=torch.float32).detach().cpu()
+    while a.dim() > 2:  # drop batch dims, e.g. (B, C, T) -> (C, T)
+        a = a.squeeze(0)
+    if a.dim() == 2:  # (C, T) or (T, C) -> mono
+        if a.shape[0] <= 8 and a.shape[0] < a.shape[1]:  # channels-first
+            a = a.mean(dim=0)
+        else:  # samples-first
+            a = a.mean(dim=1)
+    return a.contiguous()
+
+
+def _save_wav(audio, path, sample_rate):
+    """Write a mono int16 PCM WAV (stdlib only; deterministic on disk)."""
+    mono = _wav_to_mono(audio)
+    peak = mono.abs().max().item()
+    if peak > 1.0:  # vocoder output is ~[-1, 1]; guard clipping just in case
+        mono = mono / peak
+    pcm = (mono.clamp(-1.0, 1.0) * 32767.0).round().to(torch.int16).numpy()
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(int(sample_rate))
+        wf.writeframes(pcm.tobytes())
+    assert os.path.isfile(path), f"Failed to write WAV {path}"
+
+
+def _load_wav(path):
+    """Read a mono int16 WAV -> (float32 tensor in [-1, 1], sample_rate)."""
+    import numpy as np
+
+    with wave.open(str(path), "rb") as wf:
+        n_channels = wf.getnchannels()
+        sample_rate = wf.getframerate()
+        frames = wf.readframes(wf.getnframes())
+    data = np.frombuffer(frames, dtype=np.int16).astype("float32") / 32768.0
+    if n_channels > 1:
+        data = data.reshape(-1, n_channels).mean(axis=1)
+    return torch.from_numpy(data.copy()), sample_rate
+
+
+def _hz_to_mel(hz):
+    return 2595.0 * math.log10(1.0 + hz / 700.0)
+
+
+def _mel_to_hz(mel):
+    return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
+
+
+def _mel_filterbank(sample_rate, n_fft, n_mels, fmin=0.0, fmax=None):
+    """Triangular HTK mel filterbank, shape [n_mels, n_fft // 2 + 1]."""
+    fmax = fmax if fmax is not None else sample_rate / 2.0
+    n_freqs = n_fft // 2 + 1
+    fft_freqs = torch.linspace(0.0, sample_rate / 2.0, n_freqs)
+    mel_pts = torch.linspace(_hz_to_mel(fmin), _hz_to_mel(fmax), n_mels + 2)
+    hz_pts = torch.tensor([_mel_to_hz(m.item()) for m in mel_pts])
+
+    fb = torch.zeros(n_mels, n_freqs)
+    for m in range(1, n_mels + 1):
+        left, center, right = hz_pts[m - 1], hz_pts[m], hz_pts[m + 1]
+        left_slope = (fft_freqs - left) / max((center - left).item(), 1e-6)
+        right_slope = (right - fft_freqs) / max((right - center).item(), 1e-6)
+        fb[m - 1] = torch.clamp(torch.minimum(left_slope, right_slope), min=0.0)
+    return fb
+
+
+def _log_mel(wav, sample_rate, n_fft=1024, hop=256, n_mels=64, top_db=80.0):
+    """Log-mel power spectrogram (dynamic-range clamped), shape [n_mels, n_frames].
+
+    Uses a per-clip ``top_db`` floor (librosa ``power_to_db`` convention): bins more
+    than ``top_db`` below the peak are clamped. Without this, ``log(quiet_bin)`` swings
+    wildly on tiny amplitude changes, so int16/codec noise in near-silent bins would
+    dominate the L1 distance and swamp real perceptual differences.
+    """
+    mono = _wav_to_mono(wav)
+    window = torch.hann_window(n_fft)
+    spec = torch.stft(
+        mono,
+        n_fft=n_fft,
+        hop_length=hop,
+        win_length=n_fft,
+        window=window,
+        center=True,
+        return_complex=True,
+    )
+    power = spec.abs().pow(2.0)  # [n_freqs, n_frames]
+    fb = _mel_filterbank(sample_rate, n_fft, n_mels)
+    mel = fb @ power  # [n_mels, n_frames]
+    log_mel = torch.log(torch.clamp(mel, min=1e-10))
+    # top_db dB below peak -> natural-log units (dB = 10/ln(10) * ln(power)).
+    floor = log_mel.max() - (top_db / 10.0) * math.log(10.0)
+    return torch.clamp(log_mel, min=floor)
+
+
+def _audio_mel_l1_distance(generated, reference, gen_rate, ref_rate):
+    """Mean |log-mel| difference between two waveforms (rate-matched, len-aligned)."""
+    if gen_rate != ref_rate:
+        raise ValueError(f"Sample-rate mismatch: generated {gen_rate} vs golden {ref_rate}")
+    gen_mel = _log_mel(generated, gen_rate)
+    ref_mel = _log_mel(reference, ref_rate)
+    n = min(gen_mel.shape[1], ref_mel.shape[1])
+    if n == 0:
+        raise ValueError("Empty audio: one of the clips decoded to zero frames")
+    diff = (gen_mel[:, :n] - ref_mel[:, :n]).abs().mean().item()
+    print(f"[E2E audio log-mel L1] distance: {diff:.6f} (frames compared: {n})")
+    return diff
+
+
+# ---------------------------------------------------------------------------
+# Deterministic LTX-2.3 A/V render (shared by golden creation + candidate runs).
+# ---------------------------------------------------------------------------
+def _generate_ltx23_av(video_out_path, audio_out_path):
+    """Render the LPIPS clip deterministically; save MP4 (video) + WAV (audio).
+
+    Returns the audio sample rate. Skips (never fails) if any model asset is
+    missing so the suite degrades gracefully when checkpoints aren't mounted.
+    """
+    from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
+    from tensorrt_llm.visual_gen.args import TorchCompileConfig, VisualGenArgs
+
+    _skip_if_missing(LTX23_MODEL_PATH, "LTX-2.3 checkpoint", is_dir=True)
+    _skip_if_missing(LTX23_TEXT_ENCODER_PATH, "LTX-2.3 text encoder (gemma-3-12b-it)", is_dir=True)
+
+    # Force eager + deterministic: nested @torch.compile decorators are not
+    # suppressed by TorchCompileConfig(enable=False) alone, so wrap the whole
+    # render (matches the upstream LTX-2 golden generator).
+    with _lpips_deterministic_algorithms(), torch.compiler.set_stance("force_eager"):
+        args = VisualGenArgs(
+            model=LTX23_MODEL_PATH,
+            pipeline_config={"text_encoder_path": LTX23_TEXT_ENCODER_PATH},
+            torch_compile_config=TorchCompileConfig(enable=False),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        try:
+            with torch.no_grad():
+                out = pipeline.forward(
+                    prompt=LTX23_LPIPS_PROMPT,
+                    seed=LTX23_LPIPS_SEED,
+                    height=LTX23_LPIPS_HEIGHT,
+                    width=LTX23_LPIPS_WIDTH,
+                    num_frames=LTX23_LPIPS_NUM_FRAMES,
+                    frame_rate=LTX23_LPIPS_FRAME_RATE,
+                    num_inference_steps=LTX23_LPIPS_NUM_INFERENCE_STEPS,
+                    guidance_scale=LTX23_LPIPS_GUIDANCE_SCALE,
+                )
+            video = out.video.detach().cpu()
+            audio = out.audio.detach().cpu() if out.audio is not None else None
+            audio_rate = out.audio_sample_rate
+        finally:
+            del pipeline
+            import gc
+
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    _save_lpips_video_mp4(video, video_out_path, frame_rate=LTX23_LPIPS_FRAME_RATE)
+    if audio is None:
+        raise AssertionError("LTX-2.3 render returned no audio; expected an audio+video pipeline")
+    _save_wav(audio, audio_out_path, audio_rate)
+    return audio_rate
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixtures + tests.
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def ltx23_av_candidate(tmp_path_factory):
+    """Render the candidate A/V clip once per session; return (video, audio) paths."""
+    out_dir = tmp_path_factory.mktemp("ltx23_av")
+    video_path = os.path.join(str(out_dir), "ltx23_candidate_video.mp4")
+    audio_path = os.path.join(str(out_dir), "ltx23_candidate_audio.wav")
+    _generate_ltx23_av(video_path, audio_path)
+    return video_path, audio_path
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_ltx23_video_lpips_against_golden(tmp_path, ltx23_av_candidate):
+    """Decoded video vs golden MP4 must stay under the shared LPIPS threshold."""
+    _skip_if_missing(LTX23_GOLDEN_VIDEO, "LTX-2.3 LPIPS golden video")
+    if not _lpips_script_available():
+        pytest.skip(f"LPIPS eval script not found: {VISUAL_GEN_LPIPS_EVAL_SCRIPT}")
+    video_path, _ = ltx23_av_candidate
+    score = _run_lpips_eval(
+        str(tmp_path),
+        "ltx23",
+        LTX23_LPIPS_PROMPT,
+        LTX23_GOLDEN_VIDEO,
+        video_path,
+    )
+    assert score < LTX23_LPIPS_THRESHOLD, (
+        f"LTX-2.3 video LPIPS too high: {score:.6f} (expected < {LTX23_LPIPS_THRESHOLD:.6f})"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_ltx23_audio_against_golden(ltx23_av_candidate):
+    """Decoded audio vs golden WAV must stay under the log-mel L1 threshold.
+
+    Audio is the LTX-2.3-specific axis LPIPS cannot see; this is the only gate on
+    the vocoder + BWE (48 kHz) output actually sounding like the reference.
+    """
+    _skip_if_missing(LTX23_GOLDEN_AUDIO, "LTX-2.3 golden audio")
+    _, audio_path = ltx23_av_candidate
+    generated, gen_rate = _load_wav(audio_path)
+    reference, ref_rate = _load_wav(LTX23_GOLDEN_AUDIO)
+    distance = _audio_mel_l1_distance(generated, reference, gen_rate, ref_rate)
+    assert distance < LTX23_AUDIO_MEL_L1_THRESHOLD, (
+        f"LTX-2.3 audio log-mel L1 too high: {distance:.6f} "
+        f"(expected < {LTX23_AUDIO_MEL_L1_THRESHOLD:.6f})"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_ltx23_example(tmp_path):
+    """Run examples/visual_gen/models/ltx23.py end-to-end with the BF16 config.
+
+    Mirrors ``test_ltx2_example``: validates the example script + shared YAML work
+    together and produce an MP4 (a smoke test on top of the quality gates above).
+    """
+    _skip_if_missing(LTX23_MODEL_PATH, "LTX-2.3 checkpoint", is_dir=True)
+    _skip_if_missing(LTX23_TEXT_ENCODER_PATH, "LTX-2.3 text encoder (gemma-3-12b-it)", is_dir=True)
+
+    examples_root = os.path.join(REPO_ROOT, "examples", "visual_gen")
+    script_path = os.path.join(examples_root, "models", "ltx23.py")
+    config_path = os.path.join(examples_root, "configs", "ltx23-t2v-bf16-1gpu.yaml")
+    for label, path in [("example script", script_path), ("BF16 config", config_path)]:
+        if not os.path.isfile(path):
+            pytest.skip(f"LTX-2.3 {label} not found: {path}")
+
+    output_path = os.path.join(str(tmp_path), "ltx23_output.mp4")
+    result = subprocess.run(
+        [
+            sys.executable,
+            script_path,
+            "--model",
+            LTX23_MODEL_PATH,
+            "--visual_gen_args",
+            config_path,
+            "--text_encoder_path",
+            LTX23_TEXT_ENCODER_PATH,
+            "--output_path",
+            output_path,
+            "--height",
+            str(LTX23_LPIPS_HEIGHT),
+            "--width",
+            str(LTX23_LPIPS_WIDTH),
+            "--num_frames",
+            str(LTX23_LPIPS_NUM_FRAMES),
+            "--num_inference_steps",
+            str(LTX23_LPIPS_NUM_INFERENCE_STEPS),
+        ],
+        check=False,
+    )
+    assert result.returncode == 0, "LTX-2.3 example script exited non-zero"
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+# ---------------------------------------------------------------------------
+# Standalone driver (no pytest / CI harness needed) for use on a GPU node.
+# ---------------------------------------------------------------------------
+def _self_test_audio_metric():
+    """Validate the log-mel L1 metric with synthetic signals (no model needed).
+
+    Identical clips -> ~0; a pitch-shifted tone -> clearly larger. A cheap guard
+    that the mel math + WAV round-trip behave before spending a GPU render.
+    """
+    sr = 48000
+    t = torch.arange(0, sr, dtype=torch.float32) / sr  # 1 s
+    tone_a = 0.5 * torch.sin(2 * math.pi * 440.0 * t)
+    tone_a2 = 0.5 * torch.sin(2 * math.pi * 440.0 * t)  # identical
+    tone_b = 0.5 * torch.sin(2 * math.pi * 660.0 * t)  # a fifth up
+
+    same = _audio_mel_l1_distance(tone_a, tone_a2, sr, sr)
+    diff = _audio_mel_l1_distance(tone_a, tone_b, sr, sr)
+    print(f"[self-test] identical={same:.6f}  pitch-shifted={diff:.6f}")
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        wav_path = os.path.join(d, "rt.wav")
+        _save_wav(tone_a, wav_path, sr)
+        loaded, loaded_sr = _load_wav(wav_path)
+        rt = _audio_mel_l1_distance(tone_a, loaded, sr, loaded_sr)
+    print(f"[self-test] wav round-trip distance={rt:.6f} (sr={loaded_sr})")
+
+    # rt is int16 round-trip noise (I/O sanity, not the quality gate); with top_db
+    # clamping this sits well under 0.05, but keep margin so it isn't brittle.
+    ok = same < 1e-4 and diff > 0.5 and rt < 0.1
+    print(f"[self-test] {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+def _main(argv):
+    import argparse
+
+    parser = argparse.ArgumentParser(description="LTX-2.3 golden / scoring driver")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Validate the audio log-mel metric on synthetic tones (no model/GPU)",
+    )
+    parser.add_argument(
+        "--make-golden",
+        action="store_true",
+        help=f"Render deterministically and freeze goldens into {LTX23_GOLDEN_DIR}",
+    )
+    parser.add_argument(
+        "--score",
+        action="store_true",
+        help="Render a candidate and score video LPIPS + audio mel-L1 vs the goldens",
+    )
+    parser.add_argument("--work-dir", default="/tmp/ltx23_score", help="Scratch dir for candidates")
+    args = parser.parse_args(argv)
+
+    if not (args.self_test or args.make_golden or args.score):
+        parser.error("pass --self-test, --make-golden and/or --score")
+
+    if args.self_test:
+        rc = _self_test_audio_metric()
+        if rc != 0:
+            return rc
+
+    if args.make_golden:
+        os.makedirs(LTX23_GOLDEN_DIR, exist_ok=True)
+        rate = _generate_ltx23_av(LTX23_GOLDEN_VIDEO, LTX23_GOLDEN_AUDIO)
+        print(f"[golden] video -> {LTX23_GOLDEN_VIDEO}")
+        print(f"[golden] audio -> {LTX23_GOLDEN_AUDIO} ({rate} Hz)")
+
+    if args.score:
+        os.makedirs(args.work_dir, exist_ok=True)
+        cand_video = os.path.join(args.work_dir, "ltx23_candidate_video.mp4")
+        cand_audio = os.path.join(args.work_dir, "ltx23_candidate_audio.wav")
+        _generate_ltx23_av(cand_video, cand_audio)
+
+        # Audio gate (self-contained, always runs).
+        generated, gen_rate = _load_wav(cand_audio)
+        reference, ref_rate = _load_wav(LTX23_GOLDEN_AUDIO)
+        audio_dist = _audio_mel_l1_distance(generated, reference, gen_rate, ref_rate)
+        audio_ok = audio_dist < LTX23_AUDIO_MEL_L1_THRESHOLD
+
+        # Video gate (needs the shared LPIPS eval script + its deps). Degrade to a
+        # warning if unavailable so audio + determinism still report a result.
+        video_score = None
+        try:
+            video_score = _run_lpips_eval(
+                args.work_dir, "ltx23", LTX23_LPIPS_PROMPT, LTX23_GOLDEN_VIDEO, cand_video
+            )
+        except FileNotFoundError as err:
+            print(f"[WARN] video LPIPS skipped: {err}")
+        except RuntimeError as err:
+            print(f"[WARN] video LPIPS could not run (missing deps/weights?):\n{err}")
+
+        video_ok = video_score is None or video_score < LTX23_LPIPS_THRESHOLD
+        if video_score is not None:
+            print(
+                f"\n[RESULT] video LPIPS {video_score:.6f} < {LTX23_LPIPS_THRESHOLD} -> "
+                f"{'PASS' if video_ok else 'FAIL'}"
+            )
+        else:
+            print("\n[RESULT] video LPIPS -> SKIPPED (eval script/deps unavailable)")
+        print(
+            f"[RESULT] audio mel-L1 {audio_dist:.6f} < {LTX23_AUDIO_MEL_L1_THRESHOLD} -> "
+            f"{'PASS' if audio_ok else 'FAIL'}"
+        )
+        return 0 if (video_ok and audio_ok) else 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tests/unittest/_torch/visual_gen/test_ltx23_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx23_pipeline.py
@@ -1,0 +1,496 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Integration tests for the LTX-2.3 pipeline.
+
+Mirrors ``test_ltx2_pipeline.py`` (same conventions / thresholds) but targets
+the LTX-2.3 (``LTX23Pipeline``) native checkpoint. Tests cover:
+
+- Pipeline loading with quantization (FP8, FP8_BLOCK_SCALES) + FP8 weight check
+- FP8 vs BF16 single-layer numerical correctness
+- FP8 vs BF16 transformer memory comparison
+- Attention backend comparison (VANILLA vs TRTLLM), video + audio outputs
+- Single-stage variant resolution (no two-stage upsampler/LoRA in Phase-0)
+
+Requires the LTX-2.3 checkpoint. Does NOT require the LTX-2.3 reference code.
+
+Key differences from the LTX-2 template (LTX-2.3 specifics):
+- Inputs are ``LTX23Modality`` objects, which add a global ``sigma`` field
+  (drives the sigma-dependent text cross-attention K/V modulation).
+- ``caption_projection`` is ``nn.Identity`` in LTX-2.3 (the split feature
+  extractor projects to inner_dim *before* the connector), so the text
+  ``context`` fed to the transformer is already ``cross_attention_dim`` wide,
+  not ``caption_channels``.
+- The transformer emits ``(video_out, audio_out)`` from an AudioVideo model.
+"""
+
+import gc
+import os
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineComponent, PipelineLoader
+from tensorrt_llm.visual_gen.args import AttentionConfig, VisualGenArgs
+
+os.environ.setdefault("TLLM_DISABLE_MPI", "1")
+
+# ``test_common`` is part of the TRT-LLM source test harness and is present in
+# CI. When running standalone (e.g. against a pip-installed TRT-LLM inside a
+# container), it is absent; fall back to the LLM_MODELS_ROOT env var so the
+# module still imports and the explicit LTX23_MODEL_PATH override below works.
+try:
+    from test_common.llm_data import llm_models_root
+
+    _MODELS_ROOT = str(llm_models_root(check=False))
+except Exception:  # pragma: no cover - only hit outside the CI harness
+    _MODELS_ROOT = os.environ.get("LLM_MODELS_ROOT", "")
+
+# Skip non-transformer components. ``skip_components`` focuses the load on the
+# transformer; LTX-2.3 native components (audio_vae, vocoder, connectors,
+# video decoder) still load from the checkpoint automatically.
+SKIP_COMPONENTS = [
+    PipelineComponent.TEXT_ENCODER,
+    PipelineComponent.TOKENIZER,
+    PipelineComponent.VAE,
+    PipelineComponent.SCHEDULER,
+]
+
+
+_LTX23_BASE = os.path.join(_MODELS_ROOT, "LTX-2.3") if _MODELS_ROOT else ""
+_GEMMA3_DEFAULT = (
+    os.path.join(_MODELS_ROOT, "gemma", "gemma-3-12b-it") if _MODELS_ROOT else ""
+)
+
+
+# LTX-2.3 ships as a native single-file checkpoint inside its model directory;
+# quantization is applied dynamically from the BF16 weights (no separate FP8
+# checkpoint file), so a single checkpoint path covers every quant test.
+CHECKPOINT_PATH_BF16 = os.environ.get("LTX23_MODEL_PATH", _LTX23_BASE)
+GEMMA3_PATH = os.environ.get("LTX23_TEXT_ENCODER_PATH", _GEMMA3_DEFAULT)
+
+
+def _ltx23_pipeline_config(**overrides):
+    """Build pipeline_config with the Gemma3 text_encoder_path LTX-2.3 needs.
+
+    LTX-2.3's tokenizer + text encoder load from a separate Gemma directory
+    (not the diffusion checkpoint), so every full-pipeline load needs
+    ``text_encoder_path`` set.
+    """
+    cfg = {"text_encoder_path": GEMMA3_PATH}
+    cfg.update(overrides)
+    return cfg
+
+
+def _get_ltx23_transformer_inputs(transformer, device="cuda", dtype=torch.bfloat16):
+    """Create test inputs for the LTX-2.3 transformer (LTX23Modality objects).
+
+    Constructs minimal video + audio inputs compatible with the transformer's
+    args preprocessor. Unlike LTX-2, the text ``context`` is already
+    ``cross_attention_dim`` wide (caption_projection is Identity in LTX-2.3),
+    and each modality carries a global ``sigma`` alongside per-token
+    ``timesteps``.
+    """
+    torch.manual_seed(42)
+    batch = 1
+    n_frames, grid_h, grid_w = 1, 4, 4
+    v_patches = n_frames * grid_h * grid_w
+    a_patches = 8
+    text_len = 8
+
+    cfg = getattr(transformer, "_transformer_config", {})
+    in_channels = cfg.get("in_channels", 128)
+    audio_in_channels = cfg.get("audio_in_channels", 128)
+    # Post-connector context dims (== inner_dim, since caption_projection is
+    # Identity in LTX-2.3). Fall back to the checkpoint defaults.
+    v_context_dim = cfg.get("cross_attention_dim", 4096)
+    a_context_dim = cfg.get("audio_cross_attention_dim", 2048)
+
+    v_positions = torch.zeros(batch, 3, v_patches, 2, device=device)
+    idx = 0
+    for f in range(n_frames):
+        for h in range(grid_h):
+            for w in range(grid_w):
+                v_positions[:, 0, idx, :] = torch.tensor([f, f + 1], dtype=torch.float32)
+                v_positions[:, 1, idx, :] = torch.tensor([h, h + 1], dtype=torch.float32)
+                v_positions[:, 2, idx, :] = torch.tensor([w, w + 1], dtype=torch.float32)
+                idx += 1
+
+    a_positions = torch.zeros(batch, 1, a_patches, 2, device=device)
+    for i in range(a_patches):
+        a_positions[:, 0, i, :] = torch.tensor([i, i + 1], dtype=torch.float32)
+
+    v_context = torch.randn(batch, text_len, v_context_dim, device=device, dtype=dtype)
+    a_context = torch.randn(batch, text_len, a_context_dim, device=device, dtype=dtype)
+
+    from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.modality import LTX23Modality
+
+    sigma = torch.tensor([0.5], device=device)
+    video = LTX23Modality(
+        latent=torch.randn(batch, v_patches, in_channels, device=device, dtype=dtype),
+        timesteps=torch.tensor([0.5], device=device),
+        sigma=sigma,
+        positions=v_positions,
+        context=v_context,
+    )
+    audio = LTX23Modality(
+        latent=torch.randn(batch, a_patches, audio_in_channels, device=device, dtype=dtype),
+        timesteps=torch.tensor([0.5], device=device),
+        sigma=sigma,
+        positions=a_positions,
+        context=a_context,
+    )
+    text_cache = transformer.prepare_text_cache(
+        video_context=v_context,
+        video_positions=v_positions,
+        audio_context=a_context,
+        audio_positions=a_positions,
+        dtype=dtype,
+    )
+    return video, audio, text_cache
+
+
+def _extract_output(output):
+    """Extract tensors from (video_out, audio_out) tuple."""
+    if isinstance(output, tuple) and len(output) == 2:
+        return output
+    return output, None
+
+
+def _find_first_quantizable_linear(transformer):
+    """Find the first Linear layer in transformer blocks suitable for testing."""
+    for name, module in transformer.named_modules():
+        if isinstance(module, Linear) and "blocks" in name:
+            return module, name
+    return None, None
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def ltx23_bf16_checkpoint_exists():
+    """Check if the LTX-2.3 checkpoint is available locally."""
+    if not CHECKPOINT_PATH_BF16 or not os.path.exists(CHECKPOINT_PATH_BF16):
+        pytest.skip(
+            f"LTX-2.3 checkpoint not found at {CHECKPOINT_PATH_BF16}. "
+            "Set LTX23_MODEL_PATH or stage the checkpoint under LLM_MODELS_ROOT/LTX-2.3/."
+        )
+    return True
+
+
+# ============================================================================
+# Quantization Tests
+# ============================================================================
+
+
+class TestLTX23Quantization:
+    """Test LTX-2.3 quantization loading and FP8 weight verification."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("quant_algo", ["FP8", "FP8_BLOCK_SCALES"])
+    def test_load_with_quantization(self, ltx23_bf16_checkpoint_exists, quant_algo: str):
+        """Test loading LTX-2.3 with FP8 quantization and verify FP8 weights."""
+        args = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            quant_config={"quant_algo": quant_algo, "dynamic": True},
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+
+        pipeline = PipelineLoader(args).load(skip_warmup=True, skip_components=SKIP_COMPONENTS)
+
+        assert pipeline.pipeline_config.quant_config.quant_algo is not None
+
+        quant_count = 0
+        found_fp8 = False
+        for name, module in pipeline.transformer.named_modules():
+            if isinstance(module, Linear):
+                if module.quant_config and module.quant_config.quant_algo:
+                    quant_count += 1
+                    if "blocks" in name and hasattr(module, "weight") and module.weight is not None:
+                        if not found_fp8:
+                            assert module.weight.dtype == torch.float8_e4m3fn, (
+                                f"Linear {name} should have FP8 weight, got {module.weight.dtype}"
+                            )
+                            assert hasattr(module, "weight_scale"), (
+                                f"Linear {name} missing weight_scale"
+                            )
+                            found_fp8 = True
+                            print(
+                                f"\n[{quant_algo}] FP8 layer {name}: weight {module.weight.shape}"
+                            )
+
+        print(f"[{quant_algo}] Quantized {quant_count} Linear layers")
+        assert quant_count > 0, "No layers were quantized"
+        assert found_fp8, f"No FP8 Linear modules found in blocks for {quant_algo}"
+
+        del pipeline
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+# ============================================================================
+# FP8 Numerical Correctness Tests
+# ============================================================================
+
+
+class TestLTX23FP8NumericalCorrectness:
+    """Test FP8 vs BF16 numerical accuracy at single-layer level."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("quant_algo", ["FP8", "FP8_BLOCK_SCALES"])
+    def test_fp8_vs_bf16_single_layer(self, ltx23_bf16_checkpoint_exists, quant_algo: str):
+        """Test FP8 vs BF16 numerical accuracy on a single Linear layer.
+
+        1. Use F.linear() with BF16 weights as ground truth reference
+        2. Verify BF16 layer matches F.linear exactly
+        3. Compare FP8 layer output against reference
+        """
+        print(f"\n[Compare {quant_algo}] Loading BF16 pipeline...")
+        args_bf16 = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_bf16 = PipelineLoader(args_bf16).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+
+        print(f"[Compare {quant_algo}] Loading {quant_algo} pipeline...")
+        args_fp8 = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            quant_config={"quant_algo": quant_algo, "dynamic": True},
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_fp8 = PipelineLoader(args_fp8).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+
+        linear_bf16, layer_name = _find_first_quantizable_linear(pipeline_bf16.transformer)
+        linear_fp8, _ = _find_first_quantizable_linear(pipeline_fp8.transformer)
+
+        assert linear_bf16 is not None, "Could not find a Linear layer in BF16 transformer"
+        assert linear_fp8 is not None, "Could not find a Linear layer in FP8 transformer"
+
+        weight_bf16 = linear_bf16.weight.data.clone()
+        bias_bf16 = linear_bf16.bias.data.clone() if linear_bf16.bias is not None else None
+
+        torch.manual_seed(42)
+        hidden_size = linear_bf16.in_features
+        batch_seq_len = 1024
+        input_tensor = torch.randn(batch_seq_len, hidden_size, dtype=torch.bfloat16, device="cuda")
+        print(f"[Compare] Layer: {layer_name}, Input shape: {input_tensor.shape}")
+
+        with torch.no_grad():
+            expected = F.linear(input_tensor, weight_bf16, bias_bf16)
+            result_bf16 = linear_bf16(input_tensor)
+            result_fp8 = linear_fp8(input_tensor)
+
+        assert torch.allclose(result_bf16, expected, rtol=1e-5, atol=1e-6), (
+            "BF16 layer should match F.linear reference exactly"
+        )
+
+        max_diff = torch.max(torch.abs(result_fp8 - expected)).item()
+        cos_sim = F.cosine_similarity(
+            result_fp8.flatten().float(), expected.flatten().float(), dim=0
+        )
+        mse = F.mse_loss(result_fp8.flatten().float(), expected.flatten().float())
+
+        print(
+            f"\n[{layer_name}] max_diff={max_diff:.6f}, cos_sim={cos_sim.item():.6f}, mse={mse.item():.6f}"
+        )
+
+        assert cos_sim > 0.99, f"Cosine similarity too low: {cos_sim.item()}"
+        assert mse < 1.0, f"MSE too high: {mse.item()}"
+
+        del pipeline_bf16, pipeline_fp8
+        torch.cuda.empty_cache()
+
+
+# ============================================================================
+# FP8 Memory Comparison Tests
+# ============================================================================
+
+
+class TestLTX23FP8Memory:
+    """Test FP8 memory reduction for LTX-2.3."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_vs_bf16_memory_comparison(self, ltx23_bf16_checkpoint_exists):
+        """Test FP8 uses ~2x less memory than BF16."""
+
+        def get_module_memory_gb(module):
+            return sum(p.numel() * p.element_size() for p in module.parameters()) / 1024**3
+
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+
+        args_bf16 = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_bf16 = PipelineLoader(args_bf16).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+
+        bf16_model_mem = get_module_memory_gb(pipeline_bf16.transformer)
+        print(f"\n[BF16] Transformer memory: {bf16_model_mem:.2f} GB")
+
+        del pipeline_bf16
+        torch.cuda.empty_cache()
+
+        torch.cuda.reset_peak_memory_stats()
+
+        args_fp8 = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            quant_config={"quant_algo": "FP8", "dynamic": True},
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_fp8 = PipelineLoader(args_fp8).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+
+        fp8_model_mem = get_module_memory_gb(pipeline_fp8.transformer)
+        print(f"[FP8] Transformer memory: {fp8_model_mem:.2f} GB")
+
+        model_mem_ratio = bf16_model_mem / fp8_model_mem
+        print(f"\n[Comparison] Model memory ratio (BF16/FP8): {model_mem_ratio:.2f}x")
+
+        assert model_mem_ratio > 1.8, f"FP8 should use ~2x less memory, got {model_mem_ratio:.2f}x"
+
+        del pipeline_fp8
+        torch.cuda.empty_cache()
+
+
+# ============================================================================
+# Attention Backend Comparison Tests
+# ============================================================================
+
+
+class TestLTX23AttentionBackend:
+    """Test VANILLA vs TRTLLM attention backend numerical correctness."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_attention_backend_comparison(self, ltx23_bf16_checkpoint_exists):
+        """Test that VANILLA and TRTLLM backends produce similar outputs.
+
+        Load each backend sequentially (two full LTX-2.3 transformers don't fit
+        in GPU memory simultaneously). Compares both the video and audio output
+        streams (LTX-2.3 is an AudioVideo model).
+        """
+        print("\n[Attention Backend Test] Loading baseline transformer (VANILLA)...")
+        args_baseline = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            attention_config=AttentionConfig(backend="VANILLA"),
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_baseline = PipelineLoader(args_baseline).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+        transformer_baseline = pipeline_baseline.transformer
+
+        video_input, audio_input, text_cache_baseline = _get_ltx23_transformer_inputs(
+            transformer_baseline
+        )
+
+        print("[Attention Backend Test] Running VANILLA transformer forward...")
+        with torch.no_grad():
+            output_baseline = transformer_baseline(
+                video=video_input, audio=audio_input, text_cache=text_cache_baseline
+            )
+        vout_baseline, aout_baseline = _extract_output(output_baseline)
+        vout_baseline_cpu = vout_baseline.cpu() if vout_baseline is not None else None
+        aout_baseline_cpu = aout_baseline.cpu() if aout_baseline is not None else None
+
+        del pipeline_baseline, transformer_baseline
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        print("[Attention Backend Test] Loading TRTLLM transformer...")
+        args_trtllm = VisualGenArgs(
+            model=CHECKPOINT_PATH_BF16,
+            attention_config=AttentionConfig(backend="TRTLLM"),
+            pipeline_config=_ltx23_pipeline_config(),
+        )
+        pipeline_trtllm = PipelineLoader(args_trtllm).load(
+            skip_warmup=True, skip_components=SKIP_COMPONENTS
+        )
+        transformer_trtllm = pipeline_trtllm.transformer
+
+        print("[Attention Backend Test] Running TRTLLM transformer forward...")
+        _, _, text_cache_trtllm = _get_ltx23_transformer_inputs(transformer_trtllm)
+        with torch.no_grad():
+            output_trtllm = transformer_trtllm(
+                video=video_input, audio=audio_input, text_cache=text_cache_trtllm
+            )
+        vout_trtllm, aout_trtllm = _extract_output(output_trtllm)
+        vout_trtllm_cpu = vout_trtllm.cpu() if vout_trtllm is not None else None
+        aout_trtllm_cpu = aout_trtllm.cpu() if aout_trtllm is not None else None
+
+        def _compare(name, baseline_cpu, trtllm_cpu):
+            if baseline_cpu is None or trtllm_cpu is None:
+                return
+            assert baseline_cpu.shape == trtllm_cpu.shape, (
+                f"{name} output shape mismatch: "
+                f"VANILLA={baseline_cpu.shape}, TRTLLM={trtllm_cpu.shape}"
+            )
+            for backend, out in [("VANILLA", baseline_cpu), ("TRTLLM", trtllm_cpu)]:
+                assert not torch.isnan(out).any(), f"{backend} {name} output contains NaN"
+                assert not torch.isinf(out).any(), f"{backend} {name} output contains Inf"
+
+            baseline_float = baseline_cpu.float()
+            trtllm_float = trtllm_cpu.float()
+            max_diff = torch.max(torch.abs(trtllm_float - baseline_float)).item()
+            cos_sim = F.cosine_similarity(
+                trtllm_float.flatten(), baseline_float.flatten(), dim=0
+            ).item()
+
+            print(f"\n{'=' * 60}")
+            print(f"TRTLLM vs VANILLA Comparison ({name} Output)")
+            print(f"{'=' * 60}")
+            print(f"Max absolute difference: {max_diff:.6f}")
+            print(f"Cosine similarity: {cos_sim:.6f}")
+            print(f"{'=' * 60}")
+
+            assert cos_sim > 0.99, (
+                f"TRTLLM should match VANILLA for {name}: cos_sim={cos_sim:.6f}"
+            )
+            print(f"\n[PASS] TRTLLM matches VANILLA ({name}): cos_sim={cos_sim:.6f} (>0.99)")
+
+        _compare("Video", vout_baseline_cpu, vout_trtllm_cpu)
+        _compare("Audio", aout_baseline_cpu, aout_trtllm_cpu)
+
+        del pipeline_trtllm, transformer_trtllm
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+# ============================================================================
+# Variant Resolution Unit Tests (no model loading required)
+# ============================================================================
+
+
+class TestLTX23VariantResolution:
+    """LTX-2.3 is single-stage in Phase-0: resolve_variant always returns itself."""
+
+    def test_resolve_variant_returns_single_stage(self):
+        """Even with two-stage-looking config keys, LTX-2.3 stays single-stage."""
+        from unittest.mock import MagicMock
+
+        from tensorrt_llm._torch.visual_gen.models.ltx23.pipeline_ltx23 import LTX23Pipeline
+
+        config = MagicMock()
+        config.primary_pretrained_config._name_or_path = ""
+        config.extra_attrs = {
+            "spatial_upsampler_path": "/fake/upsampler.safetensors",
+            "distilled_lora_path": "/fake/lora.safetensors",
+        }
+
+        assert LTX23Pipeline.resolve_variant(config) is LTX23Pipeline
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittest/_torch/visual_gen/test_ltx23_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx23_transformer.py
@@ -1,0 +1,1035 @@
+"""Unit tests for LTX-2.3 ("V2") components.
+
+Bottom-up, one component per test class, mirroring ``test_ltx2_transformer.py``.
+These are the sigma-independent, structural pieces that can be checked with
+random weights and no checkpoint / no CUDA:
+
+- ``TestLTX23FeatureExtractor``  -> split per-modality projectors
+- ``TestLTX23TextPack``          -> per-token RMS pack that feeds them
+- ``TestLTX23VideoConnector`` / ``TestLTX23AudioConnector`` -> the two V2
+  gated 8-layer connectors (heads/dim/depth/registers/gating), plus
+  ``TestLTX23ConnectorConfigOverrides`` for config-key wiring
+
+Later components (transformer block, full LTX23Model forward) get their own
+CUDA-gated classes as they are validated.
+"""
+
+import unittest
+
+import pytest
+import torch
+
+
+# Reduced dims for a fast, checkpoint-free test.
+# Real model: caption_channels=3840, 49 Gemma hidden states -> 188160 in;
+# video_dim=4096, audio_dim=2048.
+_CAPTION_CHANNELS = 8
+_NUM_STATES = 3
+_VIDEO_DIM = 16
+_AUDIO_DIM = 8
+
+
+class TestLTX23FeatureExtractor(unittest.TestCase):
+    """Split Gemma feature extractor: video/audio projections done pre-connector.
+
+    LTX-2.3 replaces LTX-2's single shared ``aggregate_embed``
+    (Linear(3840*49 -> 3840, bias=False)) with two biased projections
+    (``video_aggregate_embed`` -> 4096, ``audio_aggregate_embed`` -> 2048).
+    """
+
+    def _make(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23GemmaFeaturesExtractor,
+        )
+
+        return LTX23GemmaFeaturesExtractor(
+            caption_channels=_CAPTION_CHANNELS,
+            video_dim=_VIDEO_DIM,
+            audio_dim=_AUDIO_DIM,
+            num_hidden_states=_NUM_STATES,
+        )
+
+    def test_structure(self):
+        """Two biased Linears with the split output dims and the flattened input dim."""
+        fe = self._make()
+        in_features = _CAPTION_CHANNELS * _NUM_STATES
+
+        self.assertTrue(hasattr(fe, "video_aggregate_embed"))
+        self.assertTrue(hasattr(fe, "audio_aggregate_embed"))
+
+        self.assertEqual(fe.video_aggregate_embed.in_features, in_features)
+        self.assertEqual(fe.video_aggregate_embed.out_features, _VIDEO_DIM)
+        self.assertEqual(fe.audio_aggregate_embed.in_features, in_features)
+        self.assertEqual(fe.audio_aggregate_embed.out_features, _AUDIO_DIM)
+
+        # LTX-2.3 projections are biased (LTX-2's shared projection was not).
+        self.assertIsNotNone(fe.video_aggregate_embed.bias)
+        self.assertIsNotNone(fe.audio_aggregate_embed.bias)
+
+    def test_forward_shapes(self):
+        """(B, S, C*num_states) -> (video [B,S,video_dim], audio [B,S,audio_dim])."""
+        fe = self._make().eval()
+        batch, seq = 2, 5
+        x = torch.randn(batch, seq, _CAPTION_CHANNELS * _NUM_STATES)
+
+        with torch.no_grad():
+            video, audio = fe(x)
+
+        self.assertEqual(video.shape, (batch, seq, _VIDEO_DIM))
+        self.assertEqual(audio.shape, (batch, seq, _AUDIO_DIM))
+
+    def test_projections_are_independent(self):
+        """Video and audio share the input but are produced by distinct weights."""
+        fe = self._make().eval()
+        x = torch.randn(1, 4, _CAPTION_CHANNELS * _NUM_STATES)
+        with torch.no_grad():
+            video, audio = fe(x)
+        # Distinct out dims already imply distinct projections; also verify the
+        # weight tensors themselves are not aliased.
+        self.assertIsNot(
+            fe.video_aggregate_embed.weight,
+            fe.audio_aggregate_embed.weight,
+        )
+        self.assertFalse(torch.equal(video[..., :_AUDIO_DIM], audio))
+
+    def test_from_config_uses_49_gemma_states(self):
+        """from_config wires the real 49-state input dim and cross-attention dims."""
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23GemmaFeaturesExtractor,
+        )
+
+        config = {
+            "transformer": {
+                "caption_channels": 3840,
+                "cross_attention_dim": 4096,
+                "audio_cross_attention_dim": 2048,
+            }
+        }
+        fe = LTX23GemmaFeaturesExtractor.from_config(config)
+        self.assertEqual(fe.video_aggregate_embed.in_features, 3840 * 49)
+        self.assertEqual(fe.video_aggregate_embed.out_features, 4096)
+        self.assertEqual(fe.audio_aggregate_embed.out_features, 2048)
+
+
+class TestLTX23TextPack(unittest.TestCase):
+    """Per-token RMS pack of the stacked Gemma hidden states.
+
+    LTX-2.3 uses ``text_encoder_norm_type=per_token_rms`` (vs LTX-2's masked
+    min-max) with the norm applied here, before the split projection. The pack
+    stacks all hidden states, RMS-normalizes per (token, layer), then flattens
+    to feed the feature extractor's ``[out, C*num_states]`` weights.
+    """
+
+    def _pack(self, hidden_states, eps=1e-6):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.pipeline_ltx23 import LTX23Pipeline
+
+        return LTX23Pipeline._per_token_rms_pack(hidden_states, eps=eps)
+
+    def test_output_shape(self):
+        """N hidden states of [B,S,C] -> [B, S, C*N]."""
+        batch, seq, channels, n = 2, 4, 8, 3
+        hidden = [torch.randn(batch, seq, channels) for _ in range(n)]
+        packed = self._pack(hidden)
+        self.assertEqual(packed.shape, (batch, seq, channels * n))
+
+    def test_per_token_rms_normalized(self):
+        """Each (token, layer) hidden vector has ~unit RMS after packing."""
+        batch, seq, channels, n = 1, 3, 16, 4
+        # Deliberately large/varied magnitudes so normalization is observable.
+        hidden = [torch.randn(batch, seq, channels) * (10.0 * (i + 1)) for i in range(n)]
+
+        packed = self._pack(hidden)  # [B, S, C*N]
+        # Unflatten back to [B, S, C, N] to measure per-(token, layer) RMS.
+        unflat = packed.view(batch, seq, channels, n)
+        rms = unflat.float().pow(2).mean(dim=2).sqrt()  # [B, S, N]
+
+        self.assertTrue(torch.allclose(rms, torch.ones_like(rms), atol=1e-2))
+
+
+class _ConnectorMixin:
+    """Shared structural assertions for the V2 embeddings connectors.
+
+    LTX-2.3 uses two independent connectors, both **8-layer, gated, 128
+    learnable registers** (vs LTX-2's single 2-layer, ungated, shared one):
+
+    - video: 32 heads x 128 -> inner_dim 4096
+    - audio: 32 heads x  64 -> inner_dim 2048
+
+    We assert on the constructed ``Embeddings1DConnector`` module (built with
+    random weights, CPU-only, no forward): head count, inner dim, depth,
+    register bank shape, and that gating is actually wired (each block's
+    attention gains a ``to_gate_logits`` head, which is ``None`` when ungated).
+    """
+
+    #: subclasses set these
+    _EXPECTED_HEADS = 32
+    _EXPECTED_HEAD_DIM = 128
+    _EXPECTED_LAYERS = 8
+    _EXPECTED_REGISTERS = 128
+
+    def _build(self):  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def test_head_count_and_inner_dim(self):
+        conn = self._build()
+        inner_dim = self._EXPECTED_HEADS * self._EXPECTED_HEAD_DIM
+        self.assertEqual(conn.num_attention_heads, self._EXPECTED_HEADS)
+        self.assertEqual(conn.inner_dim, inner_dim)
+
+    def test_depth(self):
+        conn = self._build()
+        self.assertEqual(len(conn.transformer_1d_blocks), self._EXPECTED_LAYERS)
+
+    def test_learnable_registers(self):
+        conn = self._build()
+        inner_dim = self._EXPECTED_HEADS * self._EXPECTED_HEAD_DIM
+        self.assertEqual(conn.num_learnable_registers, self._EXPECTED_REGISTERS)
+        self.assertEqual(
+            tuple(conn.learnable_registers.shape),
+            (self._EXPECTED_REGISTERS, inner_dim),
+        )
+
+    def test_gated_attention_is_wired(self):
+        """Every block's attention has a per-head gate (``to_gate_logits``)."""
+        conn = self._build()
+        for block in conn.transformer_1d_blocks:
+            gate = block.attn1.to_gate_logits
+            self.assertIsNotNone(gate, "connector attention must be gated in LTX-2.3")
+            self.assertEqual(gate.out_features, self._EXPECTED_HEADS)
+
+
+class TestLTX23VideoConnector(_ConnectorMixin, unittest.TestCase):
+    """Video connector: 32 x 128 = 4096, 8 layers, gated, 128 registers."""
+
+    _EXPECTED_HEADS = 32
+    _EXPECTED_HEAD_DIM = 128
+
+    def _build(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23VideoConnectorConfigurator,
+        )
+
+        # Empty config -> exercises the V2 defaults baked into the configurator.
+        return LTX23VideoConnectorConfigurator.from_config({})
+
+
+class TestLTX23AudioConnector(_ConnectorMixin, unittest.TestCase):
+    """Audio connector: 32 x 64 = 2048, 8 layers, gated, 128 registers."""
+
+    _EXPECTED_HEADS = 32
+    _EXPECTED_HEAD_DIM = 64
+
+    def _build(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23AudioConnectorConfigurator,
+        )
+
+        return LTX23AudioConnectorConfigurator.from_config({})
+
+
+class TestLTX23ConnectorConfigOverrides(unittest.TestCase):
+    """The configurators honor checkpoint config keys (not just the defaults)."""
+
+    def _video(self, config):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23VideoConnectorConfigurator,
+        )
+
+        return LTX23VideoConnectorConfigurator.from_config(config)
+
+    def test_reads_transformer_subdict(self):
+        """Keys are read from the ``transformer`` sub-dict when present."""
+        conn = self._video(
+            {
+                "transformer": {
+                    "connector_num_attention_heads": 16,
+                    "connector_attention_head_dim": 64,
+                    "connector_num_layers": 3,
+                    "connector_num_learnable_registers": 64,
+                }
+            }
+        )
+        self.assertEqual(conn.num_attention_heads, 16)
+        self.assertEqual(conn.inner_dim, 16 * 64)
+        self.assertEqual(len(conn.transformer_1d_blocks), 3)
+        self.assertEqual(conn.num_learnable_registers, 64)
+
+    def test_gating_can_be_disabled_via_config(self):
+        conn = self._video({"transformer": {"connector_apply_gated_attention": False}})
+        for block in conn.transformer_1d_blocks:
+            self.assertIsNone(block.attn1.to_gate_logits)
+
+
+class TestLTX23AdaLNSlots(unittest.TestCase):
+    """9-slot per-block AdaLN split: MSA [0:3], MLP [3:6], text-cross-attn [6:9].
+
+    This is *the* defining LTX-2.3 transformer change: the per-block scale/shift
+    table grows from LTX-2's 6 slots to 9 (the extra 3 drive the text
+    cross-attention query shift/scale/gate). ``_get_ada_values`` is the pure
+    tensor helper that slices those slots out of the ``[9, D]`` table plus the
+    embedded timestep. We verify slot counts, shapes, and exact values without a
+    GPU / checkpoint / attention forward.
+    """
+
+    def _get(self, table, bsz, timestep, indices):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.transformer_ltx23 import (
+            _get_ada_values,
+        )
+
+        return _get_ada_values(table, bsz, timestep, indices)
+
+    def test_each_group_yields_three_modulators(self):
+        """MSA / MLP / text-cross-attn each unpack to 3 tensors of [B, T, D]."""
+        batch, seq, dim, num_slots = 2, 5, 4, 9
+        table = torch.randn(num_slots, dim)
+        timestep = torch.randn(batch, seq, num_slots * dim)
+
+        for indices in (slice(0, 3), slice(3, 6), slice(6, 9)):
+            vals = self._get(table, batch, timestep, indices)
+            self.assertEqual(len(vals), 3)
+            for v in vals:
+                self.assertEqual(v.shape, (batch, seq, dim))
+
+    def test_text_cross_attn_slots_are_table_plus_timestep(self):
+        """Slots [6:9] = table row + matching timestep chunk (shift, scale, gate)."""
+        batch, seq, dim, num_slots = 1, 2, 3, 9
+        table = torch.randn(num_slots, dim)
+        timestep = torch.randn(batch, seq, num_slots * dim)
+        ts = timestep.reshape(batch, seq, num_slots, dim)
+
+        shift, scale, gate = self._get(table, batch, timestep, slice(6, 9))
+        self.assertTrue(torch.allclose(shift, table[6][None, None] + ts[:, :, 6, :]))
+        self.assertTrue(torch.allclose(scale, table[7][None, None] + ts[:, :, 7, :]))
+        self.assertTrue(torch.allclose(gate, table[8][None, None] + ts[:, :, 8, :]))
+
+
+class TestLTX23AVCrossAttnSlots(unittest.TestCase):
+    """5-slot audio<->video cross-attention table: 4 scale/shift + 1 gate.
+
+    Reused byte-for-byte from LTX-2. ``_get_av_ca_ada_values`` splits the
+    ``[5, D]`` table into (scale_a2v, shift_a2v, scale_v2a, shift_v2a, gate),
+    with the first 4 driven by the scale/shift timestep and the last by the gate
+    timestep.
+    """
+
+    def _get(self, table, bsz, ss_ts, gate_ts):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.transformer_ltx23 import (
+            _get_av_ca_ada_values,
+        )
+
+        return _get_av_ca_ada_values(table, bsz, ss_ts, gate_ts)
+
+    def test_five_outputs_correct_shapes(self):
+        batch, seq, dim = 2, 4, 6
+        table = torch.randn(5, dim)
+        ss_ts = torch.randn(batch, seq, 4 * dim)
+        gate_ts = torch.randn(batch, seq, 1 * dim)
+
+        vals = self._get(table, batch, ss_ts, gate_ts)
+        self.assertEqual(len(vals), 5)
+        for v in vals:
+            self.assertEqual(v.shape, (batch, seq, dim))
+
+    def test_gate_uses_gate_timestep_not_scale_shift(self):
+        """The 5th output tracks the gate row + gate timestep specifically."""
+        batch, seq, dim = 1, 2, 3
+        table = torch.randn(5, dim)
+        ss_ts = torch.randn(batch, seq, 4 * dim)
+        gate_ts = torch.randn(batch, seq, 1 * dim)
+
+        *_, gate = self._get(table, batch, ss_ts, gate_ts)
+        expected_gate = table[4][None, None] + gate_ts.reshape(batch, seq, 1, dim)[:, :, 0, :]
+        self.assertTrue(torch.allclose(gate, expected_gate))
+
+
+# ---------------------------------------------------------------------------
+# Transformer *model* structure (CUDA-gated).
+#
+# The AdaLN-helper tests above check the slot-slicing math in isolation. These
+# check that a fully-built ``LTX23Model`` is actually wired that way:
+#   * main AdaLN embedding_coefficient 6 -> 9 (adds text-cross-attn slots [6:9])
+#   * a NEW ``prompt_adaln_single`` (coeff 2) for sigma-driven text-context K/V
+#     modulation (absent entirely in LTX-2)
+#   * per-block ``scale_shift_table [9, dim]`` + ``prompt_scale_shift_table [2, dim]``
+#   * ``caption_projection`` bypassed to ``nn.Identity`` (projection now happens
+#     in the split feature extractor, before the connector)
+#   * audio<->video cross-attn tables ([5, dim]) unchanged from LTX-2
+#
+# Building the model instantiates the fused ``LTX2Attention`` modules, so (like
+# LTX-2's own transformer tests) these are CUDA-gated. Reduced dims mirror
+# ``test_ltx2_transformer.py`` for a fast build with random weights.
+# ---------------------------------------------------------------------------
+
+_V2_VIDEO_ONLY_CONFIG = dict(
+    num_attention_heads=4,
+    attention_head_dim=32,
+    in_channels=16,
+    out_channels=16,
+    num_layers=1,
+    cross_attention_dim=128,
+    caption_channels=64,
+    norm_eps=1e-6,
+    positional_embedding_max_pos=[4, 32, 32],
+    timestep_scale_multiplier=1000,
+    use_middle_indices_grid=True,
+)
+
+_V2_AUDIO_VIDEO_CONFIG = dict(
+    **_V2_VIDEO_ONLY_CONFIG,
+    audio_num_attention_heads=4,
+    audio_attention_head_dim=16,
+    audio_in_channels=16,
+    audio_out_channels=16,
+    audio_cross_attention_dim=64,
+    audio_positional_embedding_max_pos=[4],
+    av_ca_timestep_scale_multiplier=1,
+)
+
+
+def _v2_model_config(backend: str = "VANILLA"):
+    """Minimal DiffusionModelConfig, matching test_ltx2_transformer.py."""
+    from types import SimpleNamespace
+
+    from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+    from tensorrt_llm.mapping import Mapping
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+    from tensorrt_llm.visual_gen.args import AttentionConfig
+
+    return DiffusionModelConfig(
+        pretrained_config=SimpleNamespace(),
+        quant_config=QuantConfig(),
+        mapping=Mapping(),
+        attention=AttentionConfig(backend=backend),
+        skip_create_weights_in_init=False,
+    )
+
+
+def _build_ltx23_model(model_type_name: str, config: dict, device: str):
+    from tensorrt_llm._torch.visual_gen.models.ltx2.transformer_ltx2 import LTXModelType
+    from tensorrt_llm._torch.visual_gen.models.ltx23.transformer_ltx23 import LTX23Model
+
+    return LTX23Model(
+        model_type=getattr(LTXModelType, model_type_name),
+        model_config=_v2_model_config(),
+        **config,
+    ).to(device)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestLTX23VideoOnlyModelStructure(unittest.TestCase):
+    """VideoOnly LTX-2.3 transformer: 9-slot AdaLN + prompt AdaLN + Identity caption proj."""
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def _build(self):
+        return _build_ltx23_model("VideoOnly", _V2_VIDEO_ONLY_CONFIG, self.DEVICE)
+
+    def test_main_adaln_has_9_slots(self):
+        """adaln_single emits 9*dim (vs LTX-2's 6*dim): MSA + MLP + text-cross-attn."""
+        import torch.nn as nn
+
+        model = self._build()
+        d = model.inner_dim
+        self.assertEqual(model.adaln_single.linear.out_features, 9 * d)
+        # caption projection is bypassed in LTX-2.3 (done before the connector).
+        self.assertIsInstance(model.caption_projection, nn.Identity)
+
+    def test_prompt_adaln_single_exists(self):
+        """A second AdaLN (coeff 2) for sigma-driven text-context K/V; absent in LTX-2."""
+        model = self._build()
+        d = model.inner_dim
+        self.assertTrue(hasattr(model, "prompt_adaln_single"))
+        self.assertEqual(model.prompt_adaln_single.linear.out_features, 2 * d)
+
+    def test_block_scale_shift_tables(self):
+        """Per-block main table is [9, dim] and prompt table is [2, dim]."""
+        model = self._build()
+        d = model.inner_dim
+        block = model.transformer_blocks[0]
+        self.assertEqual(tuple(block.scale_shift_table.shape), (9, d))
+        self.assertEqual(tuple(block.prompt_scale_shift_table.shape), (2, d))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestLTX23AudioVideoModelStructure(unittest.TestCase):
+    """AudioVideo LTX-2.3 transformer: audio mirrors video; AV cross-attn unchanged."""
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def _build(self):
+        return _build_ltx23_model("AudioVideo", _V2_AUDIO_VIDEO_CONFIG, self.DEVICE)
+
+    def test_audio_adaln_has_9_slots_and_prompt(self):
+        model = self._build()
+        da = model.audio_inner_dim
+        self.assertEqual(model.audio_adaln_single.linear.out_features, 9 * da)
+        self.assertTrue(hasattr(model, "audio_prompt_adaln_single"))
+        self.assertEqual(model.audio_prompt_adaln_single.linear.out_features, 2 * da)
+
+    def test_audio_block_scale_shift_tables(self):
+        model = self._build()
+        da = model.audio_inner_dim
+        block = model.transformer_blocks[0]
+        self.assertEqual(tuple(block.audio_scale_shift_table.shape), (9, da))
+        self.assertEqual(tuple(block.audio_prompt_scale_shift_table.shape), (2, da))
+
+    def test_av_cross_attention_tables_unchanged(self):
+        """Audio<->video cross-attn tables stay [5, dim] (byte-for-byte reuse of LTX-2)."""
+        model = self._build()
+        block = model.transformer_blocks[0]
+        self.assertEqual(
+            tuple(block.scale_shift_table_a2v_ca_video.shape), (5, model.inner_dim)
+        )
+        self.assertEqual(
+            tuple(block.scale_shift_table_a2v_ca_audio.shape), (5, model.audio_inner_dim)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Transformer forward behavior (CUDA-gated).
+#
+# The structural classes above only inspect the *built* module. These run a
+# real forward on a tiny, random-weight LTX23Model, mirroring LTX-2's
+# ``test_*_forward_sanity`` / ``test_video_only_input_to_audio_video_model`` /
+# ``TestLTX2TextCache`` — but with the LTX-2.3-specific ``sigma`` field and the
+# *inverted* text-cache contract (2.3 K/V is step-varying, so the cache must NOT
+# carry a static per-block K/V). This is the first coverage of the whole
+# ``LTX23Model.forward`` path (prompt_adaln_single -> _compute_prompt_timestep ->
+# 9-slot AdaLN block forward -> prompt-modulated text K/V -> (vx, ax)).
+#
+# Context is ``cross_attention_dim``-wide (not ``caption_channels``) because
+# LTX-2.3's ``caption_projection`` is Identity (projection happens in the split
+# feature extractor before the connector).
+# ---------------------------------------------------------------------------
+
+
+def _init_all_weights(model: torch.nn.Module, std: float = 0.02) -> None:
+    """Fill random weights (TRT-LLM Linear uses torch.empty(); avoids NaN).
+
+    Mirrors ``test_ltx2_transformer._init_all_weights``: norm weights -> 1.0,
+    everything else -> small normal noise.
+    """
+    with torch.no_grad():
+        for name, p in model.named_parameters():
+            if "norm" in name and "weight" in name:
+                p.fill_(1.0)
+            elif p.numel() > 0:
+                torch.nn.init.normal_(p, mean=0.0, std=std)
+
+
+def _v2_video_positions(batch, n_frames, grid_h, grid_w, device):
+    n = n_frames * grid_h * grid_w
+    pos = torch.zeros(batch, 3, n, 2, device=device)
+    idx = 0
+    for f in range(n_frames):
+        for h in range(grid_h):
+            for w in range(grid_w):
+                pos[:, 0, idx, :] = torch.tensor([f, f + 1], dtype=torch.float32)
+                pos[:, 1, idx, :] = torch.tensor([h, h + 1], dtype=torch.float32)
+                pos[:, 2, idx, :] = torch.tensor([w, w + 1], dtype=torch.float32)
+                idx += 1
+    return pos
+
+
+def _v2_audio_positions(batch, a_patches, device):
+    pos = torch.zeros(batch, 1, a_patches, 2, device=device)
+    for i in range(a_patches):
+        pos[:, 0, i, :] = torch.tensor([i, i + 1], dtype=torch.float32)
+    return pos
+
+
+def _build_and_init(model_type_name, config, device, dtype=torch.bfloat16):
+    model = _build_ltx23_model(model_type_name, config, device).to(dtype).eval()
+    _init_all_weights(model)
+    return model
+
+
+def _v2_video_modality(cfg, device, dtype, *, sigma=0.5, n_frames=1, grid_h=4, grid_w=4, text_len=8):
+    """(LTX23Modality, context, positions) for the video stream at reduced dims."""
+    from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.modality import LTX23Modality
+
+    n = n_frames * grid_h * grid_w
+    ctx = torch.randn(1, text_len, cfg["cross_attention_dim"], device=device, dtype=dtype) * 0.02
+    pos = _v2_video_positions(1, n_frames, grid_h, grid_w, device)
+    mod = LTX23Modality(
+        latent=torch.randn(1, n, cfg["in_channels"], device=device, dtype=dtype) * 0.02,
+        timesteps=torch.tensor([0.5], device=device),
+        sigma=torch.tensor([sigma], device=device),
+        positions=pos,
+        context=ctx,
+    )
+    return mod, ctx, pos
+
+
+def _v2_audio_modality(cfg, device, dtype, *, sigma=0.5, a_patches=8, text_len=8):
+    """(LTX23Modality, context, positions) for the audio stream at reduced dims."""
+    from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.modality import LTX23Modality
+
+    ctx = torch.randn(
+        1, text_len, cfg["audio_cross_attention_dim"], device=device, dtype=dtype
+    ) * 0.02
+    pos = _v2_audio_positions(1, a_patches, device)
+    mod = LTX23Modality(
+        latent=torch.randn(1, a_patches, cfg["audio_in_channels"], device=device, dtype=dtype)
+        * 0.02,
+        timesteps=torch.tensor([0.5], device=device),
+        sigma=torch.tensor([sigma], device=device),
+        positions=pos,
+        context=ctx,
+    )
+    return mod, ctx, pos
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestLTX23VideoOnlyForward(unittest.TestCase):
+    """VideoOnly forward: (vx, None) with the expected shape and finite values."""
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def test_forward_sanity(self):
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        cfg = _V2_VIDEO_ONLY_CONFIG
+        model = _build_and_init("VideoOnly", cfg, self.DEVICE, dtype)
+
+        video, v_ctx, v_pos = _v2_video_modality(cfg, self.DEVICE, dtype)
+        text_cache = model.prepare_text_cache(
+            video_context=v_ctx, video_positions=v_pos, dtype=dtype
+        )
+
+        with torch.no_grad():
+            vout, aout = model(video=video, audio=None, text_cache=text_cache)
+
+        self.assertIsNotNone(vout)
+        self.assertIsNone(aout)
+        self.assertEqual(vout.shape, (1, video.latent.shape[1], cfg["out_channels"]))
+        self.assertTrue(torch.isfinite(vout).all())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestLTX23AudioVideoForward(unittest.TestCase):
+    """AudioVideo forward: both streams emit finite outputs of the right shape."""
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def test_forward_sanity(self):
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        cfg = _V2_AUDIO_VIDEO_CONFIG
+        model = _build_and_init("AudioVideo", cfg, self.DEVICE, dtype)
+
+        video, v_ctx, v_pos = _v2_video_modality(cfg, self.DEVICE, dtype)
+        audio, a_ctx, a_pos = _v2_audio_modality(cfg, self.DEVICE, dtype)
+        text_cache = model.prepare_text_cache(
+            video_context=v_ctx,
+            video_positions=v_pos,
+            audio_context=a_ctx,
+            audio_positions=a_pos,
+            dtype=dtype,
+        )
+
+        with torch.no_grad():
+            vout, aout = model(video=video, audio=audio, text_cache=text_cache)
+
+        self.assertIsNotNone(vout)
+        self.assertIsNotNone(aout)
+        self.assertEqual(vout.shape, (1, video.latent.shape[1], cfg["out_channels"]))
+        self.assertEqual(aout.shape, (1, audio.latent.shape[1], cfg["audio_out_channels"]))
+        self.assertTrue(torch.isfinite(vout).all())
+        self.assertTrue(torch.isfinite(aout).all())
+
+    def test_video_only_input_to_audio_video_model(self):
+        """AudioVideo model with ``audio=None`` returns (vx, None) cleanly.
+
+        The pipeline always builds an AudioVideo transformer, and the block
+        forward has live ``if audio is not None`` branches, so this exercises
+        the video-only input path through the dual-stream model.
+        """
+        torch.manual_seed(0)
+        dtype = torch.bfloat16
+        cfg = _V2_AUDIO_VIDEO_CONFIG
+        model = _build_and_init("AudioVideo", cfg, self.DEVICE, dtype)
+
+        video, v_ctx, v_pos = _v2_video_modality(cfg, self.DEVICE, dtype)
+        text_cache = model.prepare_text_cache(
+            video_context=v_ctx, video_positions=v_pos, dtype=dtype
+        )
+
+        with torch.no_grad():
+            vout, aout = model(video=video, audio=None, text_cache=text_cache)
+
+        self.assertIsNotNone(vout)
+        self.assertIsNone(aout)
+        self.assertEqual(vout.shape, (1, video.latent.shape[1], cfg["out_channels"]))
+        self.assertTrue(torch.isfinite(vout).all())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestLTX23SigmaTextConditioning(unittest.TestCase):
+    """The defining LTX-2.3 change: sigma-driven, step-varying text K/V.
+
+    LTX-2 caches a *static* per-block text K/V (its ``TestLTX2TextCache`` asserts
+    reusing the cache is correct). LTX-2.3 inverts this: text K/V is modulated by
+    a sigma-derived ``prompt_timestep`` and is re-projected every step, so
+    ``prepare_text_cache`` must NOT carry a static K/V, and changing only
+    ``sigma`` (holding ``timesteps`` fixed) must change the output.
+    """
+
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def test_text_cache_has_no_static_kv(self):
+        """Guards against reintroducing LTX-2-style static per-block text K/V."""
+        dtype = torch.bfloat16
+        cfg = _V2_AUDIO_VIDEO_CONFIG
+        model = _build_and_init("AudioVideo", cfg, self.DEVICE, dtype)
+
+        _, v_ctx, v_pos = _v2_video_modality(cfg, self.DEVICE, dtype)
+        _, a_ctx, a_pos = _v2_audio_modality(cfg, self.DEVICE, dtype)
+        text_cache = model.prepare_text_cache(
+            video_context=v_ctx,
+            video_positions=v_pos,
+            audio_context=a_ctx,
+            audio_positions=a_pos,
+            dtype=dtype,
+        )
+
+        for attr in ("video_kv", "audio_kv", "kv", "video_context_kv", "audio_context_kv"):
+            self.assertFalse(
+                hasattr(text_cache, attr),
+                f"LTX-2.3 text cache must not carry static K/V ({attr})",
+            )
+
+    def test_sigma_changes_output(self):
+        """Same inputs, different global sigma -> different output.
+
+        Isolates the prompt path: ``timesteps`` are held at 0.5 while ``sigma``
+        varies (0.1 vs 0.9). Any output change must come from
+        ``prompt_adaln_single`` modulating the text-context K/V.
+        """
+        torch.manual_seed(7)
+        dtype = torch.bfloat16
+        cfg = _V2_AUDIO_VIDEO_CONFIG
+        model = _build_and_init("AudioVideo", cfg, self.DEVICE, dtype)
+
+        # Build one input set, then clone it with only sigma changed.
+        video_lo, v_ctx, v_pos = _v2_video_modality(cfg, self.DEVICE, dtype, sigma=0.1)
+        audio_lo, a_ctx, a_pos = _v2_audio_modality(cfg, self.DEVICE, dtype, sigma=0.1)
+        text_cache = model.prepare_text_cache(
+            video_context=v_ctx,
+            video_positions=v_pos,
+            audio_context=a_ctx,
+            audio_positions=a_pos,
+            dtype=dtype,
+        )
+
+        from dataclasses import replace
+
+        video_hi = replace(video_lo, sigma=torch.tensor([0.9], device=self.DEVICE))
+        audio_hi = replace(audio_lo, sigma=torch.tensor([0.9], device=self.DEVICE))
+
+        with torch.no_grad():
+            vout_lo, aout_lo = model(video=video_lo, audio=audio_lo, text_cache=text_cache)
+            vout_hi, aout_hi = model(video=video_hi, audio=audio_hi, text_cache=text_cache)
+
+        v_diff = (vout_lo.float() - vout_hi.float()).abs().max().item()
+        a_diff = (aout_lo.float() - aout_hi.float()).abs().max().item()
+        self.assertGreater(v_diff, 1e-4, "video output should depend on sigma (prompt K/V path)")
+        self.assertGreater(a_diff, 1e-4, "audio output should depend on sigma (prompt K/V path)")
+
+
+# ---------------------------------------------------------------------------
+# Video VAE decoder channel recipe (CPU, structural).
+#
+# LTX-2.3's decoder differs from LTX-2 in that compress_time / compress_space
+# ALSO reduce channels by their `multiplier` (LTX-2 only did so for
+# compress_all). That makes conv_in = latent_channels * product(all compress
+# multipliers) instead of just the compress_all ones. Building with LTX-2's
+# recipe gave conv_in = 128*2 = 256; the checkpoint needs 128*8 = 1024.
+#
+# We validate with a reduced latent width (16) and the real block recipe, so the
+# per-block conv widths are cheap to allocate but exercise the exact logic.
+# ---------------------------------------------------------------------------
+
+# The real LTX-2.3 checkpoint decoder recipe (stored order).
+_LTX23_DECODER_BLOCKS = [
+    ["res_x", {"num_layers": 4}],
+    ["compress_space", {"multiplier": 2}],
+    ["res_x", {"num_layers": 6}],
+    ["compress_time", {"multiplier": 2}],
+    ["res_x", {"num_layers": 4}],
+    ["compress_all", {"multiplier": 1}],
+    ["res_x", {"num_layers": 2}],
+    ["compress_all", {"multiplier": 2}],
+    ["res_x", {"num_layers": 2}],
+]
+
+
+class TestLTX23VideoDecoderChannels(unittest.TestCase):
+    """conv_in width + compress-block conv widths match the LTX-2.3 checkpoint.
+
+    Uses latent_channels=16 (real is 128); every channel is 1/8 of the real
+    checkpoint, so the *ratios* and block behavior are identical while staying
+    cheap to allocate on CPU.
+    """
+
+    _LATENT = 16
+    _PATCH = 4
+    _OUT = 3
+
+    def _build(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.video_vae_ltx23 import (
+            LTX23VideoDecoderConfigurator,
+        )
+
+        config = {
+            "vae": {
+                "dims": 3,
+                "latent_channels": self._LATENT,
+                "out_channels": self._OUT,
+                "patch_size": self._PATCH,
+                "norm_layer": "pixel_norm",
+                "causal_decoder": False,
+                "timestep_conditioning": False,
+                "spatial_padding_mode": "reflect",
+                "decoder_blocks": _LTX23_DECODER_BLOCKS,
+            }
+        }
+        return LTX23VideoDecoderConfigurator.from_config(config)
+
+    def test_conv_in_uses_all_compress_multipliers(self):
+        """conv_in: latent -> latent * (2*1*2*2) = latent * 8."""
+        dec = self._build()
+        w = dec.conv_in.conv.weight
+        self.assertEqual(w.shape[1], self._LATENT)  # in
+        self.assertEqual(w.shape[0], self._LATENT * 8)  # out (16 -> 128)
+
+    def test_compress_time_and_space_reduce_channels(self):
+        """compress_time (up5) and compress_space (up7) halve channels.
+
+        This is the exact LTX-2 vs LTX-2.3 difference: in LTX-2 these conv
+        widths would be 2x/4x larger (channels unchanged), mismatching the
+        checkpoint. Conv output = in * prod(stride) // multiplier.
+        """
+        dec = self._build()
+        # Flow at latent=16: conv_in 128; up1 compress_all/2 -> 64;
+        # up5 compress_time in=64 -> conv out = 64*2//2 = 64;
+        # up7 compress_space in=32 -> conv out = 32*4//2 = 64.
+        self.assertEqual(dec.up_blocks[5].conv.conv.weight.shape[0], 64)  # compress_time
+        self.assertEqual(dec.up_blocks[7].conv.conv.weight.shape[0], 64)  # compress_space
+
+    def test_compress_all_conv_width(self):
+        """compress_all (up1, multiplier 2): conv out = in * 8 // 2 = 512 at latent=16."""
+        dec = self._build()
+        self.assertEqual(dec.up_blocks[1].conv.conv.weight.shape[0], self._LATENT * 32)  # 512
+
+    def test_conv_out_channels(self):
+        """Final conv emits out_channels * patch_size**2 (unpatchified later)."""
+        dec = self._build()
+        self.assertEqual(dec.conv_out.conv.weight.shape[0], self._OUT * self._PATCH**2)  # 48
+
+    def test_res_blocks_preserve_channels(self):
+        """res_x blocks (UNetMidBlock3D) keep channels; up0 stays at conv_in width."""
+        dec = self._build()
+        rb = dec.up_blocks[0].res_blocks[0]
+        self.assertEqual(rb.conv1.conv.weight.shape[0], self._LATENT * 8)
+        self.assertEqual(rb.conv1.conv.weight.shape[1], self._LATENT * 8)
+
+
+class TestLTX23FeatureExtractorRescale(unittest.TestCase):
+    """The split extractor applies ltx-core's modality-specific ``_rescale_norm``.
+
+    LTX-2.3 scales the per-token-RMS'd features by ``sqrt(out_dim / embedding_dim)``
+    *before* each projection (embedding_dim = caption_channels). Video (~1.03x) is
+    nearly a no-op, but audio (~0.73x at the real dims) is a 27% factor, so a
+    plain ``Linear(x)`` (no rescale) is numerically wrong for audio. This is the
+    exact regression a reviewer caught; assert the factor is actually applied.
+    """
+
+    def test_rescale_matches_manual_and_differs_from_unscaled(self):
+        import math
+
+        import torch.nn.functional as F
+
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23GemmaFeaturesExtractor,
+        )
+
+        # Dims chosen so both scales are non-trivial and != 1:
+        #   v_scale = sqrt(32/8) = 2.0 ,  a_scale = sqrt(2/8) = 0.5
+        caption, n_states, vdim, adim = 8, 3, 32, 2
+        fe = LTX23GemmaFeaturesExtractor(
+            caption_channels=caption,
+            video_dim=vdim,
+            audio_dim=adim,
+            num_hidden_states=n_states,
+        ).eval()
+
+        x = torch.randn(2, 4, caption * n_states)
+        with torch.no_grad():
+            video, audio = fe(x)
+
+        v_scale = math.sqrt(vdim / caption)
+        a_scale = math.sqrt(adim / caption)
+        exp_v = F.linear(x * v_scale, fe.video_aggregate_embed.weight, fe.video_aggregate_embed.bias)
+        exp_a = F.linear(x * a_scale, fe.audio_aggregate_embed.weight, fe.audio_aggregate_embed.bias)
+        self.assertTrue(torch.allclose(video, exp_v, atol=1e-5))
+        self.assertTrue(torch.allclose(audio, exp_a, atol=1e-5))
+
+        # A no-rescale implementation would equal Linear(x); ensure we differ.
+        unscaled_v = F.linear(x, fe.video_aggregate_embed.weight, fe.video_aggregate_embed.bias)
+        unscaled_a = F.linear(x, fe.audio_aggregate_embed.weight, fe.audio_aggregate_embed.bias)
+        self.assertFalse(torch.allclose(video, unscaled_v, atol=1e-4))
+        self.assertFalse(torch.allclose(audio, unscaled_a, atol=1e-4))
+
+
+class TestLTX23ConnectorRopeDefault(unittest.TestCase):
+    """Both connectors default to SPLIT RoPE (ltx-core default), not INTERLEAVED.
+
+    The LTX-2.3 checkpoint sets ``rope_type=split`` explicitly, so this default
+    has no runtime effect today; it guards against a future/partial config
+    silently falling back to LTX-2's INTERLEAVED default.
+    """
+
+    def test_default_rope_type_is_split(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.rope import LTXRopeType
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23AudioConnectorConfigurator,
+            LTX23VideoConnectorConfigurator,
+        )
+
+        for configurator in (
+            LTX23VideoConnectorConfigurator,
+            LTX23AudioConnectorConfigurator,
+        ):
+            conn = configurator.from_config({})
+            self.assertEqual(conn.rope_type, LTXRopeType.SPLIT)
+
+    def test_explicit_config_overrides_default(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.rope import LTXRopeType
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.connector import (
+            LTX23VideoConnectorConfigurator,
+        )
+
+        conn = LTX23VideoConnectorConfigurator.from_config(
+            {"transformer": {"rope_type": "interleaved"}}
+        )
+        self.assertEqual(conn.rope_type, LTXRopeType.INTERLEAVED)
+
+
+class TestLTX23Vocoder(unittest.TestCase):
+    """BigVGAN-v2 (AMP1) generator + the VocoderWithBWE 48 kHz wiring.
+
+    LTX-2.3 replaces LTX-2's HiFi-GAN (24 kHz) with a BigVGAN AMP1 generator and
+    a bandwidth-extension wrapper to 48 kHz. We check (1) a small AMP1 generator
+    produces the expected upsampled stereo waveform and reports its sample rate,
+    and (2) the configurator assembles a ``VocoderWithBWE`` at 48 kHz from a
+    2.3-style nested config (structural; no heavy BWE forward).
+    """
+
+    def _small_vocoder(self, output_sampling_rate=16000):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.vocoder_ltx23 import (
+            Vocoder,
+        )
+
+        return Vocoder(
+            resblock_kernel_sizes=[3],
+            upsample_rates=[2, 2],
+            upsample_kernel_sizes=[4, 4],
+            resblock_dilation_sizes=[[1, 3, 5]],
+            upsample_initial_channel=32,
+            resblock="AMP1",
+            output_sampling_rate=output_sampling_rate,
+            activation="snakebeta",
+        )
+
+    def test_amp1_generator_forward_shape_and_rate(self):
+        voc = self._small_vocoder(output_sampling_rate=16000).eval()
+        # Stereo mel input: (B, C=2, time, mel_bins=64) -> conv_pre expects 2*64=128.
+        batch, time, mel_bins = 1, 8, 64
+        mel = torch.randn(batch, 2, time, mel_bins)
+        with torch.no_grad():
+            wav = voc(mel)
+        # Two stereo channels out; time upsampled by prod(upsample_rates)=4.
+        self.assertEqual(wav.shape, (batch, 2, time * 4))
+        self.assertEqual(voc.output_sampling_rate, 16000)
+
+    def test_bwe_configurator_builds_48khz(self):
+        from tensorrt_llm._torch.visual_gen.models.ltx23.ltx23_core.vocoder_ltx23 import (
+            LTX23VocoderConfigurator,
+            VocoderWithBWE,
+        )
+
+        gen_cfg = dict(
+            resblock="AMP1",
+            stereo=True,
+            activation="snakebeta",
+            upsample_rates=[2, 2],
+            upsample_kernel_sizes=[4, 4],
+            resblock_kernel_sizes=[3],
+            resblock_dilation_sizes=[[1, 3, 5]],
+            upsample_initial_channel=32,
+        )
+        config = {
+            "vocoder": {
+                "vocoder": dict(gen_cfg),
+                "bwe": dict(
+                    gen_cfg,
+                    input_sampling_rate=16000,
+                    output_sampling_rate=48000,
+                    n_fft=32,
+                    hop_length=8,
+                    num_mels=16,
+                ),
+            }
+        }
+        voc = LTX23VocoderConfigurator.from_config(config)
+        self.assertIsInstance(voc, VocoderWithBWE)
+        self.assertEqual(voc.output_sampling_rate, 48000)
+        # Inner BigVGAN generator runs at the 16 kHz base rate...
+        self.assertEqual(voc.vocoder.output_sampling_rate, 16000)
+        # ...and the BWE skip resampler bridges 16 kHz -> 48 kHz (ratio 3).
+        self.assertEqual(voc.resampler.ratio, 3)
+
+
+class TestLTX23PipelineDetection(unittest.TestCase):
+    """Registry dispatch: LTX-2.3 text-projection config -> ``LTX23Pipeline``.
+
+    ``_detect_native_ltx_pipeline`` is injected into ``pipeline_registry`` by
+    ``apply_patches.py``; skip if the package has not been patched (e.g. running
+    against a vanilla install outside the container).
+    """
+
+    def _detect(self):
+        pytest.importorskip("tensorrt_llm._torch.visual_gen.pipeline_registry")
+        from tensorrt_llm._torch.visual_gen import pipeline_registry
+
+        fn = getattr(pipeline_registry, "_detect_native_ltx_pipeline", None)
+        if fn is None:
+            self.skipTest("registry not patched (apply_patches.py not run)")
+        return fn
+
+    _V2_TRANSFORMER = {
+        "caption_proj_before_connector": True,
+        "caption_projection_first_linear": False,
+        "caption_projection_second_linear": False,
+        "caption_proj_input_norm": False,
+        "cross_attention_adaln": True,
+    }
+
+    def test_v2_config_detected_as_ltx23(self):
+        detect = self._detect()
+        self.assertEqual(detect({"transformer": dict(self._V2_TRANSFORMER)}), "LTX23Pipeline")
+
+    def test_plain_config_detected_as_ltx2(self):
+        detect = self._detect()
+        self.assertEqual(detect({"transformer": {}}), "LTX2Pipeline")
+
+    def test_ambiguous_config_raises(self):
+        detect = self._detect()
+        # cross_attention_adaln=True but none of the V2 text-projection keys.
+        with self.assertRaises(ValueError):
+            detect({"transformer": {"cross_attention_adaln": True}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds single-GPU LTX-2.3 (`Lightricks/LTX-2.3`) to VisualGen.

Reused from LTX-2: `LTX2Attention`, MLP construction, fused AdaLN ops, `Embeddings1DConnector`, VAE primitives / tiled decode, Gemma load + `encode_text`.

LTX-2.3-specific components added:

- Split Gemma feature extractor, followed by two gated 8-layer connectors; `caption_projection` is `Identity`.
- 9-slot per-block AdaLN plus prompt AdaLN: global `sigma` → `prompt_timestep` modulates text K/V each denoise step (not cached per block like LTX-2).
- Video VAE: `compress_time` / `compress_space` shrink channels.
- BigVGAN-v2 AMP1 vocoder + fp32 bandwidth extension (versus LTX-2’s HiFi-GAN).
- Single-rank autotune + CUDA graph warmup uses a two-pass sequence: tune with graph capture disabled, then capture using the warm tactic cache.

Entry point: `python models/ltx2.py --model_type ltx23` with `configs/ltx23-t2v-bf16-1gpu.yaml` or `ltx23-t2v-fp8-1gpu.yaml` (`torch.compile` + CUDA graphs). Text encoder is gemma-3-12b-it.

Out of scope: multi-GPU, FP4, two-stage (spatial upsampler + distilled LoRA).

## Performance

1× B200, 768×512, 121 frames, 40 steps, CFG 4.0, torch.compile + CUDA graphs. 

| Precision | generation | denoise | pre_denoise | post_denoise |
| --------- | ---------- | ------- | ----------- | ------------ |
| BF16      | 14.80 s    | 14.24 s | 0.14 s      | 0.42 s       |
| FP8       | 12.14 s    | 11.58 s | 0.14 s      | 0.42 s       |


FP8 is 1.22× vs BF16 on generation (denoise-bound; pre/post are the same).

## Test Coverage

- Unittest: `test_visual_gen_ltx23_transformer.py`, `test_visual_gen_ltx23_pipeline.py` (listed in `l0_b200.yml`).
- Integration: `test_visual_gen_ltx23.py` — `test_ltx23_example[bf16]` / `[fp8]`, video LPIPS and audio golden (`l0_b200.yml`).
- Manual on B200: e2e BF16 and FP8 through `ltx2.py --model_type ltx23` (audio+video MP4). Encoder path: `gemma-3-12b-it`.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
