### PR TITLE
[TRTLLM-14772][doc] Add sudo to apt prerequisites

### DIFF
--- a/docs/source/installation/build-from-source.md
+++ b/docs/source/installation/build-from-source.md
@@ -12,7 +12,7 @@ Use [Docker](https://www.docker.com) to build and run TensorRT LLM. Instructions
 TensorRT LLM uses git-lfs, which needs to be installed in advance:
 
 ```bash
-apt-get update && apt-get -y install git git-lfs
+sudo apt-get update && sudo apt-get -y install git git-lfs
 git lfs install
 ```
 


### PR DESCRIPTION
## Description

Add `sudo` to both `apt-get` invocations in the build-from-source prerequisites so the documented command works for the default non-root user.

Fixes [NVBug 6533915](https://nvbugspro.nvidia.com/bug/6533915).

## Test Coverage

- `pre-commit run --files docs/source/installation/build-from-source.md`
- `git diff --check`

## PR Checklist

- [x] Reviewed the checklist in the pull request template; the applicable requirements are satisfied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Updated both `apt-get` prerequisite commands in `docs/source/installation/build-from-source.md` to use `sudo`.
- The change supports the default non-root user.
- The documentation change is consistent and has no API, performance, or regression impact.
- Pre-commit checks and `git diff --check` passed.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->