### PR TITLE
[TRTLLM-14880][feat] qualify Qwen3 dense for MX

### DIFF
--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -20,17 +20,19 @@ to the provided Hugging Face checkpoint.
 
 ## Current Support Scope
 
-The post-transform MX receive path currently supports one exact qualification
-profile:
+The post-transform MX receive path currently supports these exact qualification
+profiles:
 
 | Profile | Root class | Config identity | Scope | Protocol | Transform-layout ABI | Constraints |
 |---------|------------|-----------------|-------|----------|----------------------|-------------|
 | `llama-for-causal-lm-target-v1` | `LlamaForCausalLM` | `LlamaForCausalLM` / `llama` | Target model | 1 | `trtllm-llama-target-layout-v1` | No speculative mode or separately loaded draft model |
+| `qwen2-for-causal-lm-bf16-target-v1` | `Qwen2ForCausalLM` | `Qwen2ForCausalLM` / `qwen2` | Target model | 1 | `trtllm-qwen2-dense-target-layout-v1` | Single-node dense BF16, unquantized weights and KV cache, TRTLLM attention, default fused RoPE, untied embeddings, TP=1 or 2, PP/CP/EP=1, no LoRA, sparse attention, attention DP, speculative mode, or separately loaded draft model |
 
-The registry matches the exact root class and the architecture/model type
-captured from the resolved config before model construction. An unregistered
-subclass or config alias does not inherit support. It falls back to the
-standard Hugging Face checkpoint path before any P2P transfer starts.
+The registry matches the exact root class, the architecture/model type captured
+from the resolved config before model construction, and any runtime constraints
+declared by the profile. An unregistered subclass, config alias, or undeclared
+runtime variant does not inherit support. It falls back to the standard Hugging
+Face checkpoint path before any P2P transfer starts.
 
 TensorRT LLM applies two independent compatibility gates:
 
@@ -49,6 +51,12 @@ Loads that require a separately loaded draft model also fall back to the
 standard checkpoint path. Target-plus-draft post-transform transfer remains
 disabled until layout state is tracked and qualified independently for each
 submodel.
+
+The Qwen2 profile is text-only. It does not enable Qwen2 reward-model, MoE, or
+vision-language roots. FP16, quantized weights or KV cache, alternate attention
+backends, YaRN or unfused RoPE, tied embeddings, TP greater than 2, PP, CP, EP,
+LoRA, sparse attention, attention DP, multi-node transfer, and speculative
+decoding require separate qualification rows.
 
 ### Adding a Model Family
 
@@ -181,9 +189,9 @@ path.
 
 ## Notes and Limitations
 
-- Post-transform MX reception is currently limited to the Llama model family.
-  Other model families safely fall back to Hugging Face loading until they are
-  explicitly qualified and added as exact capability profiles.
+- Post-transform MX reception is currently limited to the exact Llama and
+  Qwen2 dense profiles above. Other roots and Qwen2 variants safely fall back
+  to Hugging Face loading until explicitly qualified.
 - The MX server and Redis lifecycle is external to TensorRT LLM. Every
   TensorRT LLM instance must be able to reach the configured MX server URL.
 - The MX server coordinates source discovery but does not store model weights.

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -27,6 +27,7 @@ profiles:
 |---------|------------|-----------------|-------|----------|----------------------|-------------|
 | `llama-for-causal-lm-target-v1` | `LlamaForCausalLM` | `LlamaForCausalLM` / `llama` | Target model | 1 | `trtllm-llama-target-layout-v1` | No speculative mode or separately loaded draft model |
 | `qwen2-for-causal-lm-bf16-target-v1` | `Qwen2ForCausalLM` | `Qwen2ForCausalLM` / `qwen2` | Target model | 1 | `trtllm-qwen2-dense-target-layout-v1` | Single-node dense BF16, unquantized weights and KV cache, TRTLLM attention, default fused RoPE, untied embeddings, TP=1 or 2, PP/CP/EP=1, no LoRA, sparse attention, attention DP, speculative mode, or separately loaded draft model |
+| `qwen3-for-causal-lm-bf16-target-v1` | `Qwen3ForCausalLM` | `Qwen3ForCausalLM` / `qwen3` | Target model | 1 | `trtllm-qwen3-dense-target-layout-v1` | Single-node dense BF16, unquantized weights and KV cache, TRTLLM attention, default fused QK-norm/RoPE, untied embeddings, TP=1 or 2, PP/CP/EP=1, no LoRA, sparse attention, attention DP, speculative mode, or separately loaded draft model |
 
 The registry matches the exact root class, the architecture/model type captured
 from the resolved config before model construction, and any runtime constraints
@@ -52,11 +53,11 @@ standard checkpoint path. Target-plus-draft post-transform transfer remains
 disabled until layout state is tracked and qualified independently for each
 submodel.
 
-The Qwen2 profile is text-only. It does not enable Qwen2 reward-model, MoE, or
-vision-language roots. FP16, quantized weights or KV cache, alternate attention
-backends, YaRN or unfused RoPE, tied embeddings, TP greater than 2, PP, CP, EP,
-LoRA, sparse attention, attention DP, multi-node transfer, and speculative
-decoding require separate qualification rows.
+The Qwen2 and Qwen3 profiles are text-only. They do not enable reward-model,
+embedding, MoE, or vision-language roots. FP16, quantized weights or KV cache,
+alternate attention backends, YaRN or unfused RoPE, tied embeddings, TP greater
+than 2, PP, CP, EP, LoRA, sparse attention, attention DP, multi-node transfer,
+and speculative decoding require separate qualification rows.
 
 ### Adding a Model Family
 
@@ -189,9 +190,9 @@ path.
 
 ## Notes and Limitations
 
