### PR TITLE
[None][feat] Construct scaffolding Controller from a config file (#3330)

### DIFF
--- a/examples/scaffolding/configs/best_of_n.json
+++ b/examples/scaffolding/configs/best_of_n.json
@@ -1,0 +1,20 @@
+{
+  "controller": {
+    "type": "BestOfNController",
+    "args": {
+      "default_sample_num": 4,
+      "generation_controller": {
+        "type": "NativeGenerationController",
+        "args": {
+          "sampling_params": {
+            "max_tokens": 512,
+            "temperature": 0.9
+          }
+        }
+      },
+      "reward_controller": {
+        "type": "NativeRewardController"
+      }
+    }
+  }
+}

--- a/examples/scaffolding/configs/majority_vote.json
+++ b/examples/scaffolding/configs/majority_vote.json
@@ -1,0 +1,18 @@
+{
+  "controller": {
+    "type": "MajorityVoteController",
+    "args": {
+      "default_sample_num": 3,
+      "generation_controller": {
+        "type": "NativeGenerationController",
+        "args": {
+          "sampling_params": {
+            "max_tokens": 1024,
+            "temperature": 0.9,
+            "top_p": 0.9
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/scaffolding/configs/native_generation.yaml
+++ b/examples/scaffolding/configs/native_generation.yaml
@@ -1,0 +1,7 @@
+# JSON and YAML are both accepted; the loader uses yaml.safe_load for either.
+controller:
+  type: NativeGenerationController
+  args:
+    sampling_params:
+      max_tokens: 1024
+      temperature: 0.9

--- a/examples/scaffolding/run_from_config.py
+++ b/examples/scaffolding/run_from_config.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run a scaffolding controller described by a config file.
+
+The controller topology comes entirely from the config, so switching between
+plain generation, majority vote and best-of-N is an edit to a JSON or YAML file
+rather than a code change.
+
+Example:
+    ```bash
+    python run_from_config.py \
+        --config configs/majority_vote.json \
+        --model_dir <path to the generation model>
+    ```
+"""
+
+import argparse
+
+from tensorrt_llm.scaffolding import (
+    NativeGenerationController,
+    NativeRewardController,
+    ScaffoldingLlm,
+    TRTLLMWorker,
+    load_controller_config,
+)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to a JSON or YAML file describing the controller",
+    )
+    parser.add_argument(
+        "--model_dir",
+        type=str,
+        required=True,
+        help="Path to the directory containing the generation model",
+    )
+    parser.add_argument(
+        "--reward_model_dir",
+        type=str,
+        default=None,
+        help="Path to a reward model, required by controllers that score candidates",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+
+    controller = load_controller_config(args.config)
+    print(f"Built {type(controller).__name__} from {args.config}")
+
+    prompts = [
+        "Natalia sold clips to 48 of her friends in April, and then she sold half as many "
+        "clips in May. How many clips did Natalia sell altogether in April and May?\r\n\r\n",
+    ]
+
+    workers = {}
+    llm = None
+    try:
+        workers[NativeGenerationController.WorkerTag.GENERATION] = TRTLLMWorker.init_with_new_llm(
+            args.model_dir
+        )
+        if args.reward_model_dir is not None:
+            workers[NativeRewardController.WorkerTag.REWARD] = TRTLLMWorker.init_with_new_llm(
+                args.reward_model_dir
+            )
+
+        llm = ScaffoldingLlm(controller, workers)
+
+        for result in llm.generate(prompts):
+            print(result.outputs[0].text)
+    finally:
+        # ScaffoldingLlm owns the workers once it exists; before that we own them, and a
+        # failure part way through worker creation must still release the earlier ones.
+        if llm is not None:
+            llm.shutdown(shutdown_workers=True)
+        else:
+            for worker in workers.values():
+                worker.shutdown()
+
+    print("main shut down done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/scaffolding/README.md
+++ b/tensorrt_llm/scaffolding/README.md
@@ -28,6 +28,40 @@ This example run the generation with TensorRT LLM backend. It shows the step of 
 [More examples](../../examples/scaffolding)
 These examples shows how to run more complex methods including majority voting and best-of-n, how to static the output tokens with the decorator, how to run the dataset on concurrency and static the results.
 
+### Building a Controller from a config file
+A `Controller` can also be described declaratively instead of being constructed in code, which makes a
+method easier to share and to migrate between projects.
+
+``` bash
+python examples/scaffolding/run_from_config.py \
+    --config examples/scaffolding/configs/majority_vote.json \
+    --model_dir PATH/TO/MODEL
+```
+
+Controllers compose recursively, so a config is a tree. Any object with a `type` key is a controller node
+and its `args` are passed to the constructor; nested controller arguments are built first.
+
+``` json
+{
+  "controller": {
+    "type": "MajorityVoteController",
+    "args": {
+      "default_sample_num": 3,
+      "generation_controller": {
+        "type": "NativeGenerationController",
+        "args": {"sampling_params": {"max_tokens": 1024, "temperature": 0.9}}
+      }
+    }
+  }
+}
+```
+
+Both JSON and YAML are accepted. `load_controller_config(path)` returns the built `Controller`, and
+`build_controller(spec)` does the same for a config already in memory. Controllers that need a live object
+rather than a literal, such as the tokenizer of `PRMController`, take it through `{"$ref": "name"}` with the
+object passed in as `build_controller(spec, objects={"name": obj})`. Controllers under `contrib` can make
+themselves available by calling `register_controller(name, cls)`.
+
 ### [Contribute Guide](contrib)
 
 

--- a/tensorrt_llm/scaffolding/__init__.py
+++ b/tensorrt_llm/scaffolding/__init__.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 from .benchmark import ScaffoldingBenchRequest, async_scaffolding_benchmark
+from .config import (CONTROLLER_REGISTRY, build_controller,
+                     load_controller_config, register_controller)
 from .controller import (BestOfNController, ChatWithMCPController, Controller,
                          MajorityVoteController, NativeChatController,
                          NativeGenerationController, NativeRewardController,
@@ -37,6 +39,10 @@ __all__ = [
     "NativeRewardController",
     "PRMController",
     "MajorityVoteController",
+    "CONTROLLER_REGISTRY",
+    "build_controller",
+    "load_controller_config",
+    "register_controller",
     "BestOfNController",
     "ChatWithMCPController",
     "Task",

--- a/tensorrt_llm/scaffolding/config.py
+++ b/tensorrt_llm/scaffolding/config.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build scaffolding controllers from a declarative config file.
+
+Controllers compose recursively: ``MajorityVoteController`` wraps a generation
+controller, and ``BestOfNController`` wraps a generation controller and a reward
+controller. A config is therefore a tree. Any object carrying a ``"type"`` key is
+a controller node, and its ``"args"`` are passed straight to the constructor;
+nested controller arguments are built first, depth first.
+
+Example:
+    ```python
+    from tensorrt_llm.scaffolding import load_controller_config
+
+    controller = load_controller_config("majority_vote.json")
+    ```
+
+    where ``majority_vote.json`` is:
+
+    ```json
+    {
+      "controller": {
+        "type": "MajorityVoteController",
+        "args": {
+          "default_sample_num": 3,
+          "generation_controller": {
+            "type": "NativeGenerationController",
+            "args": {"sampling_params": {"max_tokens": 1024, "temperature": 0.9}}
+          }
+        }
+      }
+    }
+    ```
+
+Note:
+    ``"type"`` is reserved. Any mapping carrying that key is read as a nested controller
+    node, so a controller argument that is itself a plain dict cannot contain a literal
+    ``"type"`` entry -- it would be routed into :func:`build_controller` and rejected as an
+    unknown controller type. No controller in ``CONTROLLER_REGISTRY`` takes such an argument
+    today. The rejection is deliberate: mistyping a controller name is far more likely than
+    needing a ``"type"`` key in a data argument, and failing loudly on the typo is worth more
+    than supporting the rarer case. Arguments that must carry arbitrary keys should be nested
+    one level deeper, where they are passed through untouched.
+"""
+
+from typing import Any, Dict, Mapping, Optional, Type
+
+import yaml
+
+from .controller import (
+    BestOfNController,
+    ChatWithMCPController,
+    Controller,
+    MajorityVoteController,
+    NativeChatController,
+    NativeGenerationController,
+    NativeRewardController,
+    PRMController,
+)
+
+# Explicit name -> class mapping. Deliberately a literal table rather than a
+# module scan, so that reading a config never triggers an import side effect and
+# the set of constructible controllers stays obvious.
+CONTROLLER_REGISTRY: Dict[str, Type[Controller]] = {
+    "NativeGenerationController": NativeGenerationController,
+    "NativeChatController": NativeChatController,
+    "NativeRewardController": NativeRewardController,
+    "PRMController": PRMController,
+    "MajorityVoteController": MajorityVoteController,
+    "BestOfNController": BestOfNController,
+    "ChatWithMCPController": ChatWithMCPController,
+}
+
+# Key marking a controller node.
+TYPE_KEY = "type"
+# Key holding the constructor arguments of a controller node.
+ARGS_KEY = "args"
+# Key marking a reference to a caller-supplied live object.
+REF_KEY = "$ref"
+
+
+def register_controller(name: str, controller_cls: Type[Controller]) -> None:
+    """Make a controller constructible by name from a config file.
+
+    Contributed controllers under ``scaffolding/contrib`` can call this at import
+    time so that they become available without the core registry importing them.
+
+    Args:
+        name: Name used as the ``"type"`` value in configs.
+        controller_cls: The controller class to construct.
+
+    Raises:
+        TypeError: If ``controller_cls`` is not a ``Controller`` subclass.
+        ValueError: If ``name`` is already registered to a different class.
+    """
+    if not (isinstance(controller_cls, type) and issubclass(controller_cls, Controller)):
+        raise TypeError(
+            f"{name!r} must be registered to a Controller subclass, got {controller_cls!r}"
+        )
+
+    existing = CONTROLLER_REGISTRY.get(name)
+    if existing is not None and existing is not controller_cls:
+        raise ValueError(f"Controller name {name!r} is already registered to {existing.__name__}")
+
+    CONTROLLER_REGISTRY[name] = controller_cls
+
+
+def _is_controller_spec(value: Any) -> bool:
+    """Return True if the value describes a nested controller."""
+    return isinstance(value, Mapping) and TYPE_KEY in value
+
+
+def _resolve_value(value: Any, objects: Mapping[str, Any], path: str) -> Any:
+    """Resolve a single constructor argument.
+
+    Nested controller specs are built recursively, ``$ref`` entries are looked up
+    in ``objects``, and lists are resolved element-wise. Everything else is passed
+    through unchanged, so plain dicts such as ``sampling_params`` stay dicts.
+    """
+    if _is_controller_spec(value):
+        return build_controller(value, objects=objects, _path=path)
+
+    if isinstance(value, Mapping) and REF_KEY in value:
+        ref = value[REF_KEY]
+        if ref not in objects:
+            available = ", ".join(sorted(objects)) or "<none>"
+            raise KeyError(f"{path}: unknown object reference {ref!r}. Available: {available}")
+        return objects[ref]
+
+    if isinstance(value, list):
+        return [_resolve_value(item, objects, f"{path}[{i}]") for i, item in enumerate(value)]
+
+    return value
+
+
+def build_controller(
+    spec: Mapping[str, Any],
+    objects: Optional[Mapping[str, Any]] = None,
+    _path: str = "controller",
+) -> Controller:
+    """Construct a controller from an in-memory config node.
+
+    Args:
+        spec: Mapping with a ``"type"`` key naming a registered controller and an
+            optional ``"args"`` mapping of constructor arguments.
+        objects: Live objects that cannot be expressed in a config file, such as a
+            tokenizer for ``PRMController`` or the tool list for
+            ``ChatWithMCPController``. Reference them from the config with
+            ``{"$ref": "<name>"}``.
+
+    Returns:
+        The constructed controller, with nested controllers already built.
+
+    Raises:
+        TypeError: If ``spec`` is not a mapping, or the arguments do not match the
+            controller's signature.
+        ValueError: If ``"type"`` is missing or names an unregistered controller.
+    """
+    objects = objects or {}
+
+    if not isinstance(spec, Mapping):
+        raise TypeError(
+            f"{_path}: expected a mapping describing a controller, got {type(spec).__name__}"
+        )
+
+    type_name = spec.get(TYPE_KEY)
+    if type_name is None:
+        raise ValueError(f"{_path}: missing required {TYPE_KEY!r} key")
+
+    controller_cls = CONTROLLER_REGISTRY.get(type_name)
+    if controller_cls is None:
+        known = ", ".join(sorted(CONTROLLER_REGISTRY))
+        raise ValueError(
+            f"{_path}: unknown controller type {type_name!r}. Registered types: {known}"
+        )
+
+    unexpected = set(spec) - {TYPE_KEY, ARGS_KEY}
+    if unexpected:
+        raise ValueError(
+            f"{_path}: unexpected key(s) {sorted(unexpected)}; "
+            f"constructor arguments belong under {ARGS_KEY!r}"
+        )
+
+    raw_args = spec.get(ARGS_KEY) or {}
+    if not isinstance(raw_args, Mapping):
+        raise TypeError(f"{_path}.{ARGS_KEY}: expected a mapping, got {type(raw_args).__name__}")
+
+    args = {
+        key: _resolve_value(value, objects, f"{_path}.{ARGS_KEY}.{key}")
+        for key, value in raw_args.items()
+    }
+
+    try:
+        return controller_cls(**args)
+    except TypeError as e:
+        raise TypeError(f"{_path}: cannot construct {type_name} with {sorted(args)}: {e}") from e
+
+
+def load_controller_config(
+    path: str,
+    objects: Optional[Mapping[str, Any]] = None,
+) -> Controller:
+    """Build a controller from a JSON or YAML config file.
+
+    The file must contain a top-level ``"controller"`` key. Parsing goes through
+    ``yaml.safe_load``, which accepts JSON as well, so both formats work.
+
+    Args:
+        path: Path to the config file.
+        objects: Live objects referenced from the config via ``{"$ref": "<name>"}``.
+
+    Returns:
+        The constructed controller.
+
+    Raises:
+        ValueError: If the file is empty or has no top-level ``"controller"`` key.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    if not isinstance(config, Mapping):
+        raise ValueError(
+            f"{path}: expected a mapping at the top level, got {type(config).__name__}"
+        )
+
+    if "controller" not in config:
+        raise ValueError(f"{path}: missing required top-level 'controller' key")
+
+    return build_controller(config["controller"], objects=objects)

--- a/tests/unittest/scaffolding/test_controller_config.py
+++ b/tests/unittest/scaffolding/test_controller_config.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for building scaffolding controllers from a config file.
+
+These tests construct controllers only; no model is loaded and no worker runs,
+so they are CPU-only and need no model cache.
+"""
+
+import json
+
+import pytest
+
+from tensorrt_llm.scaffolding import (
+    BestOfNController,
+    ChatWithMCPController,
+    Controller,
+    MajorityVoteController,
+    NativeChatController,
+    NativeGenerationController,
+    NativeRewardController,
+    PRMController,
+    build_controller,
+    load_controller_config,
+    register_controller,
+)
+
+
+class TestBuildFlatController:
+    def test_sampling_params_round_trip(self):
+        controller = build_controller(
+            {
+                "type": "NativeGenerationController",
+                "args": {"sampling_params": {"max_tokens": 1024, "temperature": 0.9}},
+            }
+        )
+
+        assert isinstance(controller, NativeGenerationController)
+        assert controller.sampling_params == {"max_tokens": 1024, "temperature": 0.9}
+        assert controller.streaming is False
+
+    def test_args_key_is_optional(self):
+        controller = build_controller({"type": "NativeRewardController"})
+        assert isinstance(controller, NativeRewardController)
+
+    def test_plain_dict_arg_is_not_treated_as_a_controller(self):
+        """A dict without a "type" key stays a dict."""
+        controller = build_controller(
+            {
+                "type": "NativeGenerationController",
+                "args": {"sampling_params": {"max_tokens": 4, "top_k": 50}},
+            }
+        )
+        assert isinstance(controller.sampling_params, dict)
+
+    def test_dict_arg_containing_a_type_key_is_rejected(self):
+        """Reserved key: a data dict carrying "type" is read as a controller node.
+
+        Documented in the config module. Failing loudly here is deliberate -- it keeps a
+        mistyped controller name from being silently passed through as data.
+        """
+        with pytest.raises(ValueError, match="unknown controller type"):
+            build_controller(
+                {
+                    "type": "NativeGenerationController",
+                    "args": {"sampling_params": {"type": "json_object"}},
+                }
+            )
+
+
+class TestBuildNestedController:
+    def test_majority_vote_wraps_generation_controller(self):
+        controller = build_controller(
+            {
+                "type": "MajorityVoteController",
+                "args": {
+                    "default_sample_num": 3,
+                    "generation_controller": {
+                        "type": "NativeGenerationController",
+                        "args": {"sampling_params": {"max_tokens": 8}},
+                    },
+                },
+            }
+        )
+
+        assert isinstance(controller, MajorityVoteController)
+        assert controller.default_sample_num == 3
+        assert isinstance(controller.generation_controller, NativeGenerationController)
+        assert controller.generation_controller.sampling_params == {"max_tokens": 8}
+
+    def test_best_of_n_builds_both_sub_controllers(self):
+        controller = build_controller(
+            {
+                "type": "BestOfNController",
+                "args": {
+                    "default_sample_num": 4,
+                    "generation_controller": {"type": "NativeGenerationController"},
+                    "reward_controller": {"type": "NativeRewardController"},
+                },
+            }
+        )
+
+        assert isinstance(controller, BestOfNController)
+        assert isinstance(controller.generation_controller, NativeGenerationController)
+        assert isinstance(controller.reward_controller, NativeRewardController)
+
+    def test_three_levels_of_nesting(self):
+        controller = build_controller(
+            {
+                "type": "MajorityVoteController",
+                "args": {
+                    "generation_controller": {
+                        "type": "BestOfNController",
+                        "args": {
+                            "generation_controller": {"type": "NativeChatController"},
+                            "reward_controller": {"type": "NativeRewardController"},
+                        },
+                    }
+                },
+            }
+        )
+
+        inner = controller.generation_controller
+        assert isinstance(inner, BestOfNController)
+        assert isinstance(inner.generation_controller, NativeChatController)
+
+
+class TestLiveObjectReferences:
+    def test_prm_controller_receives_tokenizer(self):
+        """Controllers needing live objects get them through {"$ref": ...}."""
+        tokenizer = object()
+
+        controller = build_controller(
+            {
+                "type": "PRMController",
+                "args": {"tokenizer": {"$ref": "tokenizer"}, "split_steps": False},
+            },
+            objects={"tokenizer": tokenizer},
+        )
+
+        assert isinstance(controller, PRMController)
+        assert controller.tokenizer is tokenizer
+        assert controller.split_steps is False
+
+    def test_chat_with_mcp_controller_receives_tools(self):
+        tools = [{"name": "search"}]
+
+        controller = build_controller(
+            {
+                "type": "ChatWithMCPController",
+                "args": {
+                    "generation_controller": {"type": "NativeGenerationController"},
+                    "tools": {"$ref": "tools"},
+                    "max_iterations": 5,
+                },
+            },
+            objects={"tools": tools},
+        )
+
+        assert isinstance(controller, ChatWithMCPController)
+        assert controller.tools is tools
+        assert controller.max_iterations == 5
+
+    def test_unresolved_reference_is_reported(self):
+        with pytest.raises(KeyError, match="unknown object reference"):
+            build_controller(
+                {"type": "PRMController", "args": {"tokenizer": {"$ref": "missing"}}},
+                objects={},
+            )
+
+
+class TestConfigErrors:
+    def test_unknown_type_lists_registered_types(self):
+        with pytest.raises(ValueError, match="unknown controller type"):
+            build_controller({"type": "NoSuchController"})
+
+    def test_missing_type_key(self):
+        with pytest.raises(ValueError, match="missing required"):
+            build_controller({"args": {}})
+
+    def test_unexpected_constructor_argument(self):
+        with pytest.raises(TypeError, match="cannot construct NativeGenerationController"):
+            build_controller({"type": "NativeGenerationController", "args": {"not_a_real_arg": 1}})
+
+    def test_nested_failure_reports_the_path(self):
+        with pytest.raises(ValueError, match=r"controller\.args\.generation_controller"):
+            build_controller(
+                {
+                    "type": "MajorityVoteController",
+                    "args": {"generation_controller": {"type": "Bogus"}},
+                }
+            )
+
+    def test_stray_top_level_key_is_rejected(self):
+        with pytest.raises(ValueError, match="unexpected key"):
+            build_controller({"type": "NativeRewardController", "sampling_params": {}})
+
+
+class TestRegisterController:
+    def test_registered_controller_can_be_built(self):
+        class _MyController(Controller):
+            def __init__(self, k: int = 1):
+                super().__init__()
+                self.k = k
+
+        register_controller("_MyController", _MyController)
+        controller = build_controller({"type": "_MyController", "args": {"k": 7}})
+
+        assert isinstance(controller, _MyController)
+        assert controller.k == 7
+
+    def test_non_controller_is_rejected(self):
+        with pytest.raises(TypeError):
+            register_controller("_NotAController", dict)
+
+    def test_duplicate_name_with_different_class_is_rejected(self):
+        class _First(Controller):
+            pass
+
+        class _Second(Controller):
+            pass
+
+        register_controller("_Duplicate", _First)
+        register_controller("_Duplicate", _First)  # same class is idempotent
+        with pytest.raises(ValueError, match="already registered"):
+            register_controller("_Duplicate", _Second)
+
+
+class TestLoadControllerConfig:
+    def test_load_from_json(self, tmp_path):
+        spec = {
+            "controller": {
+                "type": "MajorityVoteController",
+                "args": {
+                    "default_sample_num": 3,
+                    "generation_controller": {
+                        "type": "NativeGenerationController",
+                        "args": {"sampling_params": {"max_tokens": 1024}},
+                    },
+                },
+            }
+        }
+        path = tmp_path / "controller.json"
+        path.write_text(json.dumps(spec, indent=2))
+
+        controller = load_controller_config(str(path))
+
+        assert isinstance(controller, MajorityVoteController)
+        assert controller.default_sample_num == 3
+
+    def test_load_from_yaml(self, tmp_path):
+        """JSON and YAML share one code path via yaml.safe_load."""
+        path = tmp_path / "controller.yaml"
+        path.write_text(
+            "controller:\n"
+            "  type: BestOfNController\n"
+            "  args:\n"
+            "    default_sample_num: 4\n"
+            "    generation_controller:\n"
+            "      type: NativeGenerationController\n"
+            "      args:\n"
+            "        sampling_params: {max_tokens: 512}\n"
+            "    reward_controller:\n"
+            "      type: NativeRewardController\n"
+        )
+
+        controller = load_controller_config(str(path))
+
+        assert isinstance(controller, BestOfNController)
+        assert controller.default_sample_num == 4
+        assert controller.generation_controller.sampling_params == {"max_tokens": 512}
+
+    def test_missing_top_level_controller_key(self, tmp_path):
+        path = tmp_path / "controller.json"
+        path.write_text(json.dumps({"nope": {}}))
+
+        with pytest.raises(ValueError, match="missing required top-level"):
+            load_controller_config(str(path))


### PR DESCRIPTION
## Description

Closes #3330

Controllers currently have to be built in Python, and because they compose recursively
(`MajorityVoteController` wraps a generation controller; `BestOfNController` wraps a generation
controller *and* a reward controller), sharing or migrating a method means sharing code. This adds a
declarative alternative: a config tree where any node with a `"type"` key names a registered controller
and its `"args"` go to the constructor, with nested controller arguments built depth first.

```json
{
  "controller": {
    "type": "MajorityVoteController",
    "args": {
      "default_sample_num": 3,
      "generation_controller": {
        "type": "NativeGenerationController",
        "args": { "sampling_params": { "max_tokens": 1024, "temperature": 0.9 } }
      }
    }
  }
}
```

```python
from tensorrt_llm.scaffolding import load_controller_config
controller = load_controller_config("majority_vote.json")
```

### What's included

- **`tensorrt_llm/scaffolding/config.py`** — `build_controller()`, `load_controller_config()`,
  `register_controller()`, and `CONTROLLER_REGISTRY`
- **`tensorrt_llm/scaffolding/__init__.py`** — export the four names
- **`tests/unittest/scaffolding/test_controller_config.py`** — 20 tests, CPU-only, no model load
- **`examples/scaffolding/run_from_config.py`** + three sample configs
- **`tensorrt_llm/scaffolding/README.md`** — a section under Getting Started

No existing controller code is modified.

### Design notes

Three points follow `CODING_GUIDELINES.md` directly:

- **Module-level functions, not a `Controller.from_dict()` classmethod** — the guidelines say to avoid
  `from_dict()` / `from_kwargs()` and construct classes directly from arguments, so `build_controller`
  calls `cls(**args)`.
- **An explicit registry table, not a module scan** — per "Avoid Reflection". Reading a config never
  triggers an import side effect, and the constructible set stays obvious. `register_controller` lets
  `contrib` controllers opt in without the core importing them.
- **`yaml.safe_load` for parsing** — JSON and YAML then share one code path, and `pyyaml` is already a
  dependency.

Errors name the failing config path, e.g.
`controller.args.generation_controller: unknown controller type 'Bogus'. Registered types: ...`.

### One decision worth a reviewer's opinion

`PRMController` needs a `tokenizer` and `ChatWithMCPController` needs `tools` — live objects that cannot
be written into a config file. Without an escape hatch, two of the seven built-ins would not be
constructible. They are handled with a `$ref` indirection:

```python
build_controller(spec, objects={"tokenizer": tokenizer})
```
```json
{ "type": "PRMController", "args": { "tokenizer": {"$ref": "tokenizer"}, "split_steps": false } }
```

This is a judgement call rather than something established in the codebase. I'm happy to drop it and
leave those two controllers out of the first version if a smaller surface is preferred. Discussed in
[#3330](https://github.com/NVIDIA/TensorRT-LLM/issues/3330).

Worker construction is deliberately out of scope — workers need model paths, endpoints and credentials,
and the issue asks specifically about the Controller. It is a natural follow-up.

## Test Coverage

`tests/unittest/scaffolding/test_controller_config.py` — picked up automatically by the existing
`unittest/scaffolding` directory entry in `tests/integration/test_lists/test-db/l0_h100.yml`. The tests
construct controllers only; no model is loaded and no worker runs, so they are CPU-only and need no
model cache.

Covered: flat construction and `sampling_params` round-trip; a plain dict argument not being mistaken
for a controller node; two- and three-level nesting; both `$ref` paths; the five error cases (unknown
type, missing `type`, bad kwarg, nested path reporting, stray top-level key); registry duplicate and
non-`Controller` rejection; and loading from both `.json` and `.yaml`.

Locally, all 20 pass against current `main`'s scaffolding package.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help
To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added recursive `build_controller()` construction for registered controllers.
- Added `load_controller_config()` for JSON and YAML files.
- Added `CONTROLLER_REGISTRY` and `register_controller()`.
- Added `$ref` support for injecting live objects.
- Added contextual configuration and constructor errors.
- Added documentation, examples, and a config-driven runner.
- Existing controller code remains unchanged.
- Configuration examples use valid JSON/YAML structure and consistent controller parameters.
- No test-list files changed.
- Verdict: sufficient.

## QA Engineer Review

- Added CPU-only tests for flat and nested controller construction, JSON/YAML loading, sampling parameters, optional arguments, `$ref` injection, unresolved references, configuration and constructor errors, controller registration, reserved `"type"` keys, and missing top-level configuration keys.
- No corresponding `tests/integration/test_lists/`, `test-db/`, or `qa/` entries were added.
- Verdict: needs follow-up for CI or manual QA test-list coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->