### PR TITLE
[None][fix] parse RFC 2397 data URIs in one place

### DIFF
--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -29,7 +29,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from urllib.parse import unquote, urljoin, urlparse
+from urllib.parse import ParseResult, unquote, urljoin, urlparse
 
 import aiohttp
 import numpy as np
@@ -586,7 +586,16 @@ def _normalize_file_uri(uri: str) -> str:
     return uri
 
 
-def parse_data_uri(url: str) -> Tuple[str, str]:
+class UnsupportedDataURIEncodingError(NotImplementedError, ValueError):
+    """A data: URI whose payload is not base64-encoded.
+
+    Inherits NotImplementedError so callers already catching it keep working,
+    and ValueError so a malformed client payload maps to a client error rather
+    than an internal one.
+    """
+
+
+def parse_data_uri(url: Union[str, ParseResult]) -> Tuple[str, str]:
     """Parse an RFC 2397 data URI into its media type and base64 payload.
 
     The payload is returned as the still-encoded base64 string rather than as
@@ -594,7 +603,10 @@ def parse_data_uri(url: str) -> Tuple[str, str]:
     `BaseMediaIO.load_base64`, which decodes it per modality.
 
     Args:
-        url: A complete `data:` URI, e.g. `data:image/png;base64,iVBORw0...`.
+        url: A complete `data:` URI, e.g. `data:image/png;base64,iVBORw0...`,
+            or an already-parsed `ParseResult`. Callers holding a parsed URL
+            should pass it through rather than re-serializing it, since the
+            payload can be large.
 
     Returns:
         A `(media_type, data)` pair. `media_type` is the empty string for URIs
@@ -602,12 +614,14 @@ def parse_data_uri(url: str) -> Tuple[str, str]:
 
     Raises:
         ValueError: The URI has no `,` separating the header from the payload.
-        NotImplementedError: The payload is not base64-encoded.
+        UnsupportedDataURIEncodingError: The payload is not base64-encoded. This is
+            both a NotImplementedError and a ValueError.
     """
-    path = urlparse(url).path
+    parsed = url if isinstance(url, ParseResult) else urlparse(url)
+    path = parsed.path
     if "," not in path:
         raise ValueError(
-            f"Malformed data URI {url[:64]!r}: expected "
+            f"Malformed data URI {parsed.geturl()[:64]!r}: expected "
             "'data:[<media type>][;<parameter>]*,<data>', but found no ',' separating "
             "the header from the payload."
         )
@@ -617,7 +631,7 @@ def parse_data_uri(url: str) -> Tuple[str, str]:
     media_type, *parameters = data_spec.split(";")
     # Parameter names are case-insensitive per RFC 2045.
     if not any(parameter.lower() == "base64" for parameter in parameters):
-        raise NotImplementedError("Only base64 data URLs are supported for now.")
+        raise UnsupportedDataURIEncodingError("Only base64 data URLs are supported for now.")
     return media_type, data
 
 

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -586,6 +586,41 @@ def _normalize_file_uri(uri: str) -> str:
     return uri
 
 
+def parse_data_uri(url: str) -> Tuple[str, str]:
+    """Parse an RFC 2397 data URI into its media type and base64 payload.
+
+    The payload is returned as the still-encoded base64 string rather than as
+    decoded bytes, so that it can be handed straight to
+    `BaseMediaIO.load_base64`, which decodes it per modality.
+
+    Args:
+        url: A complete `data:` URI, e.g. `data:image/png;base64,iVBORw0...`.
+
+    Returns:
+        A `(media_type, data)` pair. `media_type` is the empty string for URIs
+        that omit it, such as `data:;base64,...`, which RFC 2397 permits.
+
+    Raises:
+        ValueError: The URI has no `,` separating the header from the payload.
+        NotImplementedError: The payload is not base64-encoded.
+    """
+    path = urlparse(url).path
+    if "," not in path:
+        raise ValueError(
+            f"Malformed data URI {url[:64]!r}: expected "
+            "'data:[<media type>][;<parameter>]*,<data>', but found no ',' separating "
+            "the header from the payload."
+        )
+    data_spec, data = path.split(",", 1)
+    # Everything after the media type is a parameter, and `base64` need not be
+    # the first one -- `data:audio/wav;codecs=opus;base64,...` is well-formed.
+    media_type, *parameters = data_spec.split(";")
+    # Parameter names are case-insensitive per RFC 2045.
+    if not any(parameter.lower() == "base64" for parameter in parameters):
+        raise NotImplementedError("Only base64 data URLs are supported for now.")
+    return media_type, data
+
+
 _MediaT = TypeVar("_MediaT")
 
 
