### PR TITLE
[None][perf] Fuse KDA prefill Q/K normalization and beta sigmoid

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
@@ -25,15 +25,15 @@ Supported:
   - safe_gate mode (sigmoid + lower_bound) and softplus mode
   - dt_bias
   - use_gate_in_kernel=True with A_log
+  - optional in-kernel beta sigmoid
   - chunk_size=64
 
 The public ``trtllm::kda_prefill`` operator returns only the KDA output and
 final recurrent state. Intermediate matrices remain private runner workspace.
 """
 
-from typing import Optional, Tuple
-
 import weakref
+from typing import Optional, Tuple
 
 import torch
 
@@ -331,9 +331,8 @@ def _get_padded_input_buffers(B, T_padded, H, K, dtype_qkv, dtype_g, dtype_beta,
     return e
 
 
-def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT,
-                 varlen=False):
-    """All beta fusion lives in akk_inv kernel epilogue (post-inv column-scale)."""
+def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT, varlen=False):
+    """Return cached intermediate tensors for the KDA prefill pipeline."""
     key = (dev.index or 0, B, T, H, K_dim, V_dim, NT, N_seqs, varlen)
     if key not in _buf_cache:
         bf16 = cutlass.BFloat16
@@ -360,6 +359,7 @@ def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT,
         k_scaled = _with_slack(torch.empty, B, T_alloc, H, K_dim, dtype=dtype_k)  # raw, no beta
         kg = _with_slack(torch.empty, B, T_alloc, H, K_dim, dtype=dtype_k)
         q_scaled = _with_slack(torch.empty, B, T_alloc, H, K_dim, dtype=dtype_k)
+        beta_activated = _with_slack(torch.empty, B, T_alloc, H, dtype=torch.bfloat16)
         gk_last_exp = torch.empty(B, NT, H, K_dim, device=dev, dtype=torch.float32)
         A_qk = _with_slack(torch.zeros, B, T_alloc, H, BT, dtype=dtype_k)
         A_kk = _with_slack(torch.zeros, B, T_alloc, H, BT, dtype=dtype_k)
@@ -457,6 +457,7 @@ def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT,
             k_scaled,
             kg,
             q_scaled,
+            beta_activated,
             gk_last_exp,
             A_qk,
             A_kk,
@@ -599,6 +600,7 @@ def _launch_fused_k123_inv(
     g,
     A_log,
     beta,
+    beta_activated,
     scale,
     k_scaled,
     kg,
@@ -610,9 +612,11 @@ def _launch_fused_k123_inv(
     chunk_indices,
     is_varlen,
     NT,
+    valid_tokens,
     dt_bias=None,
     safe_gate=False,
     lower_bound=None,
+    use_beta_sigmoid_in_kernel=False,
     akk_in_view=None,
     akk_out_view=None,
     cute_wrappers=None,
@@ -676,6 +680,8 @@ def _launch_fused_k123_inv(
         varlen_pure,
         cu_ci_dtypes,
         eqlen_t_key,
+        use_beta_sigmoid_in_kernel,
+        beta.dtype,
     )
 
     # Inputs are guaranteed contiguous by upstream linear projections.
@@ -687,7 +693,14 @@ def _launch_fused_k123_inv(
     k_ct = _ct(k, cutlass.BFloat16)
     g_ct = _ct(g, cutlass.BFloat16)
     alog_ct = _ct(A_log if A_log.dtype == torch.float32 else A_log.float(), cutlass.Float32)
-    beta_ct = _ct(beta, cutlass.BFloat16)
+    if beta.dtype == torch.float32:
+        beta_etype = cutlass.Float32
+    elif beta.dtype == torch.bfloat16:
+        beta_etype = cutlass.BFloat16
+    else:
+        raise ValueError(f"Kimi K3 KDA prefill beta must be float32 or bfloat16, got {beta.dtype}")
+    beta_ct = _ct(beta, beta_etype)
+    beta_activated_ct = _ct_cached(beta_activated, cutlass.BFloat16)
 
     ks_ct = _ct_cached(k_scaled, cutlass.BFloat16)
     kg_ct = _ct_cached(kg, cutlass.BFloat16)
@@ -717,6 +730,7 @@ def _launch_fused_k123_inv(
         g_ct,
         alog_ct,
         beta_ct,
+        beta_activated_ct,
         scale,
         ks_ct,
         kg_ct,
@@ -732,6 +746,7 @@ def _launch_fused_k123_inv(
         NT,
         B,
         B * (T_padded if is_varlen else NT * BT),
+        valid_tokens,
         stream,
     )
 
@@ -744,6 +759,7 @@ def _launch_fused_k123_inv(
             T_padded=T_padded,
             has_bias=has_bias,
             use_safe_gate=safe_gate,
+            use_beta_sigmoid=use_beta_sigmoid_in_kernel,
             varlen_pure=varlen_pure,
         )
         _fused_k123_cache[cache_key] = cute.compile(host_fn, *ct_args)
@@ -771,17 +787,28 @@ def _launch_fused_k123_inv(
         is_varlen_int = 0
         T_val = NT * BT
 
+    beta_for_akk = beta_activated if use_beta_sigmoid_in_kernel else beta
+    if beta_for_akk.dtype == torch.float32:
+        akk_beta_etype = cutlass.Float32
+    else:
+        akk_beta_etype = cutlass.BFloat16
+    akk_beta_ct = (
+        _ct_cached(beta_for_akk, akk_beta_etype)
+        if use_beta_sigmoid_in_kernel
+        else _ct(beta_for_akk, akk_beta_etype)
+    )
+
     # B/NT/T_val remain runtime args of akk_inv_host. Eqlen T is still part of
-    # the cache key because the raw mBeta wrapper bakes its batch stride.
+    # the cache key because the beta wrapper bakes its batch stride.
     # cu/ci dtype is a specializer for the same reason as in the K123 key above
     # (element type baked into the compiled reader).
-    akk_cache_key = (H, is_varlen, dev, cu_ci_dtypes, eqlen_t_key)
+    akk_cache_key = (H, is_varlen, dev, cu_ci_dtypes, eqlen_t_key, beta_for_akk.dtype)
     if akk_cache_key not in _akk_inv_cache:
         _akk_inv_cache[akk_cache_key] = cute.compile(
             _akk_inv_host,
             akk_in_view,
             akk_out_view,
-            beta_ct,
+            akk_beta_ct,
             B,
             NT,
             H,
@@ -792,10 +819,8 @@ def _launch_fused_k123_inv(
             stream,
         )
     akk_fn = _akk_inv_cache[akk_cache_key]
-    akk_args = (akk_in_view, akk_out_view, beta_ct, B, NT, akk_cu_ct,
-                akk_ci_ct, T_val, stream)
+    akk_args = (akk_in_view, akk_out_view, akk_beta_ct, B, NT, akk_cu_ct, akk_ci_ct, T_val, stream)
     akk_fn(*akk_args)
-
 
 
 # ========== Fused K1234 compilation cache ==========
@@ -892,6 +917,7 @@ def _chunk_kda_fwd(
     safe_gate: bool = False,
     lower_bound: float | None = None,
     use_gate_in_kernel: bool = False,
+    use_beta_sigmoid_in_kernel: bool = False,
     A_log: torch.Tensor | None = None,
     dt_bias: torch.Tensor | None = None,
     disable_recompute: bool = False,
@@ -923,13 +949,14 @@ def _chunk_kda_fwd(
             # pool the initial state may alias.
             final_state = initial_state.to(torch.float32).clone()
         else:
-            final_state = torch.zeros(
-                n_seqs, H, K, V_dim, dtype=torch.float32, device=q.device)
-        return (o, final_state, None, None, None, None, None, None, None,
-                None, None, initial_state)
+            final_state = torch.zeros(n_seqs, H, K, V_dim, dtype=torch.float32, device=q.device)
+        return (o, final_state, None, None, None, None, None, None, None, None, None, initial_state)
 
-    # ===== Fused K1234 path (eqlen only, single kernel launch) =====
-    if use_fused_k1234 and not is_varlen:
+    # ===== Fused K1234 path (eqlen only, preprocessed Q/K/beta) =====
+    # Raw beta activation is implemented in the staged K123 pipeline.
+    # Preserve the requested input semantics by routing raw-beta calls there
+    # until K1234 has the equivalent transform.
+    if use_fused_k1234 and not is_varlen and not use_beta_sigmoid_in_kernel:
         o, final_state = _launch_fused_k1234(
             q,
             k,
@@ -1028,7 +1055,8 @@ def _chunk_kda_fwd(
         assert cur_T % BT == 0 and cur_T >= real_T, (
             f"varlen single-seq path expects caller-padded input "
             f"(T={cur_T}, seqlen={real_T}); see "
-            "KDAKernelDispatch.prefill_chunk_kda")
+            "KDAKernelDispatch.prefill_chunk_kda"
+        )
         g_pad = _get_g_sentinel_buffer(B, cur_T, H, K, g.dtype, g.device, real_T)
         g_pad[:, :real_T].copy_(g[:, :real_T])
         g = g_pad
@@ -1060,7 +1088,8 @@ def _chunk_kda_fwd(
             # KDAKernelDispatch.prefill_chunk_kda.
             raise ValueError(
                 f"kda_prefill requires >= 4 total varlen chunks (got {NT}); "
-                "route small varlen batches to the FLA fallback")
+                "route small varlen batches to the FLA fallback"
+            )
         N_seqs = len(cu_seqlens) - 1
     else:
         NT = T // BT
@@ -1071,6 +1100,7 @@ def _chunk_kda_fwd(
         k_scaled,
         kg,
         q_scaled,
+        beta_activated,
         gk_last_exp,
         A_qk,
         A_kk,
@@ -1079,8 +1109,7 @@ def _chunk_kda_fwd(
         cu_eqlen,
         co_eqlen,
         cute_wrappers,
-    ) = _get_buffers(device, k.dtype, B, T, H, K, V_dim, NT, N_seqs, BT,
-                     varlen=is_varlen)
+    ) = _get_buffers(device, k.dtype, B, T, H, K, V_dim, NT, N_seqs, BT, varlen=is_varlen)
 
     # ===== State copy on side stream, parallel with K123 =====
     # K4 needs S_out populated with initial_state. By doing this copy on a
@@ -1110,6 +1139,7 @@ def _chunk_kda_fwd(
         g,
         A_log,
         beta,
+        beta_activated,
         scale,
         k_scaled,
         kg,
@@ -1121,9 +1151,11 @@ def _chunk_kda_fwd(
         chunk_indices,
         is_varlen,
         NT,
+        real_T,
         dt_bias=dt_bias,
         safe_gate=safe_gate,
         lower_bound=lower_bound,
+        use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
         akk_in_view=cute_wrappers["akk_in_view"],
         akk_out_view=cute_wrappers["akk_out_view"],
         cute_wrappers=cute_wrappers,
@@ -1202,6 +1234,7 @@ class KdaPrefillRunner:
         safe_gate: bool = False,
         lower_bound: Optional[float] = None,
         use_gate_in_kernel: bool = False,
+        use_beta_sigmoid_in_kernel: bool = False,
         A_log: Optional[torch.Tensor] = None,
         dt_bias: Optional[torch.Tensor] = None,
         disable_recompute: bool = False,
@@ -1229,6 +1262,7 @@ class KdaPrefillRunner:
             safe_gate=safe_gate,
             lower_bound=lower_bound,
             use_gate_in_kernel=use_gate_in_kernel,
+            use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
             A_log=A_log,
             dt_bias=dt_bias,
             disable_recompute=disable_recompute,
@@ -1256,6 +1290,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         safe_gate: bool = False,
         lower_bound: Optional[float] = None,
         use_gate_in_kernel: bool = False,
+        use_beta_sigmoid_in_kernel: bool = False,
         A_log: Optional[torch.Tensor] = None,
         dt_bias: Optional[torch.Tensor] = None,
         disable_recompute: bool = False,
@@ -1263,6 +1298,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
         use_fused_k1234: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Run Kimi K3 KDA chunked prefill on Blackwell GPUs.
+
+        ``use_beta_sigmoid_in_kernel`` consumes beta logits and produces the
+        activated beta inside K123.
 
         Returns ``(output, final_state)``. ``final_state`` is an empty
         tensor when ``output_final_state`` is False —
@@ -1286,6 +1324,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             safe_gate=safe_gate,
             lower_bound=lower_bound,
             use_gate_in_kernel=use_gate_in_kernel,
+            use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             use_fused_k1234=use_fused_k1234,
@@ -1310,6 +1349,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         safe_gate: bool = False,
         lower_bound: Optional[float] = None,
         use_gate_in_kernel: bool = False,
+        use_beta_sigmoid_in_kernel: bool = False,
         A_log: Optional[torch.Tensor] = None,
         dt_bias: Optional[torch.Tensor] = None,
         disable_recompute: bool = False,
@@ -1318,7 +1358,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         del k, g, beta, A_log, scale, dt_bias, initial_state
         del chunk_indices, chunk_size, safe_gate, lower_bound
-        del use_gate_in_kernel, disable_recompute, return_intermediate_states
+        del use_gate_in_kernel, use_beta_sigmoid_in_kernel, disable_recompute
+        del return_intermediate_states
         del use_fused_k1234
         num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
         output = v.new_empty(v.shape)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/kimi_k3_kda/fused_k123.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/kimi_k3_kda/fused_k123.py
@@ -49,10 +49,10 @@ SMEM: ~215KB (q+k+g × [64,128] bf16 × 2 stages + g_cumsum [64,136] fp32 × 2 s
 
 Inputs:
   g       [B,T,H,K]   bf16  raw gate
-  k       [B,T,H,K]   bf16
-  q       [B,T,H,K]   bf16
+  k       [B,T,H,K]   bf16  normalized by caller
+  q       [B,T,H,K]   bf16  normalized by caller
   A_log   [H]          fp32  per-head log decay
-  beta    [B,T,H]      bf16  used for Akk unit lower triangular
+  beta    [B,T,H]      bf16/fp32, activated in-kernel when requested
   scale                fp32  1/sqrt(K)
 
 Outputs (g_cumsum stays in SMEM, not written to GMEM):
@@ -941,6 +941,7 @@ def fused_kernel123(
     tma_tensor_G: cute.Tensor,
     mA_log: cute.Tensor,
     mBeta: cute.Tensor,
+    mBetaActivated: cute.Tensor,
     scale: cutlass.Float32,
     mKscaled: cute.Tensor,
     mKg: cute.Tensor,
@@ -969,6 +970,8 @@ def fused_kernel123(
     lower_bound: cutlass.Float32,
     HAS_BIAS: cutlass.Constexpr[int],
     USE_SAFE_GATE: cutlass.Constexpr[int],
+    valid_tokens: cutlass.Int32,
+    USE_BETA_SIGMOID: cutlass.Constexpr[int],
     VARLEN_PURE: cutlass.Constexpr[int] = 0,
 ):
     block_id, _, _ = cute.arch.block_idx()
@@ -999,6 +1002,8 @@ def fused_kernel123(
     )
     sG = smem.allocate_tensor(cutlass.BFloat16, g_smem_layout, 128)
     sGcum = smem.allocate_tensor(cutlass.Float32, g_cumsum_layout, 128)
+    beta_layout = cute.make_layout((BT, NUM_STAGES), stride=(1, BT))
+    sBeta = smem.allocate_tensor(cutlass.BFloat16, beta_layout, 128)
     partial_last_layout = cute.make_layout((K1_ROW_GROUPS, PARTIAL_COLS), stride=(PARTIAL_COLS, 1))
     sPartialLast = smem.allocate_tensor(cutlass.Float32, partial_last_layout, 128)
 
@@ -1015,11 +1020,6 @@ def fused_kernel123(
     )
     sAkk = smem.allocate_tensor(cutlass.BFloat16, akk_tile_layout, 128)
     # sAkk_pkd / sTemp removed: akk_inv runs as a separate kernel call (chained back-to-back).
-
-    # sBeta staging removed: its only consumer (K1 Pass 2b) moved beta fusion
-    # into the akk_inv epilogue, and the dead staging loop kept reading
-    # mBeta[chunk_start .. chunk_start+63] unguarded — OOB past the tensor
-    # end for the final partial chunk of a varlen batch.
 
     # =====================================================================
     # Mbarrier allocation & init
@@ -1183,6 +1183,47 @@ def fused_kernel123(
                 )
                 for vi in cutlass.range_constexpr(VEC):
                     rAcc[vi] = cutlass.Float32(0.0)
+
+                # Activate beta once per token/head and retain the bf16
+                # result in this stage for K2. The activated GMEM scratch is
+                # consumed by akk_inv, beta's second pipeline consumer.
+                if k1_warp < 2:
+                    beta_row = k1_warp * 32 + lane_id
+                    beta_t = chunk_start + beta_row
+                    beta_value = cutlass.Float32(0.0)
+                    if IS_VARLEN:
+                        if chunk_idx < num_chunks:
+                            if beta_t < ci_eos:
+                                beta_value = mBeta[i_b, beta_t, i_h].to(cutlass.Float32)
+                                if USE_BETA_SIGMOID:
+                                    beta_value = fast_rcp(
+                                        cutlass.Float32(1.0)
+                                        + cute.exp2(
+                                            -beta_value * LOG2E,
+                                            fastmath=True,
+                                        )
+                                    )
+                                    mBetaActivated[i_b, beta_t, i_h] = beta_value.to(
+                                        cutlass.BFloat16
+                                    )
+                    else:
+                        if beta_t < valid_tokens:
+                            beta_value = mBeta[i_b, beta_t, i_h].to(cutlass.Float32)
+                            if USE_BETA_SIGMOID:
+                                beta_value = fast_rcp(
+                                    cutlass.Float32(1.0)
+                                    + cute.exp2(
+                                        -beta_value * LOG2E,
+                                        fastmath=True,
+                                    )
+                                )
+                        if USE_BETA_SIGMOID:
+                            # Eqlen padding is allocated storage, so publish
+                            # explicit zeros for its invalid tail. Applying
+                            # sigmoid to the padded zero logits would produce
+                            # 0.5 and corrupt the recurrent state.
+                            mBetaActivated[i_b, beta_t, i_h] = beta_value.to(cutlass.BFloat16)
+                    sBeta[beta_row, cur_stage] = beta_value.to(cutlass.BFloat16)
 
                 for ri in cutlass.range_constexpr(ROWS_PER_K1_WARP):
                     row = k1_row_start + ri
@@ -1490,7 +1531,6 @@ def fused_kernel123(
                 phase = chunk_iter // NUM_STAGES % 2
                 chunk_idx = chunk_base + chunk_iter
                 chunk_start = cutlass.Int32(0)
-                mma_eos = cutlass.Int32(0)
                 if IS_VARLEN:
                     if chunk_idx < num_chunks:
                         _sid = cutlass.Int32(mChunkIndices[chunk_idx, 0])
@@ -1498,7 +1538,6 @@ def fused_kernel123(
                             cutlass.Int32(mCuSeqlens[_sid])
                             + cutlass.Int32(mChunkIndices[chunk_idx, 1]) * BT
                         )
-                        mma_eos = cutlass.Int32(mCuSeqlens[_sid + 1])
                 else:
                     chunk_start = chunk_idx * BT
 
@@ -1514,31 +1553,11 @@ def fused_kernel123(
 
                     _z = cutlass.Float32(0.0)
 
-                    # Varlen non-pure: a partial chunk's rows past the
-                    # sequence end must not be read — for the batch's final
-                    # chunk they lie past the end of the beta tensor
-                    # entirely (OOB read; NaN/IMA under memory pressure).
-                    # Their A-row contributions are discarded downstream, so
-                    # beta=0 is safe. Eqlen and VARLEN_PURE inputs are
-                    # padded/aligned upstream — load unconditionally there.
-                    beta_row0 = _z
-                    beta_row1 = _z
-                    if IS_VARLEN and not VARLEN_PURE:
-                        if chunk_start + q_row_base + row0 < mma_eos:
-                            beta_row0 = mBeta[
-                                i_b, chunk_start + q_row_base + row0, i_h
-                            ].to(cutlass.Float32)
-                        if chunk_start + q_row_base + row1 < mma_eos:
-                            beta_row1 = mBeta[
-                                i_b, chunk_start + q_row_base + row1, i_h
-                            ].to(cutlass.Float32)
-                    else:
-                        beta_row0 = mBeta[
-                            i_b, chunk_start + q_row_base + row0, i_h
-                        ].to(cutlass.Float32)
-                        beta_row1 = mBeta[
-                            i_b, chunk_start + q_row_base + row1, i_h
-                        ].to(cutlass.Float32)
+                    # K1 stages activated beta with invalid rows set to zero.
+                    # Reading it from SMEM also avoids repeating sigmoid for
+                    # every lower-triangular K2 tile that shares a query row.
+                    beta_row0 = sBeta[q_row_base + row0, s].to(cutlass.Float32)
+                    beta_row1 = sBeta[q_row_base + row1, s].to(cutlass.Float32)
 
                     acc_aqk_n0_0, acc_aqk_n0_1, acc_aqk_n0_2, acc_aqk_n0_3 = _z, _z, _z, _z
                     acc_aqk_n1_0, acc_aqk_n1_1, acc_aqk_n1_2, acc_aqk_n1_3 = _z, _z, _z, _z
@@ -2090,7 +2109,15 @@ def fused_kernel123(
 # Host function
 # =========================================================================
 def make_host_function(
-    B, NT, H, is_varlen=False, T_padded=None, has_bias=False, use_safe_gate=False, varlen_pure=False
+    B,
+    NT,
+    H,
+    is_varlen=False,
+    T_padded=None,
+    has_bias=False,
+    use_safe_gate=False,
+    use_beta_sigmoid=False,
+    varlen_pure=False,
 ):
     """
     `varlen_pure=True` asserts that all seq lengths in the batch are multiples
