### PR TITLE
[None][fix] Kimi K3: track shared expert output across streams

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_kimi_linear.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_linear.py
@@ -940,6 +940,11 @@ class KimiK3MoERuntime(nn.Module):
             self.aux_stream,
             disable_on_compile=True,
         )
+        if self.aux_stream is not None:
+            # ``shared_out`` may be allocated on the aux stream but is
+            # consumed by the addition below on the current stream. Keep its
+            # storage live until that cross-stream use completes.
+            shared_out.record_stream(torch.cuda.current_stream())
         return routed_out + shared_out
 
 

--- a/tests/unittest/_torch/modules/moe/test_kimi_k3_moe_multistream.py
+++ b/tests/unittest/_torch/modules/moe/test_kimi_k3_moe_multistream.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Kimi K3 shared/routed expert multi-stream tests."""
+
+from types import SimpleNamespace
+
+import torch
+
+
+def test_kimi_k3_moe_records_shared_output_on_main_stream(monkeypatch):
+    import tensorrt_llm._torch.models.modeling_kimi_linear as modeling_kimi_linear
+    from tensorrt_llm._torch.models.modeling_kimi_linear import KimiK3MoERuntime
+
+    class _Output:
+        def __init__(self):
+            self.recorded_streams = []
+
+        def record_stream(self, stream):
+            self.recorded_streams.append(stream)
+
+        def __add__(self, other):
+            return other
+
+    runtime = KimiK3MoERuntime.__new__(KimiK3MoERuntime)
+    torch.nn.Module.__init__(runtime)
+    runtime.gate = SimpleNamespace(compute_logits=lambda hidden_states: None)
+    runtime.shared_experts = lambda hidden_states: hidden_states
+    runtime.moe_main_event = object()
+    runtime.moe_shared_event = object()
+    runtime.aux_stream = object()
+
+    routed_out = _Output()
+    shared_out = _Output()
+    main_stream = object()
+    monkeypatch.setattr(
+        modeling_kimi_linear,
+        "maybe_execute_in_parallel",
+        lambda *args, **kwargs: (routed_out, shared_out),
+    )
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: main_stream)
+
+    assert runtime.forward(object()) is shared_out
+    assert shared_out.recorded_streams == [main_stream]


### PR DESCRIPTION
## Description

Kimi K3 already overlaps the routed-expert path on the current CUDA stream with the replicated shared expert on the model auxiliary stream. The shared output is then consumed by the final addition on the current stream.

Register that cross-stream use with the CUDA caching allocator via `shared_out.record_stream(torch.cuda.current_stream())`. This preserves the existing event-based fork/join scheduling while preventing the shared-output storage from being recycled before the current-stream addition completes. The pattern matches the cross-stream lifetime handling used by the KDA/MLA overlap in #17103.

Add a focused regression test that verifies the aux-stream result is recorded on the consuming stream before the final addition.

## Impact

No API, dtype, numerical, routing, or scheduling-policy change. This hardens the existing Kimi K3 shared/routed expert multi-stream path.

## Test Coverage

- `pre-commit run --files tensorrt_llm/_torch/models/modeling_kimi_linear.py tests/unittest/_torch/modules/moe/test_kimi_k3_moe_multistream.py`
- `python3 -m py_compile tensorrt_llm/_torch/models/modeling_kimi_linear.py tests/unittest/_torch/modules/moe/test_kimi_k3_moe_multistream.py`
- Targeted pytest was not runnable in the local shell: the available Python environments do not contain both PyTorch and pytest.

## PR Checklist

- [x] Focused change with a regression test
- [x] NVIDIA 2026 copyright header on the new file
- [x] DCO sign-off included
- [x] No public API or dependency changes