@@ -671,12 +706,7 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
             data = await _safe_aiohttp_get(url, session=session)
             return await self._run_in_executor(self.load_bytes, data)
         elif parsed.scheme == "data":
-            data_spec, b64_data = parsed.path.split(",", 1)
-            parts = data_spec.split(";", 1)
-            media_type = parts[0]
-            encoding = parts[1] if len(parts) > 1 else ""
-            if encoding != "base64":
-                raise NotImplementedError("Only base64 data URLs are supported for now.")
+            media_type, b64_data = parse_data_uri(url)
             return await self._run_in_executor(self.load_base64, media_type, b64_data)
         elif parsed.scheme in ("", "file"):
             return await self._run_in_executor(self.load_file, url)

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -586,6 +586,14 @@ def _normalize_file_uri(uri: str) -> str:
     return uri
 
 
+class NotADataURIError(ValueError):
+    """A URL handed to the data: URI parser that is not a data: URI.
+
+    A plain ValueError rather than also a NotImplementedError: the payload is
+    not an unsupported encoding, the input is simply the wrong kind of URL.
+    """
+
+
 class UnsupportedDataURIEncodingError(NotImplementedError, ValueError):
     """A data: URI whose payload is not base64-encoded.
 
@@ -613,15 +621,23 @@ def parse_data_uri(url: Union[str, ParseResult]) -> Tuple[str, str]:
         that omit it, such as `data:;base64,...`, which RFC 2397 permits.
 
     Raises:
+        NotADataURIError: The URL is not a `data:` URI at all.
         ValueError: The URI has no `,` separating the header from the payload.
         UnsupportedDataURIEncodingError: The payload is not base64-encoded. This is
             both a NotImplementedError and a ValueError.
     """
     parsed = url if isinstance(url, ParseResult) else urlparse(url)
+    displayed = parsed.geturl()[:64]
+    # Check the scheme first: without it a filesystem path containing a "," is
+    # split like a data URI and misreported as an encoding problem.
+    if parsed.scheme != "data":
+        raise NotADataURIError(
+            f"Expected a 'data:' URI but got scheme {parsed.scheme!r}: {displayed!r}."
+        )
     path = parsed.path
     if "," not in path:
         raise ValueError(
-            f"Malformed data URI {parsed.geturl()[:64]!r}: expected "
+            f"Malformed data URI {displayed!r}: expected "
             "'data:[<media type>][;<parameter>]*,<data>', but found no ',' separating "
             "the header from the payload."
         )

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Coroutine, Dict, List, Optional, Tuple, TypedDict, Union
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse
 
 import numpy as np
 import soundfile
@@ -43,8 +43,8 @@ from tensorrt_llm.tokenizer.deepseek_v32 import DeepseekV32Tokenizer
 logger = logging.get_logger(__name__)
 
 
-def load_base64_image(parsed_url: str) -> Image.Image:
-    _, data = parse_data_uri(urlunparse(parsed_url))
+def load_base64_image(parsed_url: ParseResult) -> Image.Image:
+    _, data = parse_data_uri(parsed_url)
     content = base64.b64decode(data)
     image = _load_and_convert_image(BytesIO(content))
     return image

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Coroutine, Dict, List, Optional, Tuple, TypedDict, Union
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import numpy as np
 import soundfile
@@ -27,6 +27,7 @@ from tensorrt_llm.inputs.media_io import (_get_aiohttp_session,
                                           _safe_aiohttp_get, _safe_request_get)
 from tensorrt_llm.inputs.media_io import \
     convert_image_mode as convert_image_mode
+from tensorrt_llm.inputs.media_io import parse_data_uri
 from tensorrt_llm.inputs.multimodal import (MultimodalServerConfig,
                                             default_hasher)
 from tensorrt_llm.inputs.multimodal_data import \
@@ -43,13 +44,7 @@ logger = logging.get_logger(__name__)
 
 
 def load_base64_image(parsed_url: str) -> Image.Image:
-    data_spec, data = parsed_url.path.split(",", 1)
-    media_type, data_type = data_spec.split(";", 1)
-
-    if data_type != "base64":
-        msg = "Only base64 data URLs are supported for now."
-        raise NotImplementedError(msg)
-
+    _, data = parse_data_uri(urlunparse(parsed_url))
     content = base64.b64decode(data)
     image = _load_and_convert_image(BytesIO(content))
     return image
