### PR TITLE
[https://nvbugs/6535874][fix] Size DFlash/DSpark worker slot buffers from num_seq_slots

### DIFF
--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -215,7 +215,12 @@ class DFlashWorker(SpecWorkerBase):
         if self._ctx_buf_inited:
             return
 
-        max_batch = spec_metadata.max_num_requests
+        # Worker-owned and allocated once, then reused for every later batch
+        # shape, so this must span the full seq-slot pool. max_num_requests is
+        # shrunk to the captured graph bucket by create_cuda_graph_metadata,
+        # which would pin the pool to whichever bucket drafts first and leave
+        # _dummy_slot aliasing a live request's row.
+        max_batch = spec_metadata.num_seq_slots or spec_metadata.max_num_requests
 
         # Prefer runtime max_seq_len over max_position_embeddings: YaRN
         # models advertise 100k+ positions, which would OOM the ctx buffer

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -258,10 +258,12 @@ class DFlashWorker(SpecWorkerBase):
             return
 
         # Worker-owned and allocated once, then reused for every later batch
-        # shape, so this must span the full seq-slot pool. max_num_requests is
-        # shrunk to the captured graph bucket by create_cuda_graph_metadata,
-        # which would pin the pool to whichever bucket drafts first and leave
-        # _dummy_slot aliasing a live request's row.
+        # shape, so this must span a stable upper bound. _free_slots assigns
+        # rows by request ID and only needs the pre-graph max_num_requests;
+        # num_seq_slots is the surviving proxy after max_num_requests is
+        # narrowed to a captured graph bucket. Under disagg-ADP it can be
+        # 2 * max_num_requests, so this deliberately overallocates the large
+        # context K/V buffers to keep one safe capacity across graph buckets.
         max_batch = spec_metadata.num_seq_slots
 
         # Prefer runtime max_seq_len over max_position_embeddings: YaRN

--- a/tensorrt_llm/_torch/speculative/dspark.py
+++ b/tensorrt_llm/_torch/speculative/dspark.py
@@ -266,7 +266,10 @@ class DSparkWorker(SpecWorkerBase):
 
         if self._win_inited:
             return
-        max_batch = spec_metadata.max_num_requests
+        # Worker-owned and allocated once, so this must span the full seq-slot
+        # pool rather than max_num_requests, which create_cuda_graph_metadata
+        # shrinks to the captured graph bucket (see the DFlash counterpart).
+        max_batch = spec_metadata.num_seq_slots or spec_metadata.max_num_requests
         num_stages = draft_model.num_stages
         self._win = int(draft_model._attn_params["window_size"])
         head_dim = int(draft_model._attn_params["head_dim"])

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -206,6 +206,7 @@ def get_spec_metadata(spec_config,
             dtype=model_config.torch_dtype,
             use_rejection_sampling=use_rejection_sampling,
             vocab_size=vocab_size,
+            num_seq_slots=num_seq_slots,
             draft_vocab_size=draft_vocab_size,
         )
     if spec_config.spec_dec_mode.is_dspark():
@@ -221,6 +222,7 @@ def get_spec_metadata(spec_config,
             dtype=model_config.torch_dtype,
             use_rejection_sampling=use_rejection_sampling,
             vocab_size=vocab_size,
+            num_seq_slots=num_seq_slots,
             draft_vocab_size=draft_vocab_size,
         )
     if spec_config.spec_dec_mode.is_draft_target_one_model():

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -406,8 +406,6 @@ unittest/_torch/ray_orchestrator/multi_gpu/test_llm_update_weights_multi_gpu.py:
 unittest/_torch/sampler/test_beam_search.py::test_beam_search_e2e[multi_process-TRTLLMSampler-cuda_graph_and_overlap-None-1-1-True-True-False] SKIP (https://nvbugs/6463819)
 unittest/_torch/sampler/test_trtllm_sampler.py::test_trtllm_sampler_best_of_with_logprobs SKIP (https://nvbugs/6487837)
 unittest/_torch/speculative/hw_agnostic/test_advanced_sampling_mode.py::test_no_topk_matches_full[0.9] SKIP (https://nvbugs/6550099)
-unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b[False] SKIP (https://nvbugs/6535767)
-unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b[True] SKIP (https://nvbugs/6535767)
 unittest/_torch/speculative/hw_agnostic/test_ngram.py::test_llama_ngram[True-True-TRTLLM] SKIP (https://nvbugs/6507102)
 unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py::test_fp8_rowwise_linear[dtype1] SKIP (https://nvbugs/6301807)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_no_autotune[use_score_as_input-RoutingDSv3-swiglu-1024-1024-1] SKIP (https://nvbugs/5908070)

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
@@ -168,8 +168,9 @@ def test_worker_graph_bucket_uses_full_seq_slot_pool():
     )
 
     assert metadata.max_num_requests == 2 < metadata.num_seq_slots
-    assert worker._kv_windows.shape == (6, 1, 8, 4)
-    assert worker._ctx_len.shape == (6,)
+    num_slots = num_seq_slots + 1
+    assert worker._kv_windows.shape[0] == num_slots
+    assert worker._ctx_len.shape[0] == num_slots
     assert worker._batch_to_slot.shape == (num_seq_slots,)
     assert worker._scratch_slot == num_seq_slots
     assert list(worker._free_slots) == list(range(num_seq_slots))

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dspark_worker.py
@@ -192,13 +192,12 @@ def test_seed_context_windows_preserves_state_across_prefill_chunks():
 
     worker = _make_worker()
     draft_model = DraftModel()
-    metadata = types.SimpleNamespace(
-        max_num_requests=1,
-        request_ids=[100],
-        get_hidden_states=lambda _num_tokens: torch.zeros(
-            3, HIDDEN * NCAP, device="cuda", dtype=torch.bfloat16
-        ),
-    )
+    # Real metadata rather than a bare SimpleNamespace: _lazy_init reads
+    # slot-pool sizing fields off it, and a sparse stub silently omits any
+    # field added later. Its own get_hidden_states serves the per-chunk
+    # captures, sized by the total_target_tokens passed below.
+    metadata = _make_metadata(max_num_requests=1)
+    metadata.request_ids = [100]
     worker._lazy_init(draft_model, metadata)
 
     first_chunk = types.SimpleNamespace(num_contexts=1, _seq_lens=[3])
@@ -208,9 +207,6 @@ def test_seed_context_windows_preserves_state_across_prefill_chunks():
     slot = worker._req_to_slot[100]
     assert int(worker._ctx_len[slot]) == 3
 
-    metadata.get_hidden_states = lambda _num_tokens: torch.zeros(
-        2, HIDDEN * NCAP, device="cuda", dtype=torch.bfloat16
-    )
     second_chunk = types.SimpleNamespace(num_contexts=1, _seq_lens=[2])
     worker._seed_context_windows(
         draft_model, metadata, second_chunk, torch.tensor([[3, 4]], device="cuda"), 2


### PR DESCRIPTION
## Summary

- **Root cause:** `DFlashWorker._lazy_init_ctx_buffers` and `DSparkWorker._lazy_init` allocated worker-owned context/window buffers once from `spec_metadata.max_num_requests`. `create_cuda_graph_metadata` shrinks that field to the captured graph bucket, so whichever bucket drafted first could permanently undersize the slot pool and make the dummy/scratch row overlap a live request slot.
- **Fix:** `num_seq_slots` is threaded through `get_spec_metadata` for DFlash and DSpark. Both metadata classes normalize its default in `__post_init__`, so copied graph metadata retains the original slot-pool capacity; both workers size their persistent buffers from that resolved value.
- **Tests:** CUDA regression coverage builds a graph bucket smaller than the persistent sequence-slot pool and verifies buffer dimensions, live-slot allocation, and dummy/scratch-slot exclusion. DSpark tests now use real metadata where slot-pool sizing fields matter.
- The independently reported SSM state-pool floor failure was fixed upstream; the waivers associated with NVBug 6535767 remain in current `main`.
- Automated fix generated by repair-bot, with review follow-ups applied.

## Test plan

- [x] Targeted pre-commit checks pass.
- [x] CI #52189 passed the H100 speculative-decoding stages covering DFlash/DSpark, including `unittest/_torch/speculative/hw_agnostic`.
- [x] CI #52189 had one unrelated B200 Gemma4 NVFP4 perf-sanity regression; the generated failure analysis classified this PR as unlikely to blame and recommended a rerun.
- Pending: full pre-merge rerun after the `ci: full pre-merge approved` label is granted.

## Links

- Bug: https://nvbugs/6535874
- CI failure analysis: https://pbss.s8k.io/v1/AUTH_svc_tensorrt/sw-tensorrt-ci-analysis/LLM/main/L0_MergeRequest_PR/52189/failure_analysis.html