@@ -2103,6 +2130,7 @@ def make_host_function(
     _IS_VARLEN = 1 if is_varlen else 0
     _HAS_BIAS = 1 if has_bias else 0
     _USE_SAFE_GATE = 1 if use_safe_gate else 0
+    _USE_BETA_SIGMOID = 1 if use_beta_sigmoid else 0
     _VARLEN_PURE = 1 if (is_varlen and varlen_pure) else 0
     if is_varlen:
         assert B == 1, "Varlen requires B=1"
@@ -2125,6 +2153,7 @@ def make_host_function(
         mG,
         mA_log,
         mBeta,
+        mBetaActivated,
         scale,
         mKscaled,
         mKg,
@@ -2139,6 +2168,7 @@ def make_host_function(
         rt_nt: cutlass.Int32,
         rt_b: cutlass.Int32,
         rt_t_total: cutlass.Int32,
+        valid_tokens: cutlass.Int32,
         # Launch stream — a runtime argument (the executor runs the model on
         # a dedicated non-blocking torch stream; launching on the DSL default
         # stream races with the caller's stream). See _launch_fused_k123_inv.
@@ -2247,6 +2277,7 @@ def make_host_function(
             BT * K_DIM * 2 * 2 * NUM_STAGES
             + BT * K_DIM * 2 * NUM_STAGES
             + BT * K_STRIDE * 4 * NUM_STAGES
+            + BT * NUM_STAGES * 2  # sBeta bf16
             + K1_ROW_GROUPS * PARTIAL_COLS * 4
             + BT * AQK_TILE_STRIDE * 2 * NUM_STAGES  # sAqk bf16 (64x72 row-major)
             + BT * AKK_STRIDE * 2 * NUM_STAGES  # sAkk bf16
@@ -2267,6 +2298,7 @@ def make_host_function(
             tma_tensor_G,
             mA_log,
             mBeta,
+            mBetaActivated,
             scale,
             mKscaled_v2,
             mKg_v2,
@@ -2295,6 +2327,8 @@ def make_host_function(
             lower_bound_val,
             _HAS_BIAS,
             _USE_SAFE_GATE,
+            valid_tokens,
+            _USE_BETA_SIGMOID,
             _VARLEN_PURE,
         ).launch(
             grid=(_grid_x, 1, 1),

--- a/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
+++ b/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
@@ -23,6 +23,7 @@ the delta-rule inner loop plus its state update.
 from __future__ import annotations
 
 import importlib
+import os
 from types import ModuleType
 from typing import Optional, Tuple
 
@@ -70,6 +71,14 @@ def is_kda_optimized_supported() -> bool:
 
 _PREFILL_MODULE: Optional[ModuleType] = None
 _PREFILL_IMPORT_ERROR: Optional[BaseException] = None
+_FUSED_PREFILL_PREPROCESS_ENV = "TRTLLM_KDA_USE_FUSED_PREFILL_PREPROCESS"
+
+
+def _use_fused_prefill_preprocess() -> bool:
+    value = os.environ.get(_FUSED_PREFILL_PREPROCESS_ENV, "1")
+    if value not in ("0", "1"):
+        raise ValueError(f"{_FUSED_PREFILL_PREPROCESS_ENV} must be '0' or '1', got {value!r}")
+    return value == "1"
 
 
 def _load_prefill_module() -> ModuleType:
@@ -253,11 +262,11 @@ class KDAKernelDispatch:
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run KDA chunked prefill.
 
-        On the optimized path this replays the preprocessing that FLA's
-        ``ChunkKDAFunction.forward`` performs when the caller enables
-        ``use_qk_l2norm_in_kernel``, ``use_beta_sigmoid_in_kernel``,
-        ``use_gate_in_kernel``, and ``state_v_first``; then dispatches to
-        the in-tree ``trtllm::kda_prefill`` CuTe DSL op.
+        On the optimized path, ``TRTLLM_KDA_USE_FUSED_PREFILL_PREPROCESS=1``
+        (the default) folds beta sigmoid into the in-tree CuTe DSL op.
+        Q/K L2 normalization remains in the existing FLA host kernels.
+        Setting the variable to ``0`` also restores the legacy beta host
+        launch before dispatching the same op.
 
         On the FLA path it calls ``fla.ops.kda.chunk_kda`` directly with the
         matching flags so the semantics are byte-equivalent.
@@ -274,6 +283,7 @@ class KDAKernelDispatch:
         chunk_indices = None
         if use_optimized and cu_seqlens is not None:
             from fla.ops.utils.index import prepare_chunk_indices
+
             chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
             # The persistent K123 scheduler needs at least 4 total chunks
             # (cgs_per_head = NT // 4 cooperative groups per head). The
@@ -282,19 +292,22 @@ class KDAKernelDispatch:
             # batches (short-prompt contexts, NT < 4) launch with a
             # zero-size grid -> DSLCudaRuntimeError. Route them to the FLA
             # reference path (negligible perf impact at these sizes). The
-            # check must happen HERE, before the l2norm/beta-sigmoid
-            # pre-transforms below: the FLA path applies both in-kernel.
+            # check must happen before dispatch: the FLA fallback applies
+            # Q/K normalization and beta sigmoid in its own kernels.
             if chunk_indices.shape[0] < 4:
                 use_optimized = False
 
         if use_optimized:
             import torch.nn.functional as F
             from fla.modules.l2norm import l2norm_fwd
-            from fla.ops.common.gate import fused_beta_sigmoid
 
+            use_fused_preprocess = _use_fused_prefill_preprocess()
             q, _ = l2norm_fwd(q)
             k, _ = l2norm_fwd(k)
-            beta = fused_beta_sigmoid(beta, scale=1.0).to(torch.bfloat16)
+            if not use_fused_preprocess:
+                from fla.ops.common.gate import fused_beta_sigmoid
+
+                beta = fused_beta_sigmoid(beta, scale=1.0).to(torch.bfloat16)
 
             real_T = q.shape[1]
             if cu_seqlens is not None:
@@ -336,6 +349,7 @@ class KDAKernelDispatch:
                 safe_gate=safe_gate,
                 lower_bound=lower_bound,
                 use_gate_in_kernel=True,
+                use_beta_sigmoid_in_kernel=use_fused_preprocess,
                 A_log=A_log_kernel,
                 dt_bias=dt_bias_kernel,
             )

--- a/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_op.py
+++ b/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_op.py
@@ -107,6 +107,108 @@ def test_optimized_prefill_matches_fla_reference() -> None:
 
 
 @torch.no_grad()
+@pytest.mark.parametrize(
+    "sequence_lengths",
+    [None, [100, 257, 63]],
+    ids=["padded_eqlen", "varlen"],
+)
+def test_fused_prefill_beta_sigmoid_matches_unfused_kernel(
+    sequence_lengths: list[int] | None,
+) -> None:
+    """In-kernel beta sigmoid matches the legacy host launch."""
+    from fla.modules.l2norm import l2norm_fwd
+    from fla.ops.common.gate import fused_beta_sigmoid
+
+    torch.manual_seed(10)
+    batch_size = 1
+    if sequence_lengths is None:
+        sequence_length = 300
+        num_sequences = batch_size
+        cu_seqlens = None
+    else:
+        sequence_length = sum(sequence_lengths)
+        num_sequences = len(sequence_lengths)
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(sequence_lengths).cumsum(0).tolist()],
+            dtype=torch.long,
+            device="cuda",
+        )
+    A_log = torch.randn(NUM_HEADS, dtype=torch.float32, device="cuda") * 0.1
+    dt_bias = torch.randn(NUM_HEADS * HEAD_DIM, dtype=torch.float32, device="cuda") * 0.1
+
+    for seed in (11, 12):
+        generator = torch.Generator(device="cuda").manual_seed(seed)
+
+        def randn(
+            *shape: int, dtype: torch.dtype = torch.bfloat16, scale: float = 0.05
+        ) -> torch.Tensor:
+            return (
+                torch.randn(*shape, generator=generator, dtype=torch.float32, device="cuda") * scale
+            ).to(dtype)
+
+        q = randn(batch_size, sequence_length, NUM_HEADS, HEAD_DIM)
+        k = randn(batch_size, sequence_length, NUM_HEADS, HEAD_DIM)
+        v = randn(batch_size, sequence_length, NUM_HEADS, HEAD_DIM)
+        g = randn(batch_size, sequence_length, NUM_HEADS, HEAD_DIM)
+        if seed == 11:
+            beta = randn(batch_size, sequence_length, NUM_HEADS, dtype=torch.float32)
+        else:
+            # Exercise the L2 epsilon path and saturated sigmoid tails.
+            q[:, ::17].zero_()
+            k[:, ::19].zero_()
+            beta = torch.linspace(
+                -20.0,
+                20.0,
+                batch_size * sequence_length * NUM_HEADS,
+                dtype=torch.float32,
+                device="cuda",
+            ).reshape(batch_size, sequence_length, NUM_HEADS)
+        initial_state = randn(
+            num_sequences, NUM_HEADS, HEAD_DIM, HEAD_DIM, dtype=torch.float32, scale=0.01
+        )
+
+        common = dict(
+            v=v,
+            g=g,
+            scale=HEAD_DIM**-0.5,
+            initial_state=initial_state,
+            output_final_state=True,
+            safe_gate=True,
+            lower_bound=-5.0,
+            use_gate_in_kernel=True,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            cu_seqlens=cu_seqlens,
+        )
+
+        q_unfused, _ = l2norm_fwd(q)
+        k_unfused, _ = l2norm_fwd(k)
+        beta_unfused = fused_beta_sigmoid(beta, scale=1.0).to(torch.bfloat16)
+        output_unfused, state_unfused = torch.ops.trtllm.kda_prefill(
+            q=q_unfused,
+            k=k_unfused,
+            beta=beta_unfused,
+            use_beta_sigmoid_in_kernel=False,
+            **common,
+        )
+        # The op reuses shape-keyed output/state buffers; retain the first
+        # result before the fused call overwrites them.
+        output_unfused = output_unfused.clone()
+        state_unfused = state_unfused.clone()
+
+        output_fused, state_fused = torch.ops.trtllm.kda_prefill(
+            q=q_unfused,
+            k=k_unfused,
+            beta=beta,
+            use_beta_sigmoid_in_kernel=True,
+            **common,
+        )
+
+        _assert_close(output_fused, output_unfused)
+        _assert_close(state_fused, state_unfused)
+
+
+@torch.no_grad()
 def test_kda_prefill_op_empty_token_batch():
     """T=0 call: no output rows, recurrent state passes through unchanged.
 
@@ -121,8 +223,7 @@ def test_kda_prefill_op_empty_token_batch():
     g = torch.empty(1, 0, num_heads, head_k, dtype=torch.float32, device="cuda")
     v = torch.empty(1, 0, num_heads, head_v, dtype=torch.bfloat16, device="cuda")
     beta = torch.empty(1, 0, num_heads, dtype=torch.float32, device="cuda")
-    initial_state = torch.randn(
-        1, num_heads, head_k, head_v, dtype=torch.float32, device="cuda")
+    initial_state = torch.randn(1, num_heads, head_k, head_v, dtype=torch.float32, device="cuda")
 
     output, final_state = torch.ops.trtllm.kda_prefill(
         q=q,
@@ -172,21 +273,22 @@ def test_kda_prefill_op_empty_token_batch_variants():
     # Varlen: two zero-length sequences -> final_state per sequence.
     cu_seqlens = torch.tensor([0, 0, 0], dtype=torch.long, device="cuda")
     _, final_state = torch.ops.trtllm.kda_prefill(
-        **common, initial_state=None, output_final_state=True,
-        cu_seqlens=cu_seqlens)
+        **common, initial_state=None, output_final_state=True, cu_seqlens=cu_seqlens
+    )
     assert final_state.shape == (2, num_heads, head_k, head_v)
     assert (final_state == 0).all()
 
     # output_final_state=False: op returns the empty placeholder tensor.
     output, final_state = torch.ops.trtllm.kda_prefill(
-        **common, initial_state=None, output_final_state=False)
+        **common, initial_state=None, output_final_state=False
+    )
     assert output.shape == (1, 0, num_heads, head_v)
     assert final_state.numel() == 0
 
     # Fused path: the guard must fire before _launch_fused_k1234.
     output, final_state = torch.ops.trtllm.kda_prefill(
-        **common, initial_state=None, output_final_state=True,
-        use_fused_k1234=True)
+        **common, initial_state=None, output_final_state=True, use_fused_k1234=True
+    )
     assert output.shape == (1, 0, num_heads, head_v)
     assert final_state.shape == (1, num_heads, head_k, head_v)
 

--- a/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_op.py
+++ b/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_op.py
@@ -42,6 +42,8 @@ def _make_attention_pair() -> tuple[KimiKDALinearAttention, KimiKDALinearAttenti
         "dtype": torch.bfloat16,
     }
     optimized = KimiKDALinearAttention(**common).to("cuda")
+    with torch.no_grad():
+        optimized.dt_bias.zero_()
     reference = KimiKDALinearAttention(**common, use_optimized_prefill=False).to("cuda")
     reference.load_state_dict(optimized.state_dict())
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Kimi K3 KDA prefill previously launched Q and K L2 normalization separately after convolution, then launched beta sigmoid before dispatching the optimized in-tree CuTe DSL chunk kernel.

This change:

- adds a fused post-convolution Triton kernel that normalizes Q and K together and prepares the Q/K/V head views;
- marks those Q/K tensors as pre-normalized so both optimized and FLA KDA paths avoid redundant normalization;
- folds beta sigmoid into the optimized KDA prefill kernel for padded and variable-length inputs;
- keeps `TRTLLM_KDA_USE_FUSED_PREFILL_PREPROCESS=0|1` as a default-on beta-fusion switch, with `0` restoring the legacy host-side beta launch;
- adds numerical-parity coverage for fused post-convolution normalization and fused versus legacy beta preprocessing, plus a CUDA-event performance comparison for post-convolution normalization.

Together, these changes reduce KDA prefill preprocessing from three host-side launches for Q normalization, K normalization, and beta sigmoid to one fused Q/K normalization launch, with beta sigmoid performed inside the KDA kernel.

## Test Coverage

- `git diff --check upstream/feat/kimi_k3...HEAD`
- Commit-time pre-commit hooks passed after resolving the combined preprocessing behavior.
- Added `test_fused_kda_post_conv_matches_reference` for numerical parity across multiple batch, sequence, head-count, and head-dimension shapes.
- Added `test_fused_kda_post_conv_performance` to compare the fused Q/K normalization kernel against the legacy two-launch path at TP-local K3 shape `(1, 256, 1536)`.
- Added `test_fused_prefill_beta_sigmoid_matches_unfused_kernel` for padded and variable-length inputs, including saturated sigmoid inputs and partial tails.
- Earlier GB300 Kimi K3 aggregated DEP16 E2E validation of the beta-fusion portion, 8K input / 1 output token, concurrency 32:
  - three fused/legacy pairs completed 256/256 requests with zero failures;
  - mean total-token throughput: fused 32,219 tok/s, legacy 32,286 tok/s (-0.21%, within run/node variance);
  - mean GSM8K exact match: fused 96.51%, legacy 96.74%; paired differences changed direction across repeats and were not statistically significant.
- The new fused post-convolution GPU tests have not yet been executed on a Blackwell GPU.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR follows TRT-LLM coding guidelines to the best of my knowledge.
- Test cases are provided for the new code paths.
- No public API or dependency changes are introduced.
- Documentation and ownership files do not require updates for this internal kernel change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
