### PR TITLE
[None][fix] Also skip the corrupt FC1 MxE4m3_MxE2m1MxE4m3 splitK cubins

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/KernelRunner.cpp
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/KernelRunner.cpp
@@ -112,7 +112,21 @@ static inline bool skipQuirks(BatchedGemmConfig const& config)
         && strstr(config.mFunctionName, "Bfloat16_MxE2m1MxE4m3") != nullptr
         && strstr(config.mFunctionName, "splitK") != nullptr;
 
-    return hang_c2x1_bM || hang_schedS_tmaOob_tileN64 || corrupt_splitk_fc2;
+    // FC1 flavor of the same MxE2m1MxE4m3 splitK family. The filter above
+    // catches only FC2 (bf16 output); the gated FC1 emits the fp8
+    // intermediate, so its output dtype is MxE4m3 and its kernel names start
+    // bmm_MxE4m3_MxE2m1MxE4m3_..._splitK2 - they escaped the FC2 filter.
+    // Instrumented Kimi K3 disagg GEN decode runs (M=2-4 microbatches)
+    // reproduced the identical single-rank whole-local-output corruption with
+    // these FC1 splitK2 cubins dispatched at the failing shapes, after all
+    // transfer/reuse/quant/routing suspects were eliminated by direct
+    // experiment. Same cross-CTA split-K reduction scheme, same skip
+    // rationale, same removal note as the FC2 family above.
+    bool const corrupt_splitk_fc1 = config.mFunctionName != nullptr
+        && strstr(config.mFunctionName, "MxE4m3_MxE2m1MxE4m3") != nullptr
+        && strstr(config.mFunctionName, "splitK") != nullptr;
+
+    return hang_c2x1_bM || hang_schedS_tmaOob_tileN64 || corrupt_splitk_fc2 || corrupt_splitk_fc1;
 }
 
 void setProblemDimensions(BatchedGemmData& gemmData, bool transposeMmaOutput, int32_t m, int32_t n, int32_t k,


### PR DESCRIPTION
## Description

#17105 skips the corrupt `Bfloat16_MxE2m1MxE4m3` splitK batched-GEMM cubins, but that name filter only covers the FC2 flavor (bf16 output). The gated FC1 kernels of the same family emit the fp8 intermediate, so their names start `bmm_MxE4m3_MxE2m1MxE4m3_..._splitK2` and escaped the filter.

These FC1 splitK cubins reproduce the same failure as the FC2 family: at small-M decode batches (M=2-4) a single rank's local MoE output intermittently turns entirely non-finite with verified-finite inputs, which then propagates to all ranks through the MoE combine and crashes serving on the sampler NaN guard. In-situ kernel-name logging (`TLLM_BATCHED_GEMM_PRINT_NAME=1`) confirmed these cubins dispatching at the failing shapes.

This adds an explicit second filter entry for the FC1 flavor, keeping the two families separately documented. Same removal note applies once repaired cubin payloads ship.

## Test Coverage

- Stress reproducer (Kimi K3 TEP16, sustained 4-way decode)
- GSM8K (Kimi K3, stock examples/kimi_k3 config) with this change: 96.74 flexible / 96.66 strict (±0.49) — unchanged from the feat/kimi_k3 reference band.