### PR TITLE
[https://nvbugs/6529792][fix] Charge the base decode token in multi-request KV budget

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2099,13 +2099,11 @@ class KVCacheManagerV2(BaseResourceManager):
         self, *, token_num_upper_bound: int, batch_size: int = 1, max_num_draft_tokens: int = 0
     ) -> int:
         extra_tokens = self.num_extra_kv_tokens + max_num_draft_tokens
-        # A generation request also spends one base decode token: add_dummy_requests
-        # and try_allocate_generation grow capacity by ``1 + draft`` (see
-        # _required_gen_capacity), as does the max_blocks_per_seq sizing in __init__.
-        # Charge it so this budget is the exact inverse of that reservation, else a
-        # pool-bound caller overshoots by one token — a whole block past a boundary.
-        # Only multi-request callers pass batch_size, so the single-request default
-        # leaves context-phase budgets untouched.
+        # A generation request also spends one base decode token: _required_gen_capacity
+        # grows capacity by ``1 + draft``. Charge it so this budget is the exact inverse
+        # of that reservation, else a pool-bound caller overshoots by one token — a
+        # whole block past a boundary. Only multi-request callers pass batch_size, so
+        # the single-request default leaves context-phase budgets untouched.
         if batch_size > 1:
             extra_tokens += 1
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2099,6 +2099,15 @@ class KVCacheManagerV2(BaseResourceManager):
         self, *, token_num_upper_bound: int, batch_size: int = 1, max_num_draft_tokens: int = 0
     ) -> int:
         extra_tokens = self.num_extra_kv_tokens + max_num_draft_tokens
+        # A generation request also spends one base decode token: add_dummy_requests
+        # and try_allocate_generation grow capacity by ``1 + draft`` (see
+        # _required_gen_capacity), as does the max_blocks_per_seq sizing in __init__.
+        # Charge it so this budget is the exact inverse of that reservation, else a
+        # pool-bound caller overshoots by one token — a whole block past a boundary.
+        # Only multi-request callers pass batch_size, so the single-request default
+        # leaves context-phase budgets untouched.
+        if batch_size > 1:
+            extra_tokens += 1
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.
         # We need to add extra tokens to the token num upper bound to account for the extra tokens.
         clamped = (

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -556,6 +556,46 @@ def test_iteration_stats_reports_physical_pool_groups_without_window_metadata() 
     assert ssm_stats.snapshot_stats.iter_reused_tokens == 32
 
 
+@pytest.mark.parametrize("max_num_draft_tokens", [0, 4])
+def test_available_tokens_charges_base_decode_token_for_multi_request(max_num_draft_tokens):
+    """RCCA https://nvbugs/6529792.
+
+    ``add_dummy_requests(is_gen=True)`` grows capacity to
+    ``token_num + num_extra_kv_tokens + kv_reserve_draft_tokens + 1``, so a budget
+    used to size such a reservation must net out that trailing base decode token.
+    Without it a pool-bound CUDA graph warmup overshot by one token — one whole
+    block — and every batch size > 1 was skipped for want of KV cache space.
+    """
+    pool_tokens, num_extra_kv_tokens = 1024, 2
+    manager = object.__new__(KVCacheManagerV2)
+    manager.num_extra_kv_tokens = num_extra_kv_tokens
+    manager._gpu_max_tokens = None
+    # Stub the real clamp as a bare pool ceiling so the assertions isolate the
+    # extra-token bookkeeping from block geometry.
+    manager.impl = SimpleNamespace(
+        clamp_max_seq_len_for_mem=(
+            lambda batch_size, token_num_upper_bound: min(token_num_upper_bound, pool_tokens)
+        )
+    )
+
+    # token_num_upper_bound above the pool, so the pool is what binds — the
+    # regime the bug needed (when max_seq_len binds instead, it already pays a -1).
+    single = manager.get_num_available_tokens(
+        token_num_upper_bound=8192, max_num_draft_tokens=max_num_draft_tokens
+    )
+    multi = manager.get_num_available_tokens(
+        token_num_upper_bound=8192, batch_size=8, max_num_draft_tokens=max_num_draft_tokens
+    )
+
+    # The multi-request budget must leave room for the base decode token...
+    assert multi == single - 1
+    # ...and the single-request default must keep its historical value.
+    assert single == pool_tokens - num_extra_kv_tokens - max_num_draft_tokens
+    # The budget is the exact inverse of the reservation it feeds (mirrors
+    # _required_gen_capacity): tight, not merely safe — one more token overflows.
+    assert multi + num_extra_kv_tokens + max_num_draft_tokens + 1 == pool_tokens
+
+
 def test_disagg_role_mapper_kinds_default_to_indexed():
     from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
     from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import Role

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -558,7 +558,7 @@ def test_iteration_stats_reports_physical_pool_groups_without_window_metadata() 
 
 @pytest.mark.parametrize("max_num_draft_tokens", [0, 4])
 def test_available_tokens_charges_base_decode_token_for_multi_request(max_num_draft_tokens):
-    """RCCA https://nvbugs/6529792.
+    """RCCA: https://nvbugs/6529792.
 
     ``add_dummy_requests(is_gen=True)`` grows capacity to
     ``token_num + num_extra_kv_tokens + kv_reserve_draft_tokens + 1``, so a budget
@@ -587,13 +587,12 @@ def test_available_tokens_charges_base_decode_token_for_multi_request(max_num_dr
         token_num_upper_bound=8192, batch_size=8, max_num_draft_tokens=max_num_draft_tokens
     )
 
-    # The multi-request budget must leave room for the base decode token...
-    assert multi == single - 1
-    # ...and the single-request default must keep its historical value.
-    assert single == pool_tokens - num_extra_kv_tokens - max_num_draft_tokens
-    # The budget is the exact inverse of the reservation it feeds (mirrors
+    # The single-request default keeps its historical value, and the multi-request
+    # budget leaves room for exactly one more token. Together these pin the budget
+    # as the exact inverse of the reservation it feeds (mirroring
     # _required_gen_capacity): tight, not merely safe — one more token overflows.
-    assert multi + num_extra_kv_tokens + max_num_draft_tokens + 1 == pool_tokens
+    assert single == pool_tokens - num_extra_kv_tokens - max_num_draft_tokens
+    assert multi == single - 1
 
 
 def test_disagg_role_mapper_kinds_default_to_indexed():

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -2708,3 +2708,40 @@ def test_cpp_hybrid_zero_local_mamba_layers():
         )
     )
     assert metadata.state_indices[0].item() == 0
