### PR TITLE
[TRTLLMINF-237][infra] Adopt resourceLedger.withResource for BuildDockerImage

### DIFF
--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -325,8 +325,23 @@ def buildImage(config, imageKeyToTag)
             trtllm_utils.llmExecStepWithRetry(this, script: "docker login ${DEFAULT_GIT_URL}:5005 -u ${USERNAME} -p ${PASSWORD}")
         }
     }
-    def containerGenFailure = null
-    try {
+    // The two `docker login`s above are held for the whole build and released by
+    // the reclaim below. resourceLedger.withResource runs the reclaim in a
+    // finally on both success and failure -- re-raising the body's own error --
+    // replacing the prior try/catch/finally/containerGenFailure/rethrow. If the
+    // build pod dies before the finally runs, the registered entry is left live
+    // for a post-build sweep (Phase 3) rather than being silently lost.
+    resourceLedger.withResource(this,
+        id: "docker-login/${config.stageName}",
+        type: "dockerLogin",
+        reclaim: { p, e ->
+            stage ("Docker Logout") {
+                withCredentials([string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')]) {
+                    sh "docker logout urm.nvidia.com"
+                    sh "docker logout ${DEFAULT_GIT_URL}:5005"
+                }
+            }
+        }) {
         def build_jobs = BUILD_JOBS
         // Fix the triton image pull timeout issue
         def BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^ARG BASE_IMAGE=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()
@@ -421,18 +436,6 @@ def buildImage(config, imageKeyToTag)
                 BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}
                 """
             }
-        }
-    } catch (Exception ex) {
-        containerGenFailure = ex
-    } finally {
-        stage ("Docker Logout") {
-            withCredentials([string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')]) {
-                sh "docker logout urm.nvidia.com"
-                sh "docker logout ${DEFAULT_GIT_URL}:5005"
-            }
-        }
-        if (containerGenFailure != null) {
-            throw containerGenFailure
         }
     }
 }

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -309,39 +309,53 @@ def buildImage(config, imageKeyToTag)
         sh "env | sort"
         sh "apk add make git"
         sh "git config --global --add safe.directory '*'"
-
-        withCredentials([usernamePassword(credentialsId: "urm-artifactory-creds", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-            trtllm_utils.llmExecStepWithRetry(this, script: "docker login urm.nvidia.com -u ${USERNAME} -p ${PASSWORD}")
-        }
-
-        withCredentials([
-            usernamePassword(
-                credentialsId: "svc_tensorrt_gitlab_read_api_token",
-                usernameVariable: 'USERNAME',
-                passwordVariable: 'PASSWORD'
-            ),
-            string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')
-        ]) {
-            trtllm_utils.llmExecStepWithRetry(this, script: "docker login ${DEFAULT_GIT_URL}:5005 -u ${USERNAME} -p ${PASSWORD}")
-        }
     }
-    // The two `docker login`s above are held for the whole build and released by
-    // the reclaim below. resourceLedger.withResource runs the reclaim in a
-    // finally on both success and failure -- re-raising the body's own error --
-    // replacing the prior try/catch/finally/containerGenFailure/rethrow. If the
-    // build pod dies before the finally runs, the registered entry is left live
-    // for a post-build sweep (Phase 3) rather than being silently lost.
+    // resourceLedger.withResource registers the docker-login lifecycle *before*
+    // the first login, then runs the reclaim (logout) in a finally on both
+    // success and failure -- re-raising the body's own error -- replacing the
+    // prior try/catch/finally/containerGenFailure/rethrow. Registering before the
+    // logins means any registry we authenticate to below is owed a logout even if
+    // a later login (or the pod) fails partway through; if the build pod dies
+    // before the finally runs, the entry is left live for a post-build sweep
+    // (Phase 3) rather than being silently lost.
     resourceLedger.withResource(this,
         id: "docker-login/${config.stageName}",
         type: "dockerLogin",
         reclaim: { p, e ->
             stage ("Docker Logout") {
                 withCredentials([string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')]) {
-                    sh "docker logout urm.nvidia.com"
-                    sh "docker logout ${DEFAULT_GIT_URL}:5005"
+                    // Best-effort and independent: attempt every logout even if an
+                    // earlier one fails, so a failure on one registry can't leave
+                    // another still authenticated.
+                    try {
+                        sh "docker logout urm.nvidia.com"
+                    } catch (Exception logoutEx) {
+                        echo "docker logout urm.nvidia.com failed: ${logoutEx}"
+                    }
+                    try {
+                        sh "docker logout ${DEFAULT_GIT_URL}:5005"
+                    } catch (Exception logoutEx) {
+                        echo "docker logout for gitlab registry failed: ${logoutEx}"
+                    }
                 }
             }
         }) {
+        stage ("Docker Login") {
+            withCredentials([usernamePassword(credentialsId: "urm-artifactory-creds", usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                trtllm_utils.llmExecStepWithRetry(this, script: "docker login urm.nvidia.com -u ${USERNAME} -p ${PASSWORD}")
+            }
+
+            withCredentials([
+                usernamePassword(
+                    credentialsId: "svc_tensorrt_gitlab_read_api_token",
+                    usernameVariable: 'USERNAME',
+                    passwordVariable: 'PASSWORD'
+                ),
+                string(credentialsId: 'default-git-url', variable: 'DEFAULT_GIT_URL')
+            ]) {
+                trtllm_utils.llmExecStepWithRetry(this, script: "docker login ${DEFAULT_GIT_URL}:5005 -u ${USERNAME} -p ${PASSWORD}")
+            }
+        }
         def build_jobs = BUILD_JOBS
         // Fix the triton image pull timeout issue
         def BASE_IMAGE = sh(script: "cd ${LLM_ROOT} && grep '^ARG BASE_IMAGE=' docker/Dockerfile.multi | grep -o '=.*' | tr -d '=\"'", returnStdout: true).trim()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `BuildDockerImage.buildImage()` registers Docker logins with `resourceLedger.withResource`.
- The ledger performs best-effort Docker logout on success and failure paths.
- The ledger preserves login records for post-build reconciliation if the build pod terminates before cleanup.
- Independent logout failures are logged without masking the original build failure.
- The change removes the previous local cleanup logic and preserves existing behavior.
- Groovy AST parsing succeeds for the modified file.
- No public or exported declarations changed.
- No configuration or test-list files changed.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

buildImage() logs into two Docker registries and must log out on both success and failure. Replace the hand-rolled try/catch/finally + containerGenFailure + manual rethrow with a single resourceLedger.withResource whose reclaim performs the logout. Behavior is preserved -- logout still runs in a finally on either path and the body's own error still propagates -- with two improvements:
  - the login is registered in the build-scoped ledger, so if the build pod dies before the finally runs, the entry is left live for a post-build sweep (Phase 3) instead of being silently lost;
  - a logout (reclaim) failure is now logged rather than masking the build's own failure.

Validated: Groovy AST parse of the modified file succeeds.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
