### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/examples/serve/compatibility/README.md
+++ b/examples/serve/compatibility/README.md
@@ -65,6 +65,8 @@ base_url = "http://localhost:8000/v1"
 api_key = "tensorrt_llm"  # Can be any string
 ```
 
+> **Tip:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting the server — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=tensorrt-llm&utm_content=compatibility) at `https://api.daoxe.com/v1`.
+
 To use a different server:
 
 ```python


### PR DESCRIPTION
Clarify that the OpenAI Python client `base_url` pattern works with TensorRT-LLM serve and with other OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com?utm_source=github&utm_medium=organic&utm_campaign=tensorrt-llm&utm_content=compatibility) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Updated `examples/serve/compatibility/README.md` to document OpenAI Python client compatibility with multi-model OpenAI-compatible gateways.
- Added DaoXE (`https://api.daoxe.com/v1`) as an example endpoint.
- The documentation change is consistent with the stated `base_url` usage.
- No runtime, API, configuration, or error-handling changes were made.

## QA Engineer Review

No test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->