### PR TITLE
fix: handle NVFP4 scale-only checkpoint shards

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -443,9 +443,41 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
         # of the model on which load_state_dict is called (e.g., VLM models
         # where the text model lives at model.language_model.*).
         weight_name = prefix + weight_name
+        input_scale_name = weight_name.rsplit(".", 1)[0] + ".input_scale"
+        alpha_name = weight_name.rsplit(".", 1)[0] + ".alpha"
+        has_unified_hf_scales = (
+            weight_name + "_scale_2" in state_dict
+            and weight_name + "_scale" in state_dict
+            and input_scale_name in state_dict
+            and float4_sf_dtype
+        )
+        if has_unified_hf_scales and (
+            weight_name not in state_dict or state_dict[weight_name].dtype == torch.uint8
+        ):
+            # Unified HF checkpoint path. Sharded safetensors may present the
+            # packed weight and its scale tensors in different state_dict shards,
+            # so this path must not depend on the weight shard being present.
+            alpha = state_dict[weight_name + "_scale_2"] * state_dict[input_scale_name]
+            alpha = torch.clamp(alpha, min=1e-30)
+            state_dict[alpha_name] = alpha
+            input_scale = torch.clamp(state_dict[input_scale_name], min=1e-30)
+            state_dict[input_scale_name] = 1 / input_scale
+            weight_scale = state_dict[weight_name + "_scale"].view(float4_sf_dtype)
+            # Round the weight block scale factors to 128x4 and then swizzle.
+            weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
+                weight_scale.view(torch.uint8).cpu().contiguous()
+            ).view(float4_sf_dtype)
+
+            m, n = weight_scale.shape
+            # scaling factors m is padded along 128 and n is padded along 4.
+            # check cpp/tensorrt_llm/plugins/fp4GemmPlugin/fp4GemmPlugin.cpp for more details.
+            padded_m, padded_n = self._pad_m_n(m, n)
+            swizzled_shape = (padded_m, padded_n)
+
+            state_dict[weight_name + "_scale"] = weight_scale_swizzled.reshape(swizzled_shape)
+            return
+
         if weight_name in state_dict:
-            input_scale_name = weight_name.rsplit(".", 1)[0] + ".input_scale"
-            alpha_name = weight_name.rsplit(".", 1)[0] + ".alpha"
             weight = state_dict[weight_name]
             # ModelOpt quantized graph path
             if weight.dtype != torch.uint8:
@@ -465,7 +497,7 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                 # ``fp4_quantize`` returns the (swizzled) block scale as a flat
                 # 1-D tensor, but ``default_scales`` registers the buffer with the
                 # padded 2-D ``(padded_m, padded_n)`` cutlass shape -- the same
-                # shape the unified-HF-checkpoint branch below produces. Reshape
+                # shape the unified-HF-checkpoint branch above produces. Reshape
                 # here so this on-the-fly (bf16 ModelOpt) path stays consistent
                 # with the registered buffer and the HF path; otherwise the flat
                 # scale fails ``load_state_dict`` with a size mismatch.
@@ -477,34 +509,6 @@ class NVFP4LinearQuantizationFromConfig(Quantization):
                 state_dict[alpha_name] = 1 / torch.clamp(
                     weight_scale_2 * state_dict[input_scale_name], min=1e-30
                 )
-            # Unified HF ckpt path
-            else:
-                if (
-                    weight_name + "_scale_2" in state_dict
-                    and weight_name + "_scale" in state_dict
-                    and input_scale_name in state_dict
-                    and float4_sf_dtype
-                ):
-                    alpha = state_dict[weight_name + "_scale_2"] * state_dict[input_scale_name]
-                    alpha = torch.clamp(alpha, min=1e-30)
-                    state_dict[alpha_name] = alpha
-                    input_scale = torch.clamp(state_dict[input_scale_name], min=1e-30)
-                    state_dict[input_scale_name] = 1 / input_scale
-                    weight_scale = state_dict[weight_name + "_scale"].view(float4_sf_dtype)
-                    # Round the weight block scale factors to 128x4 and then swizzle.
-                    weight_scale_swizzled = torch.ops.trtllm.block_scale_interleave(
-                        weight_scale.view(torch.uint8).cpu().contiguous()
-                    ).view(float4_sf_dtype)
-
-                    m, n = weight_scale.shape
-                    # scaling factors m is padded along 128 and n is padded along 4.
-                    # check cpp/tensorrt_llm/plugins/fp4GemmPlugin/fp4GemmPlugin.cpp for more details.
-                    padded_m, padded_n = self._pad_m_n(m, n)
-                    swizzled_shape = (padded_m, padded_n)
-
-                    state_dict[weight_name + "_scale"] = weight_scale_swizzled.reshape(
-                        swizzled_shape
-                    )
 
     def convert_amax_hook(self, state_dict, prefix, *args, scale_name: str, amax_name: str):
         """Convert amax from modelopt quantized graph to scales."""