@@ -122,14 +117,7 @@ async def async_load_image(
 
 
 def load_base64_video(video: str) -> BytesIO:
-    parsed_url = urlparse(video)
-    data_spec, data = parsed_url.path.split(",", 1)
-    media_type, data_type = data_spec.split(";", 1)
-
-    if data_type != "base64":
-        msg = "Only base64 data URLs are supported for now."
-        raise NotImplementedError(msg)
-
+    _, data = parse_data_uri(video)
     content = base64.b64decode(data)
     return content
 

--- a/tests/unittest/inputs/test_async_media_loading.py
+++ b/tests/unittest/inputs/test_async_media_loading.py
@@ -29,6 +29,7 @@ import tensorrt_llm.inputs.utils as utils_module
 from tensorrt_llm.inputs.media_io import (
     AudioMediaIO,
     ImageMediaIO,
+    NotADataURIError,
     UnsupportedDataURIEncodingError,
     _get_aiohttp_session,
     parse_data_uri,
@@ -159,6 +160,26 @@ class TestParseDataUri:
         assert isinstance(unsupported.value, UnsupportedDataURIEncodingError)
 
     @pytest.mark.parametrize(
+        "path",
+        [
+            "/tmp/holiday,2026.mp4",  # absolute path, comma in the filename
+            "./clips/a,b.mp4",  # relative path
+            "holiday,2026.mp4",  # bare filename
+            "/tmp/plain.mp4",  # no comma at all
+        ],
+    )
+    def test_non_data_scheme_is_rejected_as_such(self, path):
+        """A filesystem path must not be diagnosed as bad base64.
+
+        Without a scheme check, a path containing a "," is split like a data
+        URI and reported as an encoding problem, which is misleading.
+        """
+        with pytest.raises(NotADataURIError, match="Expected a 'data:' URI") as excinfo:
+            parse_data_uri(path)
+        assert not isinstance(excinfo.value, UnsupportedDataURIEncodingError)
+        assert path in str(excinfo.value)
+
+    @pytest.mark.parametrize(
         "url",
         [
             "data:image/jpeg;charset=utf-8;base64,QUJD",
@@ -166,6 +187,7 @@ class TestParseDataUri:
             "data:audio/wav;codecs=opus;base64,QUJD",
             "data:image/png,hello",
             "data:image/png;base64",
+            "/tmp/holiday,2026.mp4",
         ],
     )
     def test_accepts_str_and_parseresult_identically(self, url):

--- a/tests/unittest/inputs/test_async_media_loading.py
+++ b/tests/unittest/inputs/test_async_media_loading.py
@@ -29,6 +29,7 @@ import tensorrt_llm.inputs.utils as utils_module
 from tensorrt_llm.inputs.media_io import (
     AudioMediaIO,
     ImageMediaIO,
+    UnsupportedDataURIEncodingError,
     _get_aiohttp_session,
     parse_data_uri,
 )
@@ -129,9 +130,10 @@ class TestParseDataUri:
         """A well-formed but unencoded data URI is unsupported, not malformed."""
         with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
             parse_data_uri("data:image/png,hello")
-        # Regression guard: this used to surface as ValueError("not enough
-        # values to unpack"), indistinguishable from a genuinely broken URI.
-        assert not isinstance(excinfo.value, ValueError)
+        # NotImplementedError so callers already catching it keep working;
+        # ValueError so a bad client payload maps to a client error.
+        assert isinstance(excinfo.value, NotImplementedError)
+        assert isinstance(excinfo.value, ValueError)
 
     def test_missing_comma_raises_readable_value_error(self):
         with pytest.raises(ValueError, match="Malformed data URI") as excinfo:
@@ -139,6 +141,54 @@ class TestParseDataUri:
         message = str(excinfo.value)
         assert "unpack" not in message, "should not leak a tuple-unpacking error"
         assert "data:image/png;base64" in message
+
+    def test_malformed_and_unsupported_are_distinguishable_by_type(self):
+        """The two failure modes must not collapse into one bare ValueError.
+
+        Both are ValueErrors so either maps to a client error, but only the
+        unsupported-encoding case is an UnsupportedDataURIEncodingError. Callers can
+        therefore tell them apart without matching on message text.
+        """
+        with pytest.raises(ValueError) as malformed:
+            parse_data_uri("data:image/png;base64")  # no comma
+        with pytest.raises(ValueError) as unsupported:
+            parse_data_uri("data:image/png,hello")  # comma, but not base64
+
+        assert type(malformed.value) is ValueError
+        assert not isinstance(malformed.value, UnsupportedDataURIEncodingError)
+        assert isinstance(unsupported.value, UnsupportedDataURIEncodingError)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "data:image/jpeg;charset=utf-8;base64,QUJD",
+            "data:;base64,QUJD",
+            "data:audio/wav;codecs=opus;base64,QUJD",
+            "data:image/png,hello",
+            "data:image/png;base64",
+        ],
+    )
+    def test_accepts_str_and_parseresult_identically(self, url):
+        """Callers holding a parsed URL pass it through, avoiding a re-serialize."""
+
+        def outcome(value):
+            try:
+                return ("ok", parse_data_uri(value))
+            except Exception as exc:  # noqa: BLE001 - comparing failure modes
+                return (type(exc), str(exc))
+
+        assert outcome(url) == outcome(urlparse(url))
+
+
+class TestUnsupportedDataURIEncodingError:
+    def test_subclasses_both_not_implemented_error_and_value_error(self):
+        assert issubclass(UnsupportedDataURIEncodingError, NotImplementedError)
+        assert issubclass(UnsupportedDataURIEncodingError, ValueError)
+
+    def test_is_caught_by_either_except_clause(self):
+        for exception_type in (NotImplementedError, ValueError):
+            with pytest.raises(exception_type):
+                raise UnsupportedDataURIEncodingError("boom")
 
 
 # ──────────────────────────────────────────────────────────────