-- Post-transform MX reception is currently limited to the exact Llama and
-  Qwen2 dense profiles above. Other roots and Qwen2 variants safely fall back
-  to Hugging Face loading until explicitly qualified.
+- Post-transform MX reception is currently limited to the exact Llama, Qwen2
+  dense, and Qwen3 dense profiles above. Other roots and variants safely fall
+  back to Hugging Face loading until explicitly qualified.
 - The MX server and Redis lifecycle is external to TensorRT LLM. Every
   TensorRT LLM instance must be able to reach the configured MX server URL.
 - The MX server coordinates source discovery but does not store model weights.

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -14,7 +14,8 @@ from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
     AutoCheckpointMapper, BaseCheckpointLoader)
 from tensorrt_llm._torch.weight_sharing import (
     LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
-    QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1, ArtifactIdentity,
+    QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1, ArtifactIdentity,
     IdentityCheckPolicy, PostTransformConfigIdentity, PostTransformFeature,
     PostTransformProfile, PostTransformProfileRegistry,
     PostTransformQualificationDecision, PostTransformRuntimeConfig,
@@ -36,7 +37,8 @@ from tensorrt_llm.quantization.utils.fp4_utils import float4_e2m1x2
 
 from ...llmapi.llm_args import LoadFormat
 from ..model_config import ModelConfig
-from ..models import AutoModelForCausalLM, LlamaForCausalLM, Qwen2ForCausalLM
+from ..models import (AutoModelForCausalLM, LlamaForCausalLM, Qwen2ForCausalLM,
+                      Qwen3ForCausalLM)
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
 from ..models.modeling_utils import (MODEL_CLASS_MAPPING,
                                      DecoderModelForCausalLM, MetaInitMode,
@@ -344,6 +346,28 @@ class ModelLoader:
     This class isolates model loading logic from the main execution engine.
     """
     _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION = 1
+    _DENSE_QWEN_BF16_TARGET_RUNTIME_CONSTRAINTS = PostTransformRuntimeConstraints(
+        dtypes=frozenset({"bfloat16"}),
+        quant_algorithms=frozenset({"none"}),
+        kv_cache_quant_algorithms=frozenset({"none"}),
+        layerwise_quantization=frozenset({False}),
+        force_dynamic_quantization=frozenset({False}),
+        lora_enabled=frozenset({False}),
+        sparse_attention_enabled=frozenset({False}),
+        attention_backends=frozenset({"TRTLLM"}),
+        tp_sizes=frozenset({1, 2}),
+        pp_sizes=frozenset({1}),
+        cp_sizes=frozenset({1}),
+        moe_tp_sizes=frozenset({1, 2}),
+        moe_ep_sizes=frozenset({1}),
+        attention_tp_sizes=frozenset({1, 2}),
+        attention_cp_sizes=frozenset({1}),
+        attention_dp=frozenset({False}),
+        multi_node=frozenset({False}),
+        tied_word_embeddings=frozenset({False}),
+        rope_types=frozenset({"default"}),
+        rope_fusion=frozenset({True}),
+    )
     _POST_TRANSFORM_PROFILE_REGISTRY = PostTransformProfileRegistry(profiles=(
         PostTransformProfile(
             profile_id="llama-for-causal-lm-target-v1",
@@ -364,28 +388,18 @@ class ModelLoader:
             protocol_version=_MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
             transform_abi_id=QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
             transfer_scope=PostTransformTransferScope.TARGET_MODEL,
-            runtime_constraints=PostTransformRuntimeConstraints(
-                dtypes=frozenset({"bfloat16"}),
-                quant_algorithms=frozenset({"none"}),
-                kv_cache_quant_algorithms=frozenset({"none"}),
-                layerwise_quantization=frozenset({False}),
-                force_dynamic_quantization=frozenset({False}),
-                lora_enabled=frozenset({False}),
-                sparse_attention_enabled=frozenset({False}),
-                attention_backends=frozenset({"TRTLLM"}),
-                tp_sizes=frozenset({1, 2}),
-                pp_sizes=frozenset({1}),
-                cp_sizes=frozenset({1}),
-                moe_tp_sizes=frozenset({1, 2}),
-                moe_ep_sizes=frozenset({1}),
-                attention_tp_sizes=frozenset({1, 2}),
-                attention_cp_sizes=frozenset({1}),
-                attention_dp=frozenset({False}),
-                multi_node=frozenset({False}),
-                tied_word_embeddings=frozenset({False}),
-                rope_types=frozenset({"default"}),
-                rope_fusion=frozenset({True}),
-            ),
+            runtime_constraints=_DENSE_QWEN_BF16_TARGET_RUNTIME_CONSTRAINTS,
+        ),
+        PostTransformProfile(
+            profile_id="qwen3-for-causal-lm-bf16-target-v1",
+            root_model_class=Qwen3ForCausalLM,
+            architecture="Qwen3ForCausalLM",
+            model_type="qwen3",
+            speculative_mode=None,
+            protocol_version=_MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+            transform_abi_id=QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+            transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+            runtime_constraints=_DENSE_QWEN_BF16_TARGET_RUNTIME_CONSTRAINTS,
         ),
     ))
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -13,10 +13,12 @@ import torch
 from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
     AutoCheckpointMapper, BaseCheckpointLoader)
 from tensorrt_llm._torch.weight_sharing import (
-    LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1, ArtifactIdentity, IdentityCheckPolicy,
-    PostTransformConfigIdentity, PostTransformFeature, PostTransformProfile,
-    PostTransformProfileRegistry, PostTransformQualificationDecision,
-    PostTransformTransferScope, SourceIdentity,
+    LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1, ArtifactIdentity,
+    IdentityCheckPolicy, PostTransformConfigIdentity, PostTransformFeature,
+    PostTransformProfile, PostTransformProfileRegistry,
+    PostTransformQualificationDecision, PostTransformRuntimeConfig,
+    PostTransformRuntimeConstraints, PostTransformTransferScope, SourceIdentity,
     check_weight_sharing_compatibility)
 from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_args import (DecodingBaseConfig,
@@ -34,7 +36,7 @@ from tensorrt_llm.quantization.utils.fp4_utils import float4_e2m1x2
 
 from ...llmapi.llm_args import LoadFormat
 from ..model_config import ModelConfig
-from ..models import AutoModelForCausalLM, LlamaForCausalLM
+from ..models import AutoModelForCausalLM, LlamaForCausalLM, Qwen2ForCausalLM
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
 from ..models.modeling_utils import (MODEL_CLASS_MAPPING,
                                      DecoderModelForCausalLM, MetaInitMode,
@@ -342,8 +344,8 @@ class ModelLoader:
     This class isolates model loading logic from the main execution engine.
     """
     _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION = 1
-    _POST_TRANSFORM_PROFILE_REGISTRY = PostTransformProfileRegistry(
-        profiles=(PostTransformProfile(
+    _POST_TRANSFORM_PROFILE_REGISTRY = PostTransformProfileRegistry(profiles=(
+        PostTransformProfile(
             profile_id="llama-for-causal-lm-target-v1",
             root_model_class=LlamaForCausalLM,
             architecture="LlamaForCausalLM",
@@ -352,7 +354,40 @@ class ModelLoader:
             protocol_version=_MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
             transform_abi_id=LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
             transfer_scope=PostTransformTransferScope.TARGET_MODEL,
-        ), ))
+        ),
+        PostTransformProfile(
+            profile_id="qwen2-for-causal-lm-bf16-target-v1",
+            root_model_class=Qwen2ForCausalLM,
+            architecture="Qwen2ForCausalLM",
+            model_type="qwen2",
+            speculative_mode=None,
+            protocol_version=_MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+            transform_abi_id=QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+            transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+            runtime_constraints=PostTransformRuntimeConstraints(
+                dtypes=frozenset({"bfloat16"}),
+                quant_algorithms=frozenset({"none"}),
+                kv_cache_quant_algorithms=frozenset({"none"}),
+                layerwise_quantization=frozenset({False}),
+                force_dynamic_quantization=frozenset({False}),
+                lora_enabled=frozenset({False}),
+                sparse_attention_enabled=frozenset({False}),
+                attention_backends=frozenset({"TRTLLM"}),
+                tp_sizes=frozenset({1, 2}),
+                pp_sizes=frozenset({1}),
+                cp_sizes=frozenset({1}),
+                moe_tp_sizes=frozenset({1, 2}),
+                moe_ep_sizes=frozenset({1}),
+                attention_tp_sizes=frozenset({1, 2}),
+                attention_cp_sizes=frozenset({1}),
+                attention_dp=frozenset({False}),
+                multi_node=frozenset({False}),
+                tied_word_embeddings=frozenset({False}),
+                rope_types=frozenset({"default"}),
+                rope_fusion=frozenset({True}),
+            ),
+        ),
+    ))
 
     def __init__(self,
                  llm_args: TorchLlmArgs,
@@ -1093,11 +1128,16 @@ class ModelLoader:
                    for feature in qualification.unsupported_features))
         feature_detail = (f"; unsupported_features={unsupported_features}"
                           if unsupported_features else "")
+        unsupported_runtime_dimensions = ",".join(
+            sorted(qualification.unsupported_runtime_dimensions))
+        runtime_detail = (
+            f"; unsupported_runtime_dimensions={unsupported_runtime_dimensions}"
+            if unsupported_runtime_dimensions else "")
         raise RuntimeError(
             f"MX receiver got post-transform weights for {type(model).__name__}, "
             "but the load does not match a qualified staged post-load profile "
             f"for protocol v{cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION}: "
-            f"reason={qualification.reason.value}{feature_detail}. "
+            f"reason={qualification.reason.value}{feature_detail}{runtime_detail}. "
             "Refusing to run the full post-load path on already-transformed "
             "weights.")
 
@@ -1139,6 +1179,8 @@ class ModelLoader:
             protocol_version=cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
             transfer_scope=PostTransformTransferScope.TARGET_MODEL,
             enabled_features=frozenset(enabled_features),
+            runtime_config=PostTransformRuntimeConfig.from_model_config(
+                model.model_config),
         )
 
     def _post_load_publish(
@@ -1153,11 +1195,15 @@ class ModelLoader:
         if checkpoint_loader.checkpoint_format == "MX":
             if not qualification.qualified:
                 if not weights_preloaded:
+                    unsupported_runtime_dimensions = ",".join(
+                        sorted(qualification.unsupported_runtime_dimensions))
                     logger.info(
                         "Skipping MX post-transform publish for %s: "
-                        "qualification reason=%s.",
+                        "qualification reason=%s, "
+                        "unsupported_runtime_dimensions=%s.",
                         type(model).__name__,
                         qualification.reason.value,
+                        unsupported_runtime_dimensions or "none",
                     )
                 return
             kwargs["source_identity"] = self._source_identity

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -44,11 +44,14 @@ from tensorrt_llm._torch.weight_sharing.source_identity import (
 
 __all__ = [
     "ARTIFACT_IDENTITY_FORMAT_VERSION",
-    "ArtifactIdentity",
     "LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1",
     "QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1",
     "QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1",
     "SOURCE_IDENTITY_FORMAT_VERSION",
+    "ArtifactIdentity",
+    "IdentityCheckDecision",
+    "IdentityCheckPolicy",
+    "IdentityMatchResult",
     "PostTransformConfigIdentity",
     "PostTransformFeature",
     "PostTransformProfile",
@@ -59,9 +62,6 @@ __all__ = [
     "PostTransformRuntimeConstraints",
     "PostTransformTransferScope",
     "SourceIdentity",
-    "IdentityMatchResult",
-    "IdentityCheckPolicy",
-    "IdentityCheckDecision",
     "SourceIdentityMismatchError",
     "check_weight_sharing_compatibility",
 ]

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -20,12 +20,15 @@ from tensorrt_llm._torch.weight_sharing.artifact_identity import (
 )
 from tensorrt_llm._torch.weight_sharing.post_transform_profiles import (
     LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
     PostTransformConfigIdentity,
     PostTransformFeature,
     PostTransformProfile,
     PostTransformProfileRegistry,
     PostTransformQualificationDecision,
     PostTransformQualificationReason,
+    PostTransformRuntimeConfig,
+    PostTransformRuntimeConstraints,
     PostTransformTransferScope,
 )
 from tensorrt_llm._torch.weight_sharing.source_identity import (
@@ -42,6 +45,7 @@ __all__ = [
     "ARTIFACT_IDENTITY_FORMAT_VERSION",
     "ArtifactIdentity",
     "LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1",
+    "QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1",
     "SOURCE_IDENTITY_FORMAT_VERSION",
     "PostTransformConfigIdentity",
     "PostTransformFeature",
@@ -49,6 +53,8 @@ __all__ = [
     "PostTransformProfileRegistry",
     "PostTransformQualificationDecision",
     "PostTransformQualificationReason",
+    "PostTransformRuntimeConfig",
+    "PostTransformRuntimeConstraints",
     "PostTransformTransferScope",
     "SourceIdentity",
     "IdentityMatchResult",

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -21,6 +21,7 @@ from tensorrt_llm._torch.weight_sharing.artifact_identity import (
 from tensorrt_llm._torch.weight_sharing.post_transform_profiles import (
     LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
     QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
     PostTransformConfigIdentity,
     PostTransformFeature,
     PostTransformProfile,
@@ -46,6 +47,7 @@ __all__ = [
     "ArtifactIdentity",
     "LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1",
     "QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1",
+    "QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1",
     "SOURCE_IDENTITY_FORMAT_VERSION",
     "PostTransformConfigIdentity",
     "PostTransformFeature",

--- a/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
+++ b/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
@@ -42,6 +42,9 @@ LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1 = "trtllm-llama-target-layout-v1"
 # Stable contract for unquantized Qwen2 dense fused-QKV and fused-gate-up
 # tensors plus the target-only receiver finalization used by its first profile.
 QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1 = "trtllm-qwen2-dense-target-layout-v1"
+# Stable contract for unquantized Qwen3 dense fused-QKV and fused-gate-up
+# tensors, Q/K norm state, and target-only receiver finalization.
+QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1 = "trtllm-qwen3-dense-target-layout-v1"
 _MISSING = object()
 
 

--- a/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
+++ b/tensorrt_llm/_torch/weight_sharing/post_transform_profiles.py
@@ -28,11 +28,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from torch import nn
-
 
 # Stable identifier for the tensor names, layouts, aliases, and receiver-side
 # finalization contract produced by the currently qualified Llama target path.
@@ -40,6 +39,35 @@ if TYPE_CHECKING:
 # a transform changes transferred tensor semantics or the receiver must
 # interpret/finalize the transferred state differently.
 LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1 = "trtllm-llama-target-layout-v1"
+# Stable contract for unquantized Qwen2 dense fused-QKV and fused-gate-up
+# tensors plus the target-only receiver finalization used by its first profile.
+QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1 = "trtllm-qwen2-dense-target-layout-v1"
+_MISSING = object()
+
+
+def _canonical_string(value: object) -> str | None:
+    if value is None:
+        return None
+    value = getattr(value, "value", value)
+    if isinstance(value, (str, int, float, bool)):
+        return str(value).removeprefix("torch.")
+    rendered_value = str(value)
+    return rendered_value.removeprefix("torch.") if rendered_value.startswith("torch.") else None
+
+
+def _canonical_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _canonical_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _canonical_optional_string(container: object, attribute: str) -> str | None:
+    value = getattr(container, attribute, _MISSING)
+    if value is _MISSING:
+        return None
+    return "none" if value is None else _canonical_string(value)
 
 
 @dataclass(frozen=True)
@@ -67,6 +95,197 @@ class PostTransformConfigIdentity:
         return cls(architecture=architecture, model_type=model_type)
 
 
+@dataclass(frozen=True)
+class PostTransformRuntimeConfig:
+    """Resolved runtime dimensions used to bound qualification evidence."""
+
+    dtype: str | None
+    quant_algorithm: str | None
+    kv_cache_quant_algorithm: str | None
+    layerwise_quantization: bool | None
+    force_dynamic_quantization: bool | None
+    lora_enabled: bool | None
+    sparse_attention_enabled: bool | None
+    attention_backend: str | None
+    moe_backend: str | None
+    tp_size: int | None
+    pp_size: int | None
+    cp_size: int | None
+    moe_tp_size: int | None
+    moe_ep_size: int | None
+    attention_tp_size: int | None
+    attention_cp_size: int | None
+    attention_dp: bool | None
+    multi_node: bool | None
+    tied_word_embeddings: bool | None
+    rope_type: str | None
+    rope_fusion: bool | None
+
+    @classmethod
+    def from_model_config(cls, model_config: object) -> "PostTransformRuntimeConfig":
+        """Capture the support-matrix dimensions from a final model config."""
+
+        pretrained_config = getattr(model_config, "pretrained_config", None)
+        quant_config = getattr(model_config, "quant_config", None)
+        quant_config_dict = getattr(model_config, "quant_config_dict", _MISSING)
+        lora_config = getattr(model_config, "lora_config", _MISSING)
+        sparse_attention_config = getattr(model_config, "sparse_attention_config", _MISSING)
+        mapping = getattr(model_config, "mapping", None)
+        world_size = _canonical_int(getattr(mapping, "world_size", None))
+        gpus_per_node = _canonical_int(getattr(mapping, "gpus_per_node", None))
+        multi_node = (
+            world_size > gpus_per_node
+            if world_size is not None and gpus_per_node is not None and gpus_per_node > 0
+            else None
+        )
+
+        if quant_config_dict is _MISSING:
+            layerwise_quantization = None
+        elif quant_config_dict is None:
+            layerwise_quantization = False
+        elif isinstance(quant_config_dict, dict):
+            layerwise_quantization = bool(quant_config_dict)
+        else:
+            layerwise_quantization = None
+
+        rope_scaling = getattr(pretrained_config, "rope_scaling", None)
+        if rope_scaling is None:
+            rope_type = "default"
+        elif isinstance(rope_scaling, dict):
+            rope_type = _canonical_string(rope_scaling.get("rope_type", rope_scaling.get("type")))
+        else:
+            rope_type = None
+
+        disable_fuse_rope = getattr(pretrained_config, "disable_fuse_rope", False)
+        rope_fusion = not disable_fuse_rope if isinstance(disable_fuse_rope, bool) else None
+
+        return cls(
+            dtype=_canonical_string(getattr(pretrained_config, "torch_dtype", None)),
+            quant_algorithm=_canonical_optional_string(quant_config, "quant_algo"),
+            kv_cache_quant_algorithm=_canonical_optional_string(
+                quant_config, "kv_cache_quant_algo"
+            ),
+            layerwise_quantization=layerwise_quantization,
+            force_dynamic_quantization=_canonical_bool(
+                getattr(model_config, "force_dynamic_quantization", None)
+            ),
+            lora_enabled=None if lora_config is _MISSING else lora_config is not None,
+            sparse_attention_enabled=(
+                None if sparse_attention_config is _MISSING else sparse_attention_config is not None
+            ),
+            attention_backend=_canonical_string(getattr(model_config, "attn_backend", None)),
+            moe_backend=_canonical_string(getattr(model_config, "moe_backend", None)),
+            tp_size=_canonical_int(getattr(mapping, "tp_size", None)),
+            pp_size=_canonical_int(getattr(mapping, "pp_size", None)),
+            cp_size=_canonical_int(getattr(mapping, "cp_size", None)),
+            moe_tp_size=_canonical_int(getattr(mapping, "moe_tp_size", None)),
+            moe_ep_size=_canonical_int(getattr(mapping, "moe_ep_size", None)),
+            attention_tp_size=_canonical_int(getattr(mapping, "attn_tp_size", None)),
+            attention_cp_size=_canonical_int(getattr(mapping, "attn_cp_size", None)),
+            attention_dp=_canonical_bool(getattr(mapping, "enable_attention_dp", None)),
+            multi_node=multi_node,
+            tied_word_embeddings=_canonical_bool(
+                getattr(pretrained_config, "tie_word_embeddings", None)
+            ),
+            rope_type=rope_type,
+            rope_fusion=rope_fusion,
+        )
+
+
+@dataclass(frozen=True)
+class PostTransformRuntimeConstraints:
+    """Allowed values for one qualified runtime support-matrix row."""
+
+    _DIMENSIONS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("dtypes", "dtype"),
+        ("quant_algorithms", "quant_algorithm"),
+        ("kv_cache_quant_algorithms", "kv_cache_quant_algorithm"),
+        ("layerwise_quantization", "layerwise_quantization"),
+        ("force_dynamic_quantization", "force_dynamic_quantization"),
+        ("lora_enabled", "lora_enabled"),
+        ("sparse_attention_enabled", "sparse_attention_enabled"),
+        ("attention_backends", "attention_backend"),
+        ("moe_backends", "moe_backend"),
+        ("tp_sizes", "tp_size"),
+        ("pp_sizes", "pp_size"),
+        ("cp_sizes", "cp_size"),
+        ("moe_tp_sizes", "moe_tp_size"),
+        ("moe_ep_sizes", "moe_ep_size"),
+        ("attention_tp_sizes", "attention_tp_size"),
+        ("attention_cp_sizes", "attention_cp_size"),
+        ("attention_dp", "attention_dp"),
+        ("multi_node", "multi_node"),
+        ("tied_word_embeddings", "tied_word_embeddings"),
+        ("rope_types", "rope_type"),
+        ("rope_fusion", "rope_fusion"),
+    )
+
+    dtypes: frozenset[str | None] | None = None
+    quant_algorithms: frozenset[str | None] | None = None
+    kv_cache_quant_algorithms: frozenset[str | None] | None = None
+    layerwise_quantization: frozenset[bool | None] | None = None
+    force_dynamic_quantization: frozenset[bool | None] | None = None
+    lora_enabled: frozenset[bool | None] | None = None
+    sparse_attention_enabled: frozenset[bool | None] | None = None
+    attention_backends: frozenset[str | None] | None = None
+    moe_backends: frozenset[str | None] | None = None
+    tp_sizes: frozenset[int | None] | None = None
+    pp_sizes: frozenset[int | None] | None = None
+    cp_sizes: frozenset[int | None] | None = None
+    moe_tp_sizes: frozenset[int | None] | None = None
+    moe_ep_sizes: frozenset[int | None] | None = None
+    attention_tp_sizes: frozenset[int | None] | None = None
+    attention_cp_sizes: frozenset[int | None] | None = None
+    attention_dp: frozenset[bool | None] | None = None
+    multi_node: frozenset[bool | None] | None = None
+    tied_word_embeddings: frozenset[bool | None] | None = None
+    rope_types: frozenset[str | None] | None = None
+    rope_fusion: frozenset[bool | None] | None = None
+
+    def __post_init__(self) -> None:
+        for constraint_name, _runtime_name in self._DIMENSIONS:
+            allowed_values = getattr(self, constraint_name)
+            if allowed_values is None:
+                continue
+            normalized_values = frozenset(allowed_values)
+            if not normalized_values:
+                raise ValueError(
+                    f"Post-transform runtime constraint {constraint_name} must not be empty"
+                )
+            object.__setattr__(self, constraint_name, normalized_values)
+
+    def unsupported_dimensions(
+        self, runtime_config: PostTransformRuntimeConfig | None
+    ) -> frozenset[str]:
+        """Return constrained dimensions not satisfied by a concrete run."""
+
+        unsupported = set()
+        for constraint_name, runtime_name in self._DIMENSIONS:
+            allowed_values = getattr(self, constraint_name)
+            if allowed_values is None:
+                continue
+            runtime_value = (
+                None if runtime_config is None else getattr(runtime_config, runtime_name)
+            )
+            if runtime_value not in allowed_values:
+                unsupported.add(runtime_name)
+        return frozenset(unsupported)
+
+    def overlaps(self, other: "PostTransformRuntimeConstraints") -> bool:
+        """Whether two rows admit at least one common runtime configuration."""
+
+        for constraint_name, _runtime_name in self._DIMENSIONS:
+            allowed_values = getattr(self, constraint_name)
+            other_allowed_values = getattr(other, constraint_name)
+            if (
+                allowed_values is not None
+                and other_allowed_values is not None
+                and allowed_values.isdisjoint(other_allowed_values)
+            ):
+                return False
+        return True
+
+
 class PostTransformTransferScope(str, Enum):
     """The model component represented by a post-transform transfer."""
 
@@ -91,6 +310,7 @@ class PostTransformQualificationReason(str, Enum):
     SPECULATIVE_MODE_NOT_REGISTERED = "speculative_mode_not_registered"
     PROTOCOL_NOT_REGISTERED = "protocol_not_registered"
     TRANSFER_SCOPE_NOT_REGISTERED = "transfer_scope_not_registered"
+    RUNTIME_CONFIG_NOT_SUPPORTED = "runtime_config_not_supported"
     FEATURE_NOT_SUPPORTED = "feature_not_supported"
 
 
@@ -107,6 +327,9 @@ class PostTransformProfile:
     transfer_scope: PostTransformTransferScope
     transform_abi_id: str
     supported_features: frozenset[PostTransformFeature] = field(default_factory=frozenset)
+    runtime_constraints: PostTransformRuntimeConstraints = field(
+        default_factory=PostTransformRuntimeConstraints
+    )
 
     def __post_init__(self) -> None:
         if not self.profile_id:
@@ -122,6 +345,10 @@ class PostTransformProfile:
         if not isinstance(self.transform_abi_id, str) or not self.transform_abi_id:
             raise ValueError("Post-transform transform_abi_id must be a non-empty string")
         object.__setattr__(self, "supported_features", frozenset(self.supported_features))
+        if not isinstance(self.runtime_constraints, PostTransformRuntimeConstraints):
+            raise TypeError(
+                "Post-transform runtime_constraints must be PostTransformRuntimeConstraints"
+            )
 
 
 @dataclass(frozen=True)
@@ -131,18 +358,41 @@ class PostTransformQualificationDecision:
     reason: PostTransformQualificationReason
     profile: PostTransformProfile | None = None
     unsupported_features: frozenset[PostTransformFeature] = field(default_factory=frozenset)
+    unsupported_runtime_dimensions: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "unsupported_features", frozenset(self.unsupported_features))
+        object.__setattr__(
+            self,
+            "unsupported_runtime_dimensions",
+            frozenset(self.unsupported_runtime_dimensions),
+        )
         if self.reason is PostTransformQualificationReason.QUALIFIED:
             if self.profile is None:
                 raise ValueError("A qualified decision must include its profile")
-            if self.unsupported_features:
-                raise ValueError("A qualified decision cannot include unsupported features")
-        elif self.unsupported_features and (
-            self.reason is not PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
-        ):
-            raise ValueError("Unsupported features require a feature_not_supported decision")
+            if self.unsupported_features or self.unsupported_runtime_dimensions:
+                raise ValueError("A qualified decision cannot include unsupported dimensions")
+        else:
+            if self.unsupported_features and (
+                self.reason is not PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
+            ):
+                raise ValueError("Unsupported features require a feature_not_supported decision")
+            if self.unsupported_runtime_dimensions and (
+                self.reason is not PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED
+            ):
+                raise ValueError(
+                    "Unsupported runtime dimensions require a runtime_config_not_supported decision"
+                )
+            if (
+                self.reason is PostTransformQualificationReason.FEATURE_NOT_SUPPORTED
+                and not self.unsupported_features
+            ):
+                raise ValueError("A feature_not_supported decision must identify features")
+            if (
+                self.reason is PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED
+                and not self.unsupported_runtime_dimensions
+            ):
+                raise ValueError("A runtime_config_not_supported decision must identify dimensions")
 
     @property
     def qualified(self) -> bool:
@@ -171,9 +421,10 @@ class PostTransformProfileRegistry:
         object.__setattr__(self, "profiles", tuple(self.profiles))
 
         profile_ids: set[str] = set()
-        profile_keys: set[
-            tuple[type[nn.Module], str, str, str | None, int, PostTransformTransferScope]
-        ] = set()
+        profile_keys: dict[
+            tuple[type[nn.Module], str, str, str | None, int, PostTransformTransferScope],
+            list[PostTransformProfile],
+        ] = {}
         for profile in self.profiles:
             if profile.profile_id in profile_ids:
                 raise ValueError(f"Duplicate post-transform profile_id: {profile.profile_id!r}")
@@ -187,14 +438,16 @@ class PostTransformProfileRegistry:
                 profile.protocol_version,
                 profile.transfer_scope,
             )
-            if key in profile_keys:
-                raise ValueError(
-                    "Duplicate post-transform profile for "
-                    f"{profile.root_model_class.__name__}/{profile.architecture}/"
-                    f"{profile.model_type}/{profile.speculative_mode or 'target-only'}/"
-                    f"v{profile.protocol_version}/{profile.transfer_scope.value}"
-                )
-            profile_keys.add(key)
+            for existing_profile in profile_keys.setdefault(key, []):
+                if profile.runtime_constraints.overlaps(existing_profile.runtime_constraints):
+                    raise ValueError(
+                        "Duplicate post-transform profile for "
+                        f"{profile.root_model_class.__name__}/{profile.architecture}/"
+                        f"{profile.model_type}/{profile.speculative_mode or 'target-only'}/"
+                        f"v{profile.protocol_version}/{profile.transfer_scope.value}: "
+                        "runtime constraints overlap"
+                    )
+            profile_keys[key].append(profile)
 
     def qualify(
         self,
@@ -206,6 +459,7 @@ class PostTransformProfileRegistry:
         protocol_version: int,
         transfer_scope: PostTransformTransferScope,
         enabled_features: frozenset[PostTransformFeature] = frozenset(),
+        runtime_config: PostTransformRuntimeConfig | None = None,
     ) -> PostTransformQualificationDecision:
         """Match a receiver request against the exact qualified profile set.
 
@@ -218,6 +472,8 @@ class PostTransformProfileRegistry:
             protocol_version: Post-transform transfer protocol version.
             transfer_scope: Component represented by the transfer.
             enabled_features: Optional lifecycle features active for this load.
+            runtime_config: Resolved dtype, quantization, backend, topology, and
+                model-feature dimensions for the concrete load.
 
         Returns:
             A structured qualification decision and the matching profile, when
@@ -276,7 +532,27 @@ class PostTransformProfileRegistry:
                 PostTransformQualificationReason.TRANSFER_SCOPE_NOT_REGISTERED
             )
 
-        profile = scope_profiles[0]
+        runtime_matches = []
+        runtime_mismatches = []
+        for profile in scope_profiles:
+            unsupported_runtime_dimensions = profile.runtime_constraints.unsupported_dimensions(
+                runtime_config
+            )
+            if unsupported_runtime_dimensions:
+                runtime_mismatches.append((profile, unsupported_runtime_dimensions))
+            else:
+                runtime_matches.append(profile)
+        if not runtime_matches:
+            profile, unsupported_runtime_dimensions = min(
+                runtime_mismatches, key=lambda item: len(item[1])
+            )
+            return PostTransformQualificationDecision(
+                PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED,
+                profile=profile,
+                unsupported_runtime_dimensions=unsupported_runtime_dimensions,
+            )
+
+        profile = runtime_matches[0]
         unsupported_features = frozenset(enabled_features) - profile.supported_features
         if unsupported_features:
             return PostTransformQualificationDecision(

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 from torch import nn
-from transformers import LlamaConfig, Qwen2Config
+from transformers import LlamaConfig, Qwen2Config, Qwen3Config
 from utils.post_transform_qualification import (
     PostTransformQualificationCase,
     assert_post_transform_lifecycle_equivalent,
@@ -24,6 +24,7 @@ from tensorrt_llm._torch import distributed as distributed_mod
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models import modeling_llama as modeling_llama_mod
 from tensorrt_llm._torch.models import modeling_qwen as modeling_qwen_mod
+from tensorrt_llm._torch.models import modeling_qwen3 as modeling_qwen3_mod
 from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import MXCheckpointLoader
 from tensorrt_llm._torch.modules import mla as mla_mod
 from tensorrt_llm._torch.modules.linear import Linear, WeightMode
@@ -147,6 +148,10 @@ class _UnqualifiedQwen2ForCausalLM(model_loader_mod.Qwen2ForCausalLM):
     pass
 
 
+class _UnqualifiedQwen3ForCausalLM(model_loader_mod.Qwen3ForCausalLM):
+    pass
+
+
 def _tiny_llama_model(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -253,7 +258,57 @@ def _tiny_qwen2_model(
     return model
 
 
-def _qwen2_runtime_config(**overrides: object) -> PostTransformRuntimeConfig:
+def _tiny_qwen3_model(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    model_class: type[nn.Module] = model_loader_mod.Qwen3ForCausalLM,
+    tp_size: int = 1,
+    rank: int = 0,
+) -> nn.Module:
+    monkeypatch.setattr(torch.cuda, "Stream", lambda *_args, **_kwargs: MagicMock())
+    monkeypatch.setattr(torch.cuda, "Event", lambda *_args, **_kwargs: MagicMock())
+    qwen3_config = Qwen3Config(
+        architectures=["Qwen3ForCausalLM"],
+        attention_bias=False,
+        head_dim=4,
+        hidden_act="silu",
+        hidden_size=16,
+        intermediate_size=32,
+        max_position_embeddings=16,
+        mlp_bias=False,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        num_key_value_heads=2,
+        rms_norm_eps=1e-6,
+        rope_scaling=None,
+        tie_word_embeddings=False,
+        torch_dtype=torch.bfloat16,
+        vocab_size=32,
+    )
+    model = model_class(
+        ModelConfig(
+            pretrained_config=qwen3_config,
+            mapping=mapping_mod.Mapping(
+                world_size=tp_size,
+                rank=rank,
+                tp_size=tp_size,
+            ),
+            max_num_tokens=16,
+            max_seq_len=16,
+        )
+    )
+    with torch.no_grad():
+        for index, parameter in enumerate(model.parameters()):
+            values = torch.arange(
+                parameter.numel(),
+                dtype=torch.float32,
+                device=parameter.device,
+            ).reshape(parameter.shape)
+            parameter.copy_(((values + index) % 17).to(parameter.dtype) / 17)
+    return model
+
+
+def _dense_qwen_runtime_config(**overrides: object) -> PostTransformRuntimeConfig:
     values = {
         "dtype": "bfloat16",
         "quant_algorithm": "none",
@@ -296,7 +351,25 @@ def _qwen2_layout_state(model: nn.Module) -> dict[str, object]:
     }
 
 
-def _qwen2_input_embeddings(model: nn.Module) -> torch.Tensor:
+def _qwen3_layout_state(model: nn.Module) -> dict[str, object]:
+    layer = model.model.layers[0]
+    return {
+        "attention_type": type(layer.self_attn).__name__,
+        "qkv_weight_mode": layer.self_attn.qkv_proj.weights_loading_config.weight_mode,
+        "qkv_weight_shape": tuple(layer.self_attn.qkv_proj.weight.shape),
+        "gate_up_weight_mode": layer.mlp.gate_up_proj.weights_loading_config.weight_mode,
+        "gate_up_weight_shape": tuple(layer.mlp.gate_up_proj.weight.shape),
+        "qkv_bias": layer.self_attn.qkv_proj.bias is not None,
+        "q_norm_weight_shape": tuple(layer.self_attn.q_norm.weight.shape),
+        "k_norm_weight_shape": tuple(layer.self_attn.k_norm.weight.shape),
+        "fuse_qk_norm_rope": layer.self_attn.fuse_qk_norm_rope,
+        "rope_fusion": layer.self_attn.rope_fusion,
+        "rotary_embedding_present": layer.self_attn.rotary_emb is not None,
+        "tied_lm_head": model.lm_head.weight is model.model.embed_tokens.weight,
+    }
+
+
+def _dense_qwen_input_embeddings(model: nn.Module) -> torch.Tensor:
     input_ids = torch.tensor(
         [0, 1, 2],
         dtype=torch.long,
@@ -305,11 +378,11 @@ def _qwen2_input_embeddings(model: nn.Module) -> torch.Tensor:
     return model.model.embed_tokens(input_ids)
 
 
-def _qwen2_embedding_logits(model: nn.Module) -> torch.Tensor:
-    return model.lm_head(_qwen2_input_embeddings(model))
+def _dense_qwen_embedding_logits(model: nn.Module) -> torch.Tensor:
+    return model.lm_head(_dense_qwen_input_embeddings(model))
 
 
-def _qwen2_hidden_states(model: nn.Module) -> torch.Tensor:
+def _dense_qwen_hidden_states(model: nn.Module) -> torch.Tensor:
     qkv_weight = model.model.layers[0].self_attn.qkv_proj.weight
     values = torch.arange(
         3 * model.config.hidden_size,
@@ -319,12 +392,12 @@ def _qwen2_hidden_states(model: nn.Module) -> torch.Tensor:
     return (values % 17).to(qkv_weight.dtype) / 17
 
 
-def _qwen2_fused_qkv_output(model: nn.Module) -> torch.Tensor:
-    return model.model.layers[0].self_attn.qkv_proj(_qwen2_hidden_states(model))
+def _dense_qwen_fused_qkv_output(model: nn.Module) -> torch.Tensor:
+    return model.model.layers[0].self_attn.qkv_proj(_dense_qwen_hidden_states(model))
 
 
-def _qwen2_fused_gate_up_output(model: nn.Module) -> torch.Tensor:
-    return model.model.layers[0].mlp.gate_up_proj(_qwen2_hidden_states(model))
+def _dense_qwen_fused_gate_up_output(model: nn.Module) -> torch.Tensor:
+    return model.model.layers[0].mlp.gate_up_proj(_dense_qwen_hidden_states(model))
 
 
 def _tiny_profile_registry(*, speculative_mode: str | None = None) -> PostTransformProfileRegistry:
@@ -655,9 +728,9 @@ def test_qwen2_dense_profile_qualifies_full_staged_lifecycle() -> None:
         ),
         state_probes=(("layout", _qwen2_layout_state),),
         output_probes=(
-            ("embedding-logits", _qwen2_embedding_logits),
-            ("fused-qkv", _qwen2_fused_qkv_output),
-            ("fused-gate-up", _qwen2_fused_gate_up_output),
+            ("embedding-logits", _dense_qwen_embedding_logits),
+            ("fused-qkv", _dense_qwen_fused_qkv_output),
+            ("fused-gate-up", _dense_qwen_fused_gate_up_output),
         ),
     )
 
@@ -665,7 +738,7 @@ def test_qwen2_dense_profile_qualifies_full_staged_lifecycle() -> None:
 
     assert (
         PostTransformRuntimeConfig.from_model_config(producer.model_config)
-        == _qwen2_runtime_config()
+        == _dense_qwen_runtime_config()
     )
     assert _qwen2_layout_state(producer) == {
         "attention_type": modeling_qwen_mod.QwenAttention.__name__,
@@ -702,8 +775,8 @@ def test_qwen2_dense_profile_qualifies_tp2_rank_lifecycle(
         ),
         state_probes=(("layout", _qwen2_layout_state),),
         output_probes=(
-            ("fused-qkv", _qwen2_fused_qkv_output),
-            ("fused-gate-up", _qwen2_fused_gate_up_output),
+            ("fused-qkv", _dense_qwen_fused_qkv_output),
+            ("fused-gate-up", _dense_qwen_fused_gate_up_output),
         ),
     )
 
@@ -711,13 +784,103 @@ def test_qwen2_dense_profile_qualifies_tp2_rank_lifecycle(
 
     assert PostTransformRuntimeConfig.from_model_config(
         producer.model_config
-    ) == _qwen2_runtime_config(
+    ) == _dense_qwen_runtime_config(
         tp_size=2,
         moe_tp_size=2,
         attention_tp_size=2,
     )
     assert _qwen2_layout_state(producer)["qkv_weight_shape"] == (16, 16)
     assert _qwen2_layout_state(producer)["gate_up_weight_shape"] == (32, 16)
+
+
+def test_qwen3_dense_profile_qualifies_full_staged_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    case = PostTransformQualificationCase(
+        profile_id="qwen3-for-causal-lm-bf16-target-v1",
+        model_factory=lambda: _tiny_qwen3_model(monkeypatch),
+        unqualified_model_factory=lambda: _tiny_qwen3_model(
+            monkeypatch,
+            model_class=_UnqualifiedQwen3ForCausalLM,
+        ),
+        qualify_model=lambda model: ModelLoader._qualify_post_transform_profile(
+            model,
+            speculative_mode=None,
+            loads_draft_weights=False,
+        ),
+        state_probes=(("layout", _qwen3_layout_state),),
+        output_probes=(
+            ("embedding-logits", _dense_qwen_embedding_logits),
+            ("fused-qkv", _dense_qwen_fused_qkv_output),
+            ("fused-gate-up", _dense_qwen_fused_gate_up_output),
+        ),
+    )
+
+    producer, _receiver = assert_post_transform_lifecycle_equivalent(case)
+
+    assert (
+        PostTransformRuntimeConfig.from_model_config(producer.model_config)
+        == _dense_qwen_runtime_config()
+    )
+    assert _qwen3_layout_state(producer) == {
+        "attention_type": modeling_qwen3_mod.Qwen3Attention.__name__,
+        "qkv_weight_mode": WeightMode.FUSED_QKV_LINEAR,
+        "qkv_weight_shape": (32, 16),
+        "gate_up_weight_mode": WeightMode.FUSED_GATE_UP_LINEAR,
+        "gate_up_weight_shape": (64, 16),
+        "qkv_bias": False,
+        "q_norm_weight_shape": (4,),
+        "k_norm_weight_shape": (4,),
+        "fuse_qk_norm_rope": True,
+        "rope_fusion": False,
+        "rotary_embedding_present": True,
+        "tied_lm_head": False,
+    }
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+def test_qwen3_dense_profile_qualifies_tp2_rank_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    rank: int,
+) -> None:
+    monkeypatch.setattr(mapping_mod, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(distributed_mod, "AllReduce", _AllReduceStub)
+    case = PostTransformQualificationCase(
+        profile_id="qwen3-for-causal-lm-bf16-target-v1",
+        model_factory=lambda: _tiny_qwen3_model(
+            monkeypatch,
+            tp_size=2,
+            rank=rank,
+        ),
+        unqualified_model_factory=lambda: _tiny_qwen3_model(
+            monkeypatch,
+            model_class=_UnqualifiedQwen3ForCausalLM,
+            tp_size=2,
+            rank=rank,
+        ),
+        qualify_model=lambda model: ModelLoader._qualify_post_transform_profile(
+            model,
+            speculative_mode=None,
+            loads_draft_weights=False,
+        ),
+        state_probes=(("layout", _qwen3_layout_state),),
+        output_probes=(
+            ("fused-qkv", _dense_qwen_fused_qkv_output),
+            ("fused-gate-up", _dense_qwen_fused_gate_up_output),
+        ),
+    )
+
+    producer, _receiver = assert_post_transform_lifecycle_equivalent(case)
+
+    assert PostTransformRuntimeConfig.from_model_config(
+        producer.model_config
+    ) == _dense_qwen_runtime_config(
+        tp_size=2,
+        moe_tp_size=2,
+        attention_tp_size=2,
+    )
+    assert _qwen3_layout_state(producer)["qkv_weight_shape"] == (16, 16)
+    assert _qwen3_layout_state(producer)["gate_up_weight_shape"] == (32, 16)
 
 
 @pytest.mark.parametrize(
@@ -789,18 +952,38 @@ def test_qwen2_dense_profile_qualifies_tp2_rank_lifecycle(
         pytest.param({"rope_fusion": False}, {"rope_fusion"}, id="unfused-rope"),
     ],
 )
-def test_qwen2_dense_profile_rejects_unqualified_runtime_variants(
+@pytest.mark.parametrize(
+    "root_model_class, architecture, model_type",
+    [
+        pytest.param(
+            model_loader_mod.Qwen2ForCausalLM,
+            "Qwen2ForCausalLM",
+            "qwen2",
+            id="qwen2",
+        ),
+        pytest.param(
+            model_loader_mod.Qwen3ForCausalLM,
+            "Qwen3ForCausalLM",
+            "qwen3",
+            id="qwen3",
+        ),
+    ],
+)
+def test_dense_qwen_profiles_reject_unqualified_runtime_variants(
     overrides: dict[str, object],
     expected_dimensions: set[str],
+    root_model_class: type[nn.Module],
+    architecture: str,
+    model_type: str,
 ) -> None:
     decision = ModelLoader._POST_TRANSFORM_PROFILE_REGISTRY.qualify(
-        root_model_class=model_loader_mod.Qwen2ForCausalLM,
-        architecture="Qwen2ForCausalLM",
-        model_type="qwen2",
+        root_model_class=root_model_class,
+        architecture=architecture,
+        model_type=model_type,
         speculative_mode=None,
         protocol_version=ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
         transfer_scope=PostTransformTransferScope.TARGET_MODEL,
-        runtime_config=_qwen2_runtime_config(**overrides),
+        runtime_config=_dense_qwen_runtime_config(**overrides),
     )
 
     assert not decision.qualified

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -13,17 +13,20 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 from torch import nn
-from transformers import LlamaConfig
+from transformers import LlamaConfig, Qwen2Config
 from utils.post_transform_qualification import (
     PostTransformQualificationCase,
     assert_post_transform_lifecycle_equivalent,
 )
 
+import tensorrt_llm.mapping as mapping_mod
+from tensorrt_llm._torch import distributed as distributed_mod
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models import modeling_llama as modeling_llama_mod
+from tensorrt_llm._torch.models import modeling_qwen as modeling_qwen_mod
 from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import MXCheckpointLoader
 from tensorrt_llm._torch.modules import mla as mla_mod
-from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm._torch.modules.linear import Linear, WeightMode
 from tensorrt_llm._torch.modules.mla import MLA
 from tensorrt_llm._torch.pyexecutor import model_loader as model_loader_mod
 from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
@@ -36,6 +39,7 @@ from tensorrt_llm._torch.weight_sharing import (
     PostTransformProfile,
     PostTransformProfileRegistry,
     PostTransformQualificationReason,
+    PostTransformRuntimeConfig,
     PostTransformTransferScope,
 )
 from tensorrt_llm.llmapi.llm_args import LoadFormat
@@ -63,6 +67,17 @@ class _LinearStub(nn.Module):
 
     def post_load_weights(self):
         pass
+
+
+class _AllReduceStub(nn.Module):
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        super().__init__()
+
+    def uses_nccl_symmetric_memory_window(self) -> bool:
+        return False
+
+    def forward(self, tensor: torch.Tensor, **_kwargs: object) -> torch.Tensor:
+        return tensor
 
 
 def _make_draft_model_config():
@@ -128,6 +143,10 @@ class _UnqualifiedLlamaForCausalLM(model_loader_mod.LlamaForCausalLM):
     pass
 
 
+class _UnqualifiedQwen2ForCausalLM(model_loader_mod.Qwen2ForCausalLM):
+    pass
+
+
 def _tiny_llama_model(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -189,6 +208,125 @@ def _llama_embedding_logits(model: nn.Module) -> torch.Tensor:
     return model.lm_head(model.model.embed_tokens(input_ids))
 
 
+def _tiny_qwen2_model(
+    *,
+    model_class: type[nn.Module] = model_loader_mod.Qwen2ForCausalLM,
+    tp_size: int = 1,
+    rank: int = 0,
+) -> nn.Module:
+    qwen2_config = Qwen2Config(
+        architectures=["Qwen2ForCausalLM"],
+        attention_bias=True,
+        hidden_act="silu",
+        hidden_size=16,
+        intermediate_size=32,
+        max_position_embeddings=16,
+        mlp_bias=False,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        num_key_value_heads=2,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+        torch_dtype=torch.bfloat16,
+        vocab_size=32,
+    )
+    model = model_class(
+        ModelConfig(
+            pretrained_config=qwen2_config,
+            mapping=mapping_mod.Mapping(
+                world_size=tp_size,
+                rank=rank,
+                tp_size=tp_size,
+            ),
+            max_num_tokens=16,
+            max_seq_len=16,
+        )
+    )
+    with torch.no_grad():
+        for index, parameter in enumerate(model.parameters()):
+            values = torch.arange(
+                parameter.numel(),
+                dtype=torch.float32,
+                device=parameter.device,
+            ).reshape(parameter.shape)
+            parameter.copy_(((values + index) % 17).to(parameter.dtype) / 17)
+    return model
+
+
+def _qwen2_runtime_config(**overrides: object) -> PostTransformRuntimeConfig:
+    values = {
+        "dtype": "bfloat16",
+        "quant_algorithm": "none",
+        "kv_cache_quant_algorithm": "none",
+        "layerwise_quantization": False,
+        "force_dynamic_quantization": False,
+        "lora_enabled": False,
+        "sparse_attention_enabled": False,
+        "attention_backend": "TRTLLM",
+        "moe_backend": "CUTLASS",
+        "tp_size": 1,
+        "pp_size": 1,
+        "cp_size": 1,
+        "moe_tp_size": 1,
+        "moe_ep_size": 1,
+        "attention_tp_size": 1,
+        "attention_cp_size": 1,
+        "attention_dp": False,
+        "multi_node": False,
+        "tied_word_embeddings": False,
+        "rope_type": "default",
+        "rope_fusion": True,
+    }
+    values.update(overrides)
+    return PostTransformRuntimeConfig(**values)
+
+
+def _qwen2_layout_state(model: nn.Module) -> dict[str, object]:
+    layer = model.model.layers[0]
+    return {
+        "attention_type": type(layer.self_attn).__name__,
+        "qkv_weight_mode": layer.self_attn.qkv_proj.weights_loading_config.weight_mode,
+        "qkv_weight_shape": tuple(layer.self_attn.qkv_proj.weight.shape),
+        "gate_up_weight_mode": layer.mlp.gate_up_proj.weights_loading_config.weight_mode,
+        "gate_up_weight_shape": tuple(layer.mlp.gate_up_proj.weight.shape),
+        "qkv_bias": layer.self_attn.qkv_proj.bias is not None,
+        "rope_fusion": layer.self_attn.rope_fusion,
+        "rotary_embedding": layer.self_attn.rotary_emb,
+        "tied_lm_head": model.lm_head.weight is model.model.embed_tokens.weight,
+    }
+
+
+def _qwen2_input_embeddings(model: nn.Module) -> torch.Tensor:
+    input_ids = torch.tensor(
+        [0, 1, 2],
+        dtype=torch.long,
+        device=model.model.embed_tokens.weight.device,
+    )
+    return model.model.embed_tokens(input_ids)
+
+
+def _qwen2_embedding_logits(model: nn.Module) -> torch.Tensor:
+    return model.lm_head(_qwen2_input_embeddings(model))
+
+
+def _qwen2_hidden_states(model: nn.Module) -> torch.Tensor:
+    qkv_weight = model.model.layers[0].self_attn.qkv_proj.weight
+    values = torch.arange(
+        3 * model.config.hidden_size,
+        dtype=torch.float32,
+        device=qkv_weight.device,
+    ).reshape(3, model.config.hidden_size)
+    return (values % 17).to(qkv_weight.dtype) / 17
+
+
+def _qwen2_fused_qkv_output(model: nn.Module) -> torch.Tensor:
+    return model.model.layers[0].self_attn.qkv_proj(_qwen2_hidden_states(model))
+
+
+def _qwen2_fused_gate_up_output(model: nn.Module) -> torch.Tensor:
+    return model.model.layers[0].mlp.gate_up_proj(_qwen2_hidden_states(model))
+
+
 def _tiny_profile_registry(*, speculative_mode: str | None = None) -> PostTransformProfileRegistry:
     return PostTransformProfileRegistry(
         profiles=(
@@ -233,6 +371,7 @@ def _make_loader(monkeypatch, *, events, spec_config=None):
     monkeypatch.setattr(model_loader_mod, "timing", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(model_loader_mod, "maybe_create_moe_load_balancer", _moe_context)
     monkeypatch.setattr(model_loader_mod, "MetaInitMode", lambda: nullcontext())
+
     # These tests stub ModelConfig, while SourceIdentity has dedicated
     # coverage. Keep this file focused on ModelLoader MX branch behavior.
 
@@ -500,6 +639,173 @@ def test_default_profile_qualifies_real_tiny_llama_lifecycle(
     )
 
     assert_post_transform_lifecycle_equivalent(case)
+
+
+def test_qwen2_dense_profile_qualifies_full_staged_lifecycle() -> None:
+    case = PostTransformQualificationCase(
+        profile_id="qwen2-for-causal-lm-bf16-target-v1",
+        model_factory=_tiny_qwen2_model,
+        unqualified_model_factory=lambda: _tiny_qwen2_model(
+            model_class=_UnqualifiedQwen2ForCausalLM
+        ),
+        qualify_model=lambda model: ModelLoader._qualify_post_transform_profile(
+            model,
+            speculative_mode=None,
+            loads_draft_weights=False,
+        ),
+        state_probes=(("layout", _qwen2_layout_state),),
+        output_probes=(
+            ("embedding-logits", _qwen2_embedding_logits),
+            ("fused-qkv", _qwen2_fused_qkv_output),
+            ("fused-gate-up", _qwen2_fused_gate_up_output),
+        ),
+    )
+
+    producer, _receiver = assert_post_transform_lifecycle_equivalent(case)
+
+    assert (
+        PostTransformRuntimeConfig.from_model_config(producer.model_config)
+        == _qwen2_runtime_config()
+    )
+    assert _qwen2_layout_state(producer) == {
+        "attention_type": modeling_qwen_mod.QwenAttention.__name__,
+        "qkv_weight_mode": WeightMode.FUSED_QKV_LINEAR,
+        "qkv_weight_shape": (32, 16),
+        "gate_up_weight_mode": WeightMode.FUSED_GATE_UP_LINEAR,
+        "gate_up_weight_shape": (64, 16),
+        "qkv_bias": True,
+        "rope_fusion": True,
+        "rotary_embedding": None,
+        "tied_lm_head": False,
+    }
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+def test_qwen2_dense_profile_qualifies_tp2_rank_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    rank: int,
+) -> None:
+    monkeypatch.setattr(mapping_mod, "mpi_disabled", lambda: False)
+    monkeypatch.setattr(distributed_mod, "AllReduce", _AllReduceStub)
+    case = PostTransformQualificationCase(
+        profile_id="qwen2-for-causal-lm-bf16-target-v1",
+        model_factory=lambda: _tiny_qwen2_model(tp_size=2, rank=rank),
+        unqualified_model_factory=lambda: _tiny_qwen2_model(
+            model_class=_UnqualifiedQwen2ForCausalLM,
+            tp_size=2,
+            rank=rank,
+        ),
+        qualify_model=lambda model: ModelLoader._qualify_post_transform_profile(
+            model,
+            speculative_mode=None,
+            loads_draft_weights=False,
+        ),
+        state_probes=(("layout", _qwen2_layout_state),),
+        output_probes=(
+            ("fused-qkv", _qwen2_fused_qkv_output),
+            ("fused-gate-up", _qwen2_fused_gate_up_output),
+        ),
+    )
+
+    producer, _receiver = assert_post_transform_lifecycle_equivalent(case)
+
+    assert PostTransformRuntimeConfig.from_model_config(
+        producer.model_config
+    ) == _qwen2_runtime_config(
+        tp_size=2,
+        moe_tp_size=2,
+        attention_tp_size=2,
+    )
+    assert _qwen2_layout_state(producer)["qkv_weight_shape"] == (16, 16)
+    assert _qwen2_layout_state(producer)["gate_up_weight_shape"] == (32, 16)
+
+
+@pytest.mark.parametrize(
+    "overrides, expected_dimensions",
+    [
+        pytest.param({"dtype": "float16"}, {"dtype"}, id="fp16"),
+        pytest.param(
+            {"quant_algorithm": "FP8"},
+            {"quant_algorithm"},
+            id="weight-quantization",
+        ),
+        pytest.param(
+            {"kv_cache_quant_algorithm": "FP8"},
+            {"kv_cache_quant_algorithm"},
+            id="kv-cache-quantization",
+        ),
+        pytest.param(
+            {"layerwise_quantization": True},
+            {"layerwise_quantization"},
+            id="layerwise-quantization",
+        ),
+        pytest.param(
+            {"force_dynamic_quantization": True},
+            {"force_dynamic_quantization"},
+            id="dynamic-quantization",
+        ),
+        pytest.param({"lora_enabled": True}, {"lora_enabled"}, id="lora"),
+        pytest.param(
+            {"sparse_attention_enabled": True},
+            {"sparse_attention_enabled"},
+            id="sparse-attention",
+        ),
+        pytest.param(
+            {"attention_backend": "FLASHINFER"},
+            {"attention_backend"},
+            id="attention-backend",
+        ),
+        pytest.param({"tp_size": 4}, {"tp_size"}, id="tp4"),
+        pytest.param({"pp_size": 2}, {"pp_size"}, id="pipeline-parallel"),
+        pytest.param({"cp_size": 2}, {"cp_size"}, id="context-parallel"),
+        pytest.param(
+            {"moe_tp_size": 4},
+            {"moe_tp_size"},
+            id="moe-tensor-parallel",
+        ),
+        pytest.param({"moe_ep_size": 2}, {"moe_ep_size"}, id="expert-parallel"),
+        pytest.param(
+            {"attention_tp_size": 4},
+            {"attention_tp_size"},
+            id="attention-tensor-parallel",
+        ),
+        pytest.param(
+            {"attention_cp_size": 2},
+            {"attention_cp_size"},
+            id="attention-context-parallel",
+        ),
+        pytest.param(
+            {"attention_dp": True},
+            {"attention_dp"},
+            id="attention-dp",
+        ),
+        pytest.param({"multi_node": True}, {"multi_node"}, id="multi-node"),
+        pytest.param(
+            {"tied_word_embeddings": True},
+            {"tied_word_embeddings"},
+            id="tied-embeddings",
+        ),
+        pytest.param({"rope_type": "yarn"}, {"rope_type"}, id="yarn"),
+        pytest.param({"rope_fusion": False}, {"rope_fusion"}, id="unfused-rope"),
+    ],
+)
+def test_qwen2_dense_profile_rejects_unqualified_runtime_variants(
+    overrides: dict[str, object],
+    expected_dimensions: set[str],
+) -> None:
+    decision = ModelLoader._POST_TRANSFORM_PROFILE_REGISTRY.qualify(
+        root_model_class=model_loader_mod.Qwen2ForCausalLM,
+        architecture="Qwen2ForCausalLM",
+        model_type="qwen2",
+        speculative_mode=None,
+        protocol_version=ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        runtime_config=_qwen2_runtime_config(**overrides),
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED
+    assert decision.unsupported_runtime_dimensions == frozenset(expected_dimensions)
 
 
 def test_separate_draft_model_is_not_qualified_by_target_only_profile(

--- a/tests/unittest/_torch/weight_sharing/test_post_transform_profiles.py
+++ b/tests/unittest/_torch/weight_sharing/test_post_transform_profiles.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
+import torch
 from torch import nn
 
 from tensorrt_llm._torch.weight_sharing import (
@@ -25,6 +27,8 @@ from tensorrt_llm._torch.weight_sharing import (
     PostTransformProfile,
     PostTransformProfileRegistry,
     PostTransformQualificationReason,
+    PostTransformRuntimeConfig,
+    PostTransformRuntimeConstraints,
     PostTransformTransferScope,
 )
 
@@ -48,6 +52,7 @@ def _profile(
     transform_abi_id: str = LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
     transfer_scope: PostTransformTransferScope = PostTransformTransferScope.TARGET_MODEL,
     supported_features: frozenset[PostTransformFeature] = frozenset(),
+    runtime_constraints: PostTransformRuntimeConstraints | None = None,
 ) -> PostTransformProfile:
     return PostTransformProfile(
         profile_id=profile_id,
@@ -59,7 +64,36 @@ def _profile(
         transform_abi_id=transform_abi_id,
         transfer_scope=transfer_scope,
         supported_features=supported_features,
+        runtime_constraints=runtime_constraints or PostTransformRuntimeConstraints(),
     )
+
+
+def _runtime_config(**overrides: object) -> PostTransformRuntimeConfig:
+    values = {
+        "dtype": "bfloat16",
+        "quant_algorithm": "none",
+        "kv_cache_quant_algorithm": "none",
+        "layerwise_quantization": False,
+        "force_dynamic_quantization": False,
+        "lora_enabled": False,
+        "sparse_attention_enabled": False,
+        "attention_backend": "TRTLLM",
+        "moe_backend": "CUTLASS",
+        "tp_size": 1,
+        "pp_size": 1,
+        "cp_size": 1,
+        "moe_tp_size": 1,
+        "moe_ep_size": 1,
+        "attention_tp_size": 1,
+        "attention_cp_size": 1,
+        "attention_dp": False,
+        "multi_node": False,
+        "tied_word_embeddings": False,
+        "rope_type": "default",
+        "rope_fusion": True,
+    }
+    values.update(overrides)
+    return PostTransformRuntimeConfig(**values)
 
 
 def test_exact_profile_is_qualified() -> None:
@@ -209,6 +243,201 @@ def test_explicitly_supported_optional_feature_is_qualified() -> None:
     assert decision.profile is profile
 
 
+def test_runtime_constraints_qualify_only_declared_rows() -> None:
+    constraints = PostTransformRuntimeConstraints(
+        dtypes=frozenset({"bfloat16"}),
+        tp_sizes=frozenset({1, 2}),
+        rope_types=frozenset({"default"}),
+    )
+    profile = _profile(runtime_constraints=constraints)
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        runtime_config=_runtime_config(tp_size=2, moe_tp_size=2, attention_tp_size=2),
+    )
+
+    assert decision.qualified
+    assert decision.profile is profile
+
+
+@pytest.mark.parametrize(
+    "overrides, expected_dimension",
+    [
+        pytest.param({"dtype": "float16"}, "dtype", id="dtype"),
+        pytest.param({"tp_size": 4}, "tp_size", id="tp-size"),
+        pytest.param({"rope_type": "yarn"}, "rope_type", id="rope-type"),
+    ],
+)
+def test_runtime_constraints_report_unsupported_dimension(
+    overrides: dict[str, object],
+    expected_dimension: str,
+) -> None:
+    profile = _profile(
+        runtime_constraints=PostTransformRuntimeConstraints(
+            dtypes=frozenset({"bfloat16"}),
+            tp_sizes=frozenset({1, 2}),
+            rope_types=frozenset({"default"}),
+        )
+    )
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        runtime_config=replace(_runtime_config(), **overrides),
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED
+    assert decision.profile is profile
+    assert decision.unsupported_runtime_dimensions == frozenset({expected_dimension})
+
+
+def test_constrained_profile_rejects_missing_runtime_config() -> None:
+    profile = _profile(
+        runtime_constraints=PostTransformRuntimeConstraints(
+            dtypes=frozenset({"bfloat16"}),
+            tp_sizes=frozenset({1, 2}),
+        )
+    )
+    registry = PostTransformProfileRegistry((profile,))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+    )
+
+    assert not decision.qualified
+    assert decision.reason is PostTransformQualificationReason.RUNTIME_CONFIG_NOT_SUPPORTED
+    assert decision.unsupported_runtime_dimensions == frozenset({"dtype", "tp_size"})
+
+
+def test_registry_selects_disjoint_runtime_profile() -> None:
+    bf16_profile = _profile(
+        runtime_constraints=PostTransformRuntimeConstraints(dtypes=frozenset({"bfloat16"}))
+    )
+    fp16_profile = _profile(
+        profile_id="model-fp16-target-v1",
+        runtime_constraints=PostTransformRuntimeConstraints(dtypes=frozenset({"float16"})),
+    )
+    registry = PostTransformProfileRegistry((bf16_profile, fp16_profile))
+
+    decision = registry.qualify(
+        root_model_class=_Model,
+        architecture="ModelForCausalLM",
+        model_type="model",
+        speculative_mode=None,
+        protocol_version=1,
+        transfer_scope=PostTransformTransferScope.TARGET_MODEL,
+        runtime_config=_runtime_config(dtype="float16"),
+    )
+
+    assert decision.qualified
+    assert decision.profile is fp16_profile
+
+
+def test_registry_rejects_overlapping_runtime_profiles() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Duplicate post-transform profile for .*runtime constraints overlap",
+    ):
+        PostTransformProfileRegistry(
+            (
+                _profile(
+                    runtime_constraints=PostTransformRuntimeConstraints(
+                        dtypes=frozenset({"bfloat16"}),
+                        tp_sizes=frozenset({1, 2}),
+                    )
+                ),
+                _profile(
+                    profile_id="overlapping-profile",
+                    runtime_constraints=PostTransformRuntimeConstraints(
+                        dtypes=frozenset({"bfloat16"}),
+                        tp_sizes=frozenset({2, 4}),
+                    ),
+                ),
+            )
+        )
+
+
+def test_runtime_config_is_captured_from_final_model_config() -> None:
+    model_config = SimpleNamespace(
+        pretrained_config=SimpleNamespace(
+            torch_dtype=torch.bfloat16,
+            tie_word_embeddings=False,
+            rope_scaling={"rope_type": "default"},
+            disable_fuse_rope=False,
+        ),
+        quant_config=SimpleNamespace(
+            quant_algo=None,
+            kv_cache_quant_algo=None,
+        ),
+        quant_config_dict=None,
+        force_dynamic_quantization=False,
+        lora_config=None,
+        sparse_attention_config=None,
+        attn_backend="TRTLLM",
+        moe_backend="CUTLASS",
+        mapping=SimpleNamespace(
+            world_size=2,
+            gpus_per_node=8,
+            tp_size=2,
+            pp_size=1,
+            cp_size=1,
+            moe_tp_size=2,
+            moe_ep_size=1,
+            attn_tp_size=2,
+            attn_cp_size=1,
+            enable_attention_dp=False,
+        ),
+    )
+
+    assert PostTransformRuntimeConfig.from_model_config(model_config) == _runtime_config(
+        tp_size=2, moe_tp_size=2, attention_tp_size=2
+    )
+
+
+def test_runtime_config_distinguishes_missing_from_unquantized() -> None:
+    unquantized = PostTransformRuntimeConfig.from_model_config(
+        SimpleNamespace(quant_config=SimpleNamespace(quant_algo=None, kv_cache_quant_algo=None))
+    )
+    missing = PostTransformRuntimeConfig.from_model_config(
+        SimpleNamespace(quant_config=SimpleNamespace())
+    )
+
+    assert unquantized.quant_algorithm == "none"
+    assert unquantized.kv_cache_quant_algorithm == "none"
+    assert missing.quant_algorithm is None
+    assert missing.kv_cache_quant_algorithm is None
+
+
+def test_runtime_config_detects_multi_node_topology() -> None:
+    runtime_config = PostTransformRuntimeConfig.from_model_config(
+        SimpleNamespace(
+            mapping=SimpleNamespace(
+                world_size=2,
+                gpus_per_node=1,
+            )
+        )
+    )
+
+    assert runtime_config.multi_node is True
+
+
 def test_registry_rejects_duplicate_profile_id() -> None:
     with pytest.raises(ValueError, match="Duplicate post-transform profile_id"):
         PostTransformProfileRegistry(
@@ -225,6 +454,11 @@ def test_registry_rejects_duplicate_profile_id() -> None:
 def test_registry_rejects_duplicate_match_key() -> None:
     with pytest.raises(ValueError, match="Duplicate post-transform profile for"):
         PostTransformProfileRegistry((_profile(), _profile(profile_id="other-profile-id")))
+
+
+def test_runtime_constraints_reject_empty_allowed_values() -> None:
+    with pytest.raises(ValueError, match="runtime constraint dtypes"):
+        PostTransformRuntimeConstraints(dtypes=frozenset())
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -36,6 +36,7 @@ from _source_identity_fakes import (
 from tensorrt_llm._torch.weight_sharing import (
     LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
     QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
     IdentityCheckPolicy,
     SourceIdentity,
     SourceIdentityMismatchError,
@@ -75,6 +76,7 @@ def test_from_model_config_requires_one_artifact_source() -> None:
     [
         LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
         QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+        QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
     ],
 )
 def test_from_model_config_binds_transform_abi(transform_abi_id: str) -> None:

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -35,6 +35,7 @@ from _source_identity_fakes import (
 
 from tensorrt_llm._torch.weight_sharing import (
     LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
+    QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
     IdentityCheckPolicy,
     SourceIdentity,
     SourceIdentityMismatchError,
@@ -69,14 +70,21 @@ def test_from_model_config_requires_one_artifact_source() -> None:
         )
 
 
-def test_from_model_config_binds_transform_abi() -> None:
+@pytest.mark.parametrize(
+    "transform_abi_id",
+    [
+        LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
+        QWEN2_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1,
+    ],
+)
+def test_from_model_config_binds_transform_abi(transform_abi_id: str) -> None:
     identity = SourceIdentity.from_model_config(
         FakeModelConfig(),
         artifact_identity=make_artifact_identity(),
-        transform_abi_id=LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1,
+        transform_abi_id=transform_abi_id,
     )
 
-    assert identity.transform_abi_id == LLAMA_POST_TRANSFORM_LAYOUT_ABI_V1
+    assert identity.transform_abi_id == transform_abi_id
 
 
 @pytest.mark.parametrize("transform_abi_id", ["", 1])


### PR DESCRIPTION
## Summary

- Add a fail-closed post-transform qualification profile for Qwen3 dense target models.
- Reuse the finalized dense BF16 runtime support matrix from #16974 while assigning Qwen3 a distinct transform-layout ABI and realized RoPE constraint.
- Qualify the Q/K-normalized attention lifecycle, fused QKV and gate-up layouts, default fused QK-norm/RoPE path, and untied language-model head.
- Add TP1 and rank-local TP2 lifecycle coverage, shared runtime rejection coverage, source-identity ABI coverage, and support documentation.
- Extend the ModelExpress donor/receiver CI harness with Qwen2-7B-Instruct and Qwen3-8B TP1 and TP2 cases.
- Rebase onto `main` after #16974 and #17222 merged, so this PR now contains only its Qwen3 and shared CI-coverage delta.

## Qualified Scope

- Exact root/config identity: `Qwen3ForCausalLM` / `qwen3`
- Target-model post-transform transfer
- Dense BF16 with unquantized weights and KV cache
- TRTLLM attention with default fused QK-norm/RoPE
- TP1 and TP2
- PP1 and CP1
- Untied embeddings and no speculative mode or separately loaded draft model

The dense root does not consume MoE-only backend or partition settings, so the profile does not constrain them; `SourceIdentity` still requires donor and receiver configurations to match. Unsupported combinations fail closed, including FP16, quantization, alternate attention backends, TP greater than 2, PP/CP expansion, LoRA, sparse attention, attention data parallelism, multi-node execution, tied embeddings, YaRN, disabling the default fused QK-norm/RoPE path, and speculative decoding.

## Validation

- Added full-load versus staged-load lifecycle equivalence coverage for Qwen3 dense TP1 and both TP2 ranks.
- Added Q/K norm, fused-layout, transform-guard, parameter/buffer, deterministic output, and unregistered-root negative coverage.
- Extended shared dense runtime rejection and MoE-only-dimension coverage plus SourceIdentity transform-ABI binding checks to Qwen3.
- Added Qwen2 and Qwen3 TP1 cases to `DGX_H100-2_GPUs-PyTorch-ModelExpress-1` and TP2 cases to `DGX_H100-4_GPUs-PyTorch-ModelExpress-OnDemand-1`.
- Changed-file pre-commit hooks: passed.
- Test-list duplicate and AST validation: passed (2,062 unique entries).
- Test-to-stage mapping for all four Qwen cases: passed.
- Python syntax compilation for all changed Python files: passed.
- Focused PyTorch unit tests: pending in a Linux TensorRT-LLM runtime because the local Python environment lacks TensorRT-LLM test dependencies.
- Real Qwen2/Qwen3 ModelExpress baseline/donor/receiver and no-disk GPU validation: pending CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Adds a fail-closed Qwen3 dense BF16 post-transform profile.
- Supports unquantized weights and KV cache, TP1/TP2, PP1, CP1, untied embeddings, and the required QK-norm/RoPE configuration.
- Rejects unsupported runtime variants, including FP16, quantization, alternate attention backends, expanded parallelism, LoRA, sparse attention, tied embeddings, YaRN, and speculative decoding.
- Adds and exports `QWEN3_DENSE_POST_TRANSFORM_LAYOUT_ABI_V1`.
- Updates ModelExpress documentation and adds Qwen2/Qwen3 H100 TP1/TP2 coverage.
- Pre-commit hooks, test-list validation, stage mapping, and Python syntax compilation passed.
- Focused runtime tests and GPU ModelExpress validation remain pending.
- ModelExpress helper runs 67559, 67926, 67992, and 68869 passed, but their main pipelines failed. Runs 68014 and 68063 failed in both helper and main pipelines. Run 68382 was aborted. Investigate these failures before rerunning CI.
- Configuration values and test-list entries are consistent. No duplicate entries or invalid paths were identified.

## QA Engineer Review

### Added or modified test functions

- `tests/unittest/_torch/executor/test_model_loader_mx.py`
  - Added `test_qwen3_dense_profile_qualifies_full_staged_lifecycle`.
  - Added `test_qwen3_dense_profile_qualifies_tp2_rank_lifecycle`.
  - Modified `test_bf16_dense_profiles_reject_unqualified_runtime_variants`.
  - Modified `test_bf16_dense_profiles_reject_wrong_realized_rope_fusion`.
  - Updated existing Qwen2 lifecycle tests to use generalized dense-Qwen helpers.
- `tests/unittest/_torch/weight_sharing/test_source_identity.py`
  - Modified `test_from_model_config_binds_transform_abi` to include the Qwen3 ABI.
- `tests/integration/defs/model_express/test_model_express.py`
  - Extended `test_mx_donor_receiver` with Qwen2 and Qwen3 TP1/TP2 variants.

### Test-list coverage

- `tests/integration/test_lists/test-db/l0_model_express.yml` covers:
  - `test_mx_donor_receiver[qwen2-bf16-tp1]`
  - `test_mx_donor_receiver[qwen3-bf16-tp1]`
  - `test_mx_donor_receiver[qwen2-bf16-tp2]`
  - `test_mx_donor_receiver[qwen3-bf16-tp2]`
- The modified unit tests are not listed in the provided CI test-list file.
- Verdict: needs follow-up because focused runtime results are unavailable and the reported ModelExpress pipelines failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->