--- a/tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py
+++ b/tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py
@@ -130,3 +130,32 @@ def test_fp8_load_hook_maps_prequantized_scales_with_prefix():
     )
     assert prefix + "layer.proj.activation_scale" not in mock_state_dict
     assert prefix + "layer.proj.weight_scale_inv" not in mock_state_dict
+
+
+def test_nvfp4_load_hook_maps_scale_only_shard_with_prefix(monkeypatch):
+    from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
+        NVFP4LinearQuantizationFromConfig,
+    )
+
+    monkeypatch.setattr(
+        torch.ops.trtllm,
+        "block_scale_interleave",
+        lambda weight_scale: weight_scale,
+        raising=False,
+    )
+
+    config = TransformConfig(stage="pattern_matcher")
+    nvfp4_imp = NVFP4LinearQuantizationFromConfig(config)
+
+    weight_name = "layer.proj.weight"
+    prefix = "nested."
+    mock_state_dict = {
+        prefix + weight_name + "_scale_2": torch.tensor(2.0, dtype=torch.float32),
+        prefix + weight_name + "_scale": torch.ones(128, 4, dtype=torch.float8_e4m3fn),
+        prefix + "layer.proj.input_scale": torch.tensor(3.0, dtype=torch.float32),
+    }
+
+    nvfp4_imp.load_hook(mock_state_dict, prefix, None, weight_name=weight_name)
+
+    assert mock_state_dict[prefix + "layer.proj.alpha"] == torch.tensor(6.0)
+    assert mock_state_dict[prefix + "layer.proj.input_scale"] == torch.tensor(1.0 / 3.0)

--- a/tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py
+++ b/tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py
@@ -132,15 +132,24 @@ def test_fp8_load_hook_maps_prequantized_scales_with_prefix():
     assert prefix + "layer.proj.weight_scale_inv" not in mock_state_dict
 
 
-def test_nvfp4_load_hook_maps_scale_only_shard_with_prefix(monkeypatch):
+def test_nvfp4_load_hook_maps_scale_only_shard_with_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
         NVFP4LinearQuantizationFromConfig,
     )
 
+    expected_weight_scale = torch.arange(128 * 4, dtype=torch.int16).to(torch.uint8)
+
+    def _mock_block_scale_interleave(weight_scale: torch.Tensor) -> torch.Tensor:
+        assert tuple(weight_scale.shape) == (128, 4)
+        assert weight_scale.dtype == torch.uint8
+        return expected_weight_scale
+
     monkeypatch.setattr(
         torch.ops.trtllm,
         "block_scale_interleave",
-        lambda weight_scale: weight_scale,
+        _mock_block_scale_interleave,
         raising=False,
     )
 
@@ -159,3 +168,9 @@ def test_nvfp4_load_hook_maps_scale_only_shard_with_prefix(monkeypatch):
 
     assert mock_state_dict[prefix + "layer.proj.alpha"] == torch.tensor(6.0)
     assert mock_state_dict[prefix + "layer.proj.input_scale"] == torch.tensor(1.0 / 3.0)
+    stored_weight_scale = mock_state_dict[prefix + weight_name + "_scale"]
+    assert tuple(stored_weight_scale.shape) == (128, 4)
+    assert torch.equal(
+        stored_weight_scale.view(torch.uint8).reshape(-1),
+        expected_weight_scale,
+    )


### PR DESCRIPTION
## Summary
- Allow the NVFP4 unified-HF checkpoint load hook to process scale-only state-dict shards.
- Keep the existing packed-weight path intact, while no longer requiring the packed weight to be present before computing `alpha`, inverted `input_scale`, and swizzled `weight_scale`.
- Add a regression test for a prefixed scale-only shard.

Fixes #11541

## Test Plan
- `python -m ruff check tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py`
- `python -m py_compile tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py tests/unittest/auto_deploy/singlegpu/utils/test_quantization_utils.py`
- Not run locally: targeted pytest is blocked in this Windows checkout because the environment lacks a usable MPI runtime (`impi.dll`/`msmpi.dll`) and compiled TensorRT-LLM bindings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated NVFP4 unified-HF checkpoint loading to process scale-only shards.
- The hook computes `alpha`, inverts `input_scale`, and swizzles `weight_scale` before requiring the packed weight.
- The existing packed-weight conversion path remains unchanged.
- No public API or configuration changes were found.
- Static checks, Python compilation, Ruff, and `git diff --check` passed.
- Targeted tests were not run because the Windows environment lacks usable MPI and compiled TensorRT-LLM bindings.

## QA Engineer Review

- Added `test_nvfp4_load_hook_maps_scale_only_shard_with_prefix`.
- The test validates scale loading from a prefixed, scale-only state dictionary.
- The test is not covered by a reported `test-db/` or `qa/` test-list entry.
- Verdict: needs follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->