@@ -169,8 +219,9 @@ class TestLoadBase64Image:
     def test_non_base64_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
             load_base64_image(urlparse("data:image/png,hello"))
-        # Previously ValueError("not enough values to unpack").
-        assert not isinstance(excinfo.value, ValueError)
+        # Both, so callers catching either builtin behave sensibly.
+        assert isinstance(excinfo.value, NotImplementedError)
+        assert isinstance(excinfo.value, ValueError)
 
     def test_base64_as_parameter_value_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
@@ -179,11 +230,22 @@ class TestLoadBase64Image:
     def test_empty_spec_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
             load_base64_image(urlparse("data:,hello"))
-        assert not isinstance(excinfo.value, ValueError)
+        assert isinstance(excinfo.value, NotImplementedError)
+        assert isinstance(excinfo.value, ValueError)
 
     def test_missing_comma_raises_value_error(self):
         with pytest.raises(ValueError, match="Malformed data URI"):
             load_base64_image(urlparse("data:image/png;base64"))
+
+    def test_parsed_url_is_not_re_serialized(self, monkeypatch):
+        """The ParseResult is handed to the parser as-is, not urlunparse'd back."""
+        monkeypatch.setattr(
+            media_io_module,
+            "urlparse",
+            lambda _: pytest.fail("parse_data_uri re-parsed an already-parsed URL"),
+        )
+        url = _data_uri("image/jpeg;base64", _make_jpeg_bytes())
+        assert isinstance(load_base64_image(urlparse(url)), Image.Image)
 
 
 class TestLoadBase64Video:
@@ -215,7 +277,8 @@ class TestLoadBase64Video:
     def test_non_base64_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
             load_base64_video("data:video/mp4,hello")
-        assert not isinstance(excinfo.value, ValueError)
+        assert isinstance(excinfo.value, NotImplementedError)
+        assert isinstance(excinfo.value, ValueError)
 
     def test_base64_as_parameter_value_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
@@ -224,7 +287,8 @@ class TestLoadBase64Video:
     def test_empty_spec_raises_not_implemented(self):
         with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
             load_base64_video("data:,hello")
-        assert not isinstance(excinfo.value, ValueError)
+        assert isinstance(excinfo.value, NotImplementedError)
+        assert isinstance(excinfo.value, ValueError)
 
     def test_missing_comma_raises_value_error(self):
         with pytest.raises(ValueError, match="Malformed data URI"):

