### PR TITLE
[TRTLLM-14904][fix] Work around flashinfer 0.6.15 autotuner cache-key hash/eq inconsistency

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -66,6 +66,81 @@ if TYPE_CHECKING:
         TrtllmAttentionMetadata,
     )
 
+
+def _patch_flashinfer_dynamic_tensor_spec_eq() -> None:
+    """Work around a hash/eq inconsistency in flashinfer 0.6.15's autotuner.
+
+    ``DynamicTensorSpec`` defines a custom ``__hash__`` that skips
+    ``tensor_initializers`` (and hashes callables by identity), but keeps the
+    dataclass-generated ``__eq__``, which compares all fields by value.
+    Callers such as ``trtllm_batch_decode_with_kv_cache_mla`` build a fresh
+    ``TuningConfig`` per call with fresh initializer closures, so the
+    ``lru_cache`` on ``AutoTuner._find_nearest_profile`` accumulates
+    hash-equal but eq-unequal keys up to the cache cap; every autotuner cache
+    probe on the MLA decode path then walks the entire collision chain in
+    Python ``__eq__`` (tens of milliseconds per attention call, per layer).
+
+    The workaround replaces ``__eq__`` with one consistent with the existing
+    ``__hash__``: ignore ``tensor_initializers``, compare
+    ``map_to_tuning_buckets`` by identity, and ``gen_tuning_buckets`` by
+    value if it is a tuple and by identity otherwise. Keys equal under this
+    ``__eq__`` produce identical nearest profiles, so cached results stay
+    correct, and hash/eq consistency is restored (equal objects hash equal).
+
+    The bug is upstream in flashinfer; the patch is applied only when a
+    behavioral probe shows the inconsistency (two specs differing only in
+    initializer closures that hash equal but compare unequal), so a fixed
+    flashinfer release degrades this to a no-op.
+    """
+    try:
+        from flashinfer.autotuner.autotuner import DynamicTensorSpec
+
+        def _probe_spec():
+            return DynamicTensorSpec(
+                input_idx=(0,),
+                dim_idx=(0,),
+                gen_tuning_buckets=(1,),
+                map_to_tuning_buckets=_probe_spec,  # any stable callable
+                tensor_initializers=[lambda shapes, dtype, device: None],
+            )
+
+        a, b = _probe_spec(), _probe_spec()
+        if not (hash(a) == hash(b) and a != b):
+            return  # flashinfer without the inconsistency; nothing to do
+
+        def _hash_consistent_eq(self, other):
+            if self is other:
+                return True
+            if not isinstance(other, DynamicTensorSpec):
+                return NotImplemented
+            if isinstance(self.gen_tuning_buckets, tuple) and isinstance(
+                other.gen_tuning_buckets, tuple
+            ):
+                buckets_equal = self.gen_tuning_buckets == other.gen_tuning_buckets
+            else:
+                buckets_equal = self.gen_tuning_buckets is other.gen_tuning_buckets
+            return (
+                self.input_idx == other.input_idx
+                and self.dim_idx == other.dim_idx
+                and buckets_equal
+                and self.map_to_tuning_buckets is other.map_to_tuning_buckets
+            )
+
+        DynamicTensorSpec.__eq__ = _hash_consistent_eq
+        logger.debug(
+            "Patched flashinfer DynamicTensorSpec.__eq__ to be hash-consistent "
+            "(autotuner cache collision-chain workaround)."
+        )
+    except Exception:
+        # A future flashinfer refactor (moved class, changed fields) must not
+        # break attention; it just loses the workaround.
+        logger.debug("Skipping flashinfer DynamicTensorSpec.__eq__ workaround.", exc_info=True)
+
+
+if IS_FLASHINFER_AVAILABLE:
+    _patch_flashinfer_dynamic_tensor_spec_eq()
+
+
 _SUPPORTED_MLA_BACKENDS = {"cute-dsl", "trtllm-gen"}
 
 


### PR DESCRIPTION
## Description

flashinfer 0.6.15's `DynamicTensorSpec` defines a custom `__hash__` that skips `tensor_initializers` (and hashes callables by identity) while keeping the dataclass-generated `__eq__`, which compares all fields by value. Callers such as `trtllm_batch_decode_with_kv_cache_mla` build a fresh `TuningConfig` per call with fresh initializer closures, so the `lru_cache` on `AutoTuner._find_nearest_profile` accumulates hash-equal but eq-unequal keys up to its 16384 cap. Every autotuner cache probe on the MLA decode path then walks the whole collision chain in Python `__eq__` — a 17–19 ms host stall per eager MLA generation call. Mixed prefill+decode iterations run eagerly and pay this on every call; decode-only iterations replay CUDA graphs and are unaffected, which made it present as a prefill-side regression. flashinfer 0.6.14 built a fresh bucket mapper per call, so keys hashed differently and cache probes missed in O(1); the 0.6.14→0.6.15 bump (#16530) exposed the inconsistency.

This PR installs a guarded TRT-LLM-side workaround where the fmha flashinfer backend imports flashinfer: `DynamicTensorSpec.__eq__` is replaced with one consistent with its existing `__hash__` (ignore `tensor_initializers`, compare callables by identity). A behavioral probe applies the patch only when the inconsistency is actually present, and any failure degrades to not patching, so a future flashinfer release with different internals is unaffected.

The bug is upstream in flashinfer; an upstream issue is being filed, and this workaround should be dropped once a fixed release is picked up.

## Test Coverage

- Serving benchmark at high concurrency on a large MoE model with MLA attention: output throughput recovered ~15% (back to par with the pre-regression baseline band); low-concurrency throughput unchanged.
- CPU microbenchmark of the autotuner cache probe: ~2 µs per call with cache size 1 post-patch, versus ~10 ms per call with an 8000-entry collision chain unpatched.

## PR Checklist

- [x] PR title and description are self-explanatory
- [x] Commit message includes ticket ID and is signed off (DCO)
- [x] Change is guarded and degrades safely if flashinfer internals change