+
+
+def test_hybrid_available_tokens_base_decode_token_is_v2_only(monkeypatch):
+    """RCCA: https://nvbugs/6529792.
+
+    ``KVCacheManagerV2.get_num_available_tokens`` charges the base decode token that
+    ``add_dummy_requests(is_gen=True)`` reserves, gated on ``batch_size``. Both hybrid
+    subclasses must stay on the correct side of that gate: the V2 one inherits the
+    charged budget (it delegates ``add_dummy_requests`` to V2, so an uncharged budget
+    would overshoot the pool by a whole block), while the Cpp one derives from V1 --
+    whose reservation has no such token -- so its override must keep passing
+    ``batch_size`` through untouched instead of deducting one.
+    """
+    # The V2 hybrid must resolve to V2's charged accessor itself; shadowing it here
+    # would silently reintroduce the bug. Identity is what carries the charged
+    # budget over, so the budget arithmetic needs testing only once, against
+    # KVCacheManagerV2 (see test_available_tokens_charges_base_decode_token_*).
+    assert (
+        MambaHybridCacheManagerV2.get_num_available_tokens
+        is KVCacheManagerV2.get_num_available_tokens
+    )
+
+    # V1 ignores batch_size, so the Cpp override must return the parent's value as-is.
+    assert issubclass(CppMambaHybridCacheManager, KVCacheManager)
+    pool_tokens = 1024
+    seen = {}
+
+    def fake_v1_accessor(self, token_num_upper_bound, max_num_draft_tokens=0, **kwargs):
+        seen.update(kwargs)
+        return pool_tokens
+
+    monkeypatch.setattr(KVCacheManager, "get_num_available_tokens", fake_v1_accessor)
+    cpp = object.__new__(CppMambaHybridCacheManager)
+    cpp.local_num_mamba_layers = 0
+    cpp.linear_attention_metadata = None
+    assert cpp.get_num_available_tokens(8192, batch_size=8) == pool_tokens
+    assert seen == {"batch_size": 8}


### PR DESCRIPTION
## Summary
- **Root cause**: `KVCacheManagerV2.get_num_available_tokens` was meant to be the exact inverse of the capacity that `add_dummy_requests(is_gen=True)` reserves, but `_required_gen_capacity` grows capacity by `1 + draft_tokens` while the budget only netted out `num_extra_kv_tokens + max_num_draft_tokens` — missing the single base decode token. When the KV pool (not `max_seq_len`) is the binding constraint, that one-token overshoot pushes the reservation a whole block past a pool boundary, so CUDA graph warmup finds no free space and silently skips every batch size > 1. On GPT-OSS-120B single-GPU with KV cache manager V2, this only manifests on a card whose usable memory makes the pool bind (~79 GiB); a larger-memory H100 variant yields a `max_num_tokens` above `max_seq_len`, so the pool never binds and the skips never appear.
- **Fix**: Add the missing `+1` to `extra_tokens` in `get_num_available_tokens`, gated on `batch_size > 1` so only multi-request (warmup-reservation) callers are affected and single-request context-phase budgets keep their historical values — the fix is applied at the accessor so both warmup reservation sites are corrected in one place. Blast-radius analysis over the 8 call sites confirmed only the 2 warmup-reservation sites pass `batch_size`, and unit tests pin the budget as the tight inverse of the reservation (`multi == single - 1`) plus a guard that the V2 hybrid subclass inherits the charged accessor while the Cpp/V1-derived hybrid override keeps passing `batch_size` through unchanged.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6529792


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Correctly charges one additional base decode token when `batch_size > 1`.
- Preserves single-request and context-phase budgets.
- Applies the V2 behavior to V2-based hybrid managers.
- Preserves V1-derived manager behavior by forwarding `batch_size` without the V2 charge.
- The change is small and does not alter public declarations or configuration files.
- Regression tests cover zero and four draft tokens and validate budget/reservation inversion.

## QA Engineer Review

- Added parametrized coverage in `tests/unittest/_torch/executor/test_kv_cache_manager_v2.py` for multi-request token accounting.
- Added hybrid-manager coverage in `tests/unittest/_torch/executor/test_mamba_cache_manager.py`.
- No `tests/integration/test_lists/` changes are included, so these tests are not identified in `test-db/` or `qa/` coverage lists.
- Verdict: needs follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->