--- a/tests/unittest/inputs/test_async_media_loading.py
+++ b/tests/unittest/inputs/test_async_media_loading.py
@@ -3,6 +3,7 @@
 """Tests for async media loading in tensorrt_llm.inputs.media_io and utils.
 
 Covers:
+- parse_data_uri: the shared RFC 2397 parser behind every `data:` URL path
 - async_load_image / async_load_audio with data URLs and file paths
 - CPU-bound work is offloaded to a thread pool (event loop not blocked)
 - aiohttp session is reused across calls (_get_aiohttp_session)
@@ -14,6 +15,7 @@ import tempfile
 import threading
 from io import BytesIO
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import numpy as np
 import pytest
@@ -24,8 +26,19 @@ from PIL import Image
 
 import tensorrt_llm.inputs.media_io as media_io_module
 import tensorrt_llm.inputs.utils as utils_module
-from tensorrt_llm.inputs.media_io import _get_aiohttp_session
-from tensorrt_llm.inputs.utils import MultimodalDataTracker, async_load_audio, async_load_image
+from tensorrt_llm.inputs.media_io import (
+    AudioMediaIO,
+    ImageMediaIO,
+    _get_aiohttp_session,
+    parse_data_uri,
+)
+from tensorrt_llm.inputs.utils import (
+    MultimodalDataTracker,
+    async_load_audio,
+    async_load_image,
+    load_base64_image,
+    load_base64_video,
+)
 
 # ──────────────────────────────────────────────────────────────
 # Helpers
@@ -40,6 +53,28 @@ def _make_image_data_url() -> str:
     return f"data:image/jpeg;base64,{b64_str}"
 
 
+def _make_jpeg_bytes() -> bytes:
+    """Build a small in-memory JPEG and return its raw bytes."""
+    img = Image.new("RGB", (8, 8), color=(100, 150, 200))
+    image_buf = BytesIO()
+    img.save(image_buf, format="JPEG")
+    return image_buf.getvalue()
+
+
+def _make_wav_bytes(sample_rate: int = 16000) -> bytes:
+    """Build a short in-memory WAV clip and return its raw bytes."""
+    time_axis = np.linspace(0, 0.05, int(sample_rate * 0.05), endpoint=False)
+    audio_samples = (np.sin(2 * np.pi * 440 * time_axis) * 0.5).astype(np.float32)
+    audio_buf = BytesIO()
+    soundfile.write(audio_buf, audio_samples, sample_rate, format="WAV")
+    return audio_buf.getvalue()
+
+
+def _data_uri(header: str, payload: bytes) -> str:
+    """Assemble a `data:` URI from a header and a to-be-base64-encoded payload."""
+    return f"data:{header},{base64.b64encode(payload).decode()}"
+
+
 def _make_audio_file(tmp_path: str) -> str:
     """Write a short WAV file and return its path."""
     sample_rate = 16000
@@ -50,11 +85,178 @@ def _make_audio_file(tmp_path: str) -> str:
 
 
 # ──────────────────────────────────────────────────────────────
+# parse_data_uri
+# ──────────────────────────────────────────────────────────────
+
+
+class TestParseDataUri:
+    """RFC 2397 parsing, shared by every `data:` URL code path."""
+
+    @pytest.mark.parametrize(
+        "url, expected_media_type",
+        [
+            ("data:image/png;base64,QUJD", "image/png"),
+            # `base64` is not required to be the only parameter, nor the first.
+            ("data:audio/wav;codecs=opus;base64,QUJD", "audio/wav"),
+            ("data:image/jpeg;charset=utf-8;base64,QUJD", "image/jpeg"),
+            # RFC 2397 permits omitting the media type entirely.
+            ("data:;base64,QUJD", ""),
+            # Parameter names are case-insensitive per RFC 2045.
+            ("data:text/plain;BASE64,QUJD", "text/plain"),
+            ("data:text/plain;Base64,QUJD", "text/plain"),
+        ],
+    )
+    def test_returns_media_type_and_undecoded_payload(self, url, expected_media_type):
+        media_type, payload = parse_data_uri(url)
+        assert media_type == expected_media_type
+        assert payload == "QUJD"  # returned still encoded; callers decode
+
+    def test_base64_must_be_a_whole_parameter_not_a_substring(self):
+        """`;name=base64` is a parameter *value*, so the URI is not base64."""
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            parse_data_uri("data:image/png;name=base64,hello")
+
+    def test_empty_payload_parses_rather_than_raising(self):
+        """A trailing comma with no data is well-formed; decoding fails later."""
+        assert parse_data_uri("data:image/jpeg;base64,") == ("image/jpeg", "")
+
+    def test_empty_spec_is_not_base64(self):
+        """`data:,hello` has no parameters at all, so it is not base64."""
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            parse_data_uri("data:,hello")
+
+    def test_non_base64_raises_not_implemented(self):
+        """A well-formed but unencoded data URI is unsupported, not malformed."""
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
+            parse_data_uri("data:image/png,hello")
+        # Regression guard: this used to surface as ValueError("not enough
+        # values to unpack"), indistinguishable from a genuinely broken URI.
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_missing_comma_raises_readable_value_error(self):
+        with pytest.raises(ValueError, match="Malformed data URI") as excinfo:
+            parse_data_uri("data:image/png;base64")
+        message = str(excinfo.value)
+        assert "unpack" not in message, "should not leak a tuple-unpacking error"
+        assert "data:image/png;base64" in message
+
+
+# ──────────────────────────────────────────────────────────────
+# load_base64_image / load_base64_video — the synchronous helpers
+# ──────────────────────────────────────────────────────────────
+
+
+class TestLoadBase64Image:
+    """`load_base64_image` takes an already-parsed URL, not a string."""
+
+    def test_parameterized_data_url_loads(self):
+        url = _data_uri("image/jpeg;charset=utf-8;base64", _make_jpeg_bytes())
+        assert isinstance(load_base64_image(urlparse(url)), Image.Image)
+
+    def test_plain_data_url_still_loads(self):
+        url = _data_uri("image/jpeg;base64", _make_jpeg_bytes())
+        assert isinstance(load_base64_image(urlparse(url)), Image.Image)
+
+    def test_empty_media_type_loads(self):
+        url = _data_uri(";base64", _make_jpeg_bytes())
+        assert isinstance(load_base64_image(urlparse(url)), Image.Image)
+
+    @pytest.mark.parametrize("parameter", ["BASE64", "Base64"])
+    def test_case_variants_load(self, parameter):
+        url = _data_uri(f"image/jpeg;{parameter}", _make_jpeg_bytes())
+        assert isinstance(load_base64_image(urlparse(url)), Image.Image)
+
+    def test_non_base64_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
+            load_base64_image(urlparse("data:image/png,hello"))
+        # Previously ValueError("not enough values to unpack").
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_base64_as_parameter_value_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            load_base64_image(urlparse("data:image/png;name=base64,hello"))
+
+    def test_empty_spec_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
+            load_base64_image(urlparse("data:,hello"))
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_missing_comma_raises_value_error(self):
+        with pytest.raises(ValueError, match="Malformed data URI"):
+            load_base64_image(urlparse("data:image/png;base64"))
+
+
+class TestLoadBase64Video:
+    """`load_base64_video` takes the URL string and returns raw bytes."""
+
+    PAYLOAD = b"\x00\x01\x02fake-mp4-bytes"
+
+    def test_parameterized_data_url_loads(self):
+        url = _data_uri("video/mp4;codecs=avc1;base64", self.PAYLOAD)
+        assert load_base64_video(url) == self.PAYLOAD
+
+    def test_plain_data_url_still_loads(self):
+        url = _data_uri("video/mp4;base64", self.PAYLOAD)
+        assert load_base64_video(url) == self.PAYLOAD
+
+    def test_empty_media_type_loads(self):
+        url = _data_uri(";base64", self.PAYLOAD)
+        assert load_base64_video(url) == self.PAYLOAD
+
+    @pytest.mark.parametrize("parameter", ["BASE64", "Base64"])
+    def test_case_variants_load(self, parameter):
+        url = _data_uri(f"video/mp4;{parameter}", self.PAYLOAD)
+        assert load_base64_video(url) == self.PAYLOAD
+
+    def test_empty_payload_decodes_to_empty_bytes(self):
+        """Matches pre-existing behaviour: parsing succeeds, payload is empty."""
+        assert load_base64_video("data:video/mp4;base64,") == b""
+
+    def test_non_base64_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
+            load_base64_video("data:video/mp4,hello")
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_base64_as_parameter_value_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            load_base64_video("data:video/mp4;name=base64,hello")
+
+    def test_empty_spec_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs") as excinfo:
+            load_base64_video("data:,hello")
+        assert not isinstance(excinfo.value, ValueError)
+
+    def test_missing_comma_raises_value_error(self):
+        with pytest.raises(ValueError, match="Malformed data URI"):
+            load_base64_video("data:video/mp4;base64")
+
+
+# ──────────────────────────────────────────────────────────────
 # async_load_image
 # ──────────────────────────────────────────────────────────────
 
 
 class TestAsyncLoadImage:
+    @pytest.mark.asyncio
+    async def test_load_image_from_parameterized_data_url(self):
+        """Extra RFC 2397 parameters ahead of `base64` must not break parsing."""
+        url = _data_uri("image/jpeg;charset=utf-8;base64", _make_jpeg_bytes())
+        image = await async_load_image(url, format="pil")
+        assert isinstance(image, Image.Image)
+        assert image.mode == "RGB"
+
+    @pytest.mark.asyncio
+    async def test_load_image_from_data_url_without_media_type(self):
+        url = _data_uri(";base64", _make_jpeg_bytes())
+        image = await async_load_image(url, format="pil")
+        assert isinstance(image, Image.Image)
+        assert image.mode == "RGB"
+
+    @pytest.mark.asyncio
+    async def test_load_image_from_non_base64_data_url_raises(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            await async_load_image("data:image/png,hello", format="pil")
+
     @pytest.mark.asyncio
     async def test_load_image_from_data_url_pil(self):
         url = _make_image_data_url()
@@ -135,6 +337,65 @@ class TestAsyncLoadAudio:
         assert worker_thread_ids[0] != event_loop_thread_id, (
             "soundfile.read ran on the event loop thread — event loop is being blocked"
         )
+
+
+# ──────────────────────────────────────────────────────────────
+# BaseMediaIO.async_load — data URLs
+# ──────────────────────────────────────────────────────────────
+
+
+class TestMediaIODataUrl:
+    """`BaseMediaIO.async_load` reaches `data:` URLs through the shared parser."""
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_parameterized_data_url(self):
+        # The payload is PCM WAV; `codecs=opus` is present only to exercise a
+        # second parameter ahead of `base64`, which used to be misread as the
+        # encoding and rejected.
+        url = _data_uri("audio/wav;codecs=opus;base64", _make_wav_bytes())
+        audio_array, sample_rate = await AudioMediaIO().async_load(url)
+        assert isinstance(audio_array, np.ndarray)
+        assert sample_rate == 16000  # matches the default in _make_wav_bytes
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_data_url_without_media_type(self):
+        url = _data_uri(";base64", _make_wav_bytes())
+        audio_array, sample_rate = await AudioMediaIO().async_load(url)
+        assert isinstance(audio_array, np.ndarray)
+        assert sample_rate == 16000
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_non_base64_data_url_raises(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            await AudioMediaIO().async_load("data:audio/wav,hello")
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_data_url_without_comma_raises(self):
+        with pytest.raises(ValueError, match="Malformed data URI"):
+            await AudioMediaIO().async_load("data:audio/wav;base64")
+
+    @pytest.mark.asyncio
+    async def test_base64_as_parameter_value_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Only base64 data URLs"):
+            await AudioMediaIO().async_load("data:audio/wav;name=base64,hello")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("parameter", ["BASE64", "Base64"])
+    async def test_case_variants_load(self, parameter):
+        url = _data_uri(f"audio/wav;{parameter}", _make_wav_bytes())
+        audio_array, _ = await AudioMediaIO().async_load(url)
+        assert isinstance(audio_array, np.ndarray)
+
+    @pytest.mark.asyncio
+    async def test_empty_media_type_reaches_every_subclass(self):
+        """No `load_base64` override dispatches on media_type, so "" is safe."""
+        image = await ImageMediaIO(format="pil").async_load(
+            _data_uri(";base64", _make_jpeg_bytes())
+        )
+        assert isinstance(image, Image.Image)
+
+        audio_array, _ = await AudioMediaIO().async_load(_data_uri(";base64", _make_wav_bytes()))
+        assert isinstance(audio_array, np.ndarray)
 
 
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Centralizes RFC 2397 parsing in `parse_data_uri`.
- Routes image, video, and `BaseMediaIO` loading through the shared parser.
- Supports parameters, case-insensitive `base64`, empty media types, and empty payloads.
- Adds distinct errors for non-data URLs and unsupported encodings.
- Accepts strings and `ParseResult` objects.
- No configuration or test-list changes.
- No correctness, performance, API consistency, or scope concerns identified.

## QA Engineer Review

- Expanded `tests/unittest/inputs/test_async_media_loading.py`.
- Added tests for parser behavior, parameterized URIs, encoding markers, empty values, malformed URIs, unsupported encodings, and `ParseResult` inputs.
- Added coverage for synchronous image and video loaders, asynchronous image and audio loaders, executor behavior, and `BaseMediaIO` subclasses.
- No test functions were removed.
- No matching entries were found in `tests/integration/test_lists/test-db/` or `tests/integration/test_lists/`.
- Verdict: needs follow-up because CBTS coverage data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

The `data:` URI parse was duplicated in three places and all three copies
mishandled well-formed input. This lands one RFC 2397 parser and routes every
copy through it.

Fixed:
- **Parameterized URIs.** `data_spec.split(";", 1)` assumed exactly one `";"`,
  so `data:audio/wav;codecs=opus;base64,...` parsed its media type as
  `"codecs=opus;base64"` and raised `NotImplementedError` on valid input.
  Affected all three copies.
- **Wrong exception type.** `load_base64_image` and `load_base64_video` raised
  `ValueError("not enough values to unpack")` on a legal non-base64 URI such as
  `data:image/png,hello`. They now raise `UnsupportedDataURIEncodingError`,
  matching what `BaseMediaIO.async_load` already did.
- **Missing comma.** Surfaced as a tuple-unpacking error rather than a message
  naming the expected URI shape.
- **Case-sensitive parameters.** `;BASE64,` was rejected; RFC 2045 parameter
  names are case-insensitive.
- **Non-`data:` URLs.** A filesystem path containing a `,` was split like a data
  URI and reported as an unsupported encoding, a confident but wrong diagnosis.
  The scheme is now checked first, and a non-`data:` URL raises
  `NotADataURIError`.

Also handled: an empty media type (`data:;base64,...` is legal per RFC 2397),
and `base64` matching a whole parameter token rather than a substring, so
`data:image/png;name=base64,hello` is correctly rejected.

`parse_data_uri` returns the payload as a base64 **string**, not decoded bytes,
because `BaseMediaIO.load_base64(media_type, data)` consumes the string and each
subclass decodes it. Changing that abstract signature is a separate API
question; callers that want bytes decode in one line.

Every URI that parsed before parses identically. No subclass reads `media_type`,
so an empty media type is inert.

> **Note for reviewers.** An earlier revision of this description claimed a
> malformed data URI would return HTTP 500 rather than 400. That was wrong.
> `create_error_response` (openai_server.py:746-749) defaults to
> `status_code=HTTPStatus.BAD_REQUEST`, so on `openai_chat` the `except
> ValueError` at :1618 and the `except Exception` at :1620 return the same
> HTTP 400. The real difference is that :1620 calls
> `logger.error(traceback.format_exc())` first and :1618 does not, so bad
> client input writes an error-level traceback into the server log.
>
> `parse_data_uri` now raises `UnsupportedDataURIEncodingError`, which inherits
> both `NotImplementedError` and `ValueError`, so that input is classified as a
> client error and routed to the silent arm. A missing `,` remains a plain
> `ValueError`, keeping the two failure modes distinguishable by type.
>
> For the record on reachability: `/v1/chat/completions` reaches
> `BaseMediaIO.async_load` via `_make_media_io` (chat_utils.py:149-156), not
> `load_image` / `load_video`. `async_load_image` and `async_load_video` have
> no call sites outside re-exports and tests; `load_video` has none; and
> `load_image`'s three callers are all VisualGen, which writes base64 to disk
> and passes a path.

Additive and backward-compatible: one new module-level helper, two new exception
classes, `parse_data_uri` widened from `str` to `Union[str, ParseResult]`, and
`load_base64_image`'s annotation corrected to the `ParseResult` it has always
been passed. Nothing removed, no caller-visible signature narrowed.
`api-compatible` if a maintainer can apply the label.

## Test Coverage

`tests/unittest/inputs/test_async_media_loading.py`, 55 new tests (61 in the
module, up from 6):

- `TestParseDataUri`: parameterized URIs, empty media type, case-insensitive
  `BASE64`/`Base64`, `base64` as a parameter *value* rejected, empty payload
  parsed rather than raised, `data:,hello`, and the three failure modes kept
  distinguishable by type: `NotADataURIError` for a non-`data:` scheme,
  a plain `ValueError` for a missing comma, and
  `UnsupportedDataURIEncodingError` for a non-base64 payload.
- `TestUnsupportedDataURIEncodingError`: subclasses both `NotImplementedError`
  and `ValueError`, and is caught by either `except` clause.
- `TestLoadBase64Image` / `TestLoadBase64Video`: direct coverage of the two
  synchronous helpers whose exception type changes, plus a guard that
  `load_base64_image` passes its `ParseResult` through instead of
  re-serializing it.
- `TestMediaIODataUrl`: the same paths through `BaseMediaIO.async_load`,
  including `data:audio/wav;codecs=opus;base64,...`, plus a check that an empty
  media type reaches every `load_base64` subclass unharmed.
- `TestAsyncLoadImage`: parameterized and empty-media-type data URLs through
  `async_load_image`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.