### PR TITLE
[None][fix] Disable threadleak for executor unittest wrapper

### DIFF
--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import os
 import re
+import shlex
 import warnings
 from subprocess import CalledProcessError
 
@@ -63,6 +64,21 @@ def merge_report(base_file, extra_file, output_file, is_retry=False):
     base.write(output_file, encoding="UTF-8", xml_declaration=True)
 
 
+def _is_executor_unittest_group_case(case: str) -> bool:
+    try:
+        case_args = shlex.split(case)
+    except ValueError:
+        case_args = case.split()
+    if not case_args:
+        return False
+    return case_args[0].replace("\\", "/").rstrip("/") == "unittest/_torch/executor"
+
+
+def _append_case_specific_pytest_options(command: list[str], case: str) -> None:
+    if _is_executor_unittest_group_case(case):
+        command.extend(["-o", "threadleak=False"])
+
+
 def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
     import pandas as pd
     import pynvml
@@ -88,7 +104,8 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
 
     num_workers = 1
 
-    # This dataframe is not manually edited. Infra team will regularly generate this dataframe based on test execution results.
+    # This dataframe is not manually edited. Infra team will regularly generate this dataframe based on
+    # test execution results.
     # If you need to override this policy, please use postprocess code as below.
     agg_unit_mem_path = f'{test_root}/integration/defs/agg_unit_mem_df.csv'
     print(f'Loading unittest parallel config from: {agg_unit_mem_path}')
@@ -117,7 +134,8 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
         num_workers = min(num_workers, 8)
     else:
         warnings.warn(
-            f'Cannot find parallel config entry for unittest {case} on "{gpu_name}". Fallback to serial test. Please add config entry to agg_unit_mem_df.csv.'
+            f'Cannot find parallel config entry for unittest {case} on "{gpu_name}". '
+            'Fallback to serial test. Please add config entry to agg_unit_mem_df.csv.'
         )
 
     num_workers = max(1, num_workers)
@@ -129,7 +147,6 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
 
     ignore_opt = f"--ignore={test_root}/integration"
 
-    import shlex
     arg_list = shlex.split(case)
     case_fn = re.sub(r'[/\s"\']+', '-', case)
     if len(case_fn) > 80:
@@ -197,6 +214,7 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
         s3_secret_key = request.config.getoption("--s3-secret-key",
                                                  default=None)
 
+    _append_case_specific_pytest_options(command, case)
     command += arg_list
 
     print(f"Running unit test:\"python {' '.join(command)}\"")

--- a/tests/unittest/others/test_unittests_wrapper.py
+++ b/tests/unittest/others/test_unittests_wrapper.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_test_unittests_module():
+    defs_module = types.ModuleType("defs")
+    conftest_module = types.ModuleType("defs.conftest")
+    conftest_module.tests_path = lambda: Path("tests")
+    sys.modules.setdefault("defs", defs_module)
+    sys.modules.setdefault("defs.conftest", conftest_module)
+
+    module_path = Path(__file__).parents[2] / "integration" / "defs" / "test_unittests.py"
+    spec = importlib.util.spec_from_file_location("_test_unittests_wrapper", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_executor_unittest_group_disables_threadleak_checker():
+    module = _load_test_unittests_module()
+    command = ["-m", "pytest", "unittest/_torch/executor"]
+
+    module._append_case_specific_pytest_options(command, "unittest/_torch/executor")
+
+    assert "-o" in command
+    assert "threadleak=False" in command
+
+
+def test_non_executor_unittest_group_keeps_threadleak_checker():
+    module = _load_test_unittests_module()
+    command = ["-m", "pytest", "unittest/_torch/attention"]
+
+    module._append_case_specific_pytest_options(command, "unittest/_torch/attention")
+
+    assert "threadleak=False" not in command

--- a/tests/unittest/others/test_unittests_wrapper.py
+++ b/tests/unittest/others/test_unittests_wrapper.py
@@ -64,12 +64,12 @@ def test_loader_restores_stub_modules_after_context() -> None:
 
 def test_executor_unittest_group_disables_threadleak_checker(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_test_unittests_module(monkeypatch)
-    command = ["-m", "pytest", "unittest/_torch/executor"]
+    command = ["-m", "pytest"]
 
     module._append_case_specific_pytest_options(command, "unittest/_torch/executor")
+    command += ["unittest/_torch/executor"]
 
-    assert "-o" in command
-    assert "threadleak=False" in command
+    assert command == ["-m", "pytest", "-o", "threadleak=False", "unittest/_torch/executor"]
 
 
 @pytest.mark.parametrize(
@@ -77,6 +77,7 @@ def test_executor_unittest_group_disables_threadleak_checker(monkeypatch: pytest
     [
         "unittest/_torch/executor/test_example.py",
         "unittest/_torch/executor -k test_example",
+        'unittest/_torch/executor "unterminated',
     ],
 )
 def test_executor_unittest_subsets_keep_threadleak_checker(


### PR DESCRIPTION
## Summary
- Disable pytest-threadleak for the full `unittest/_torch/executor` wrapper case by adding `-o threadleak=False` to the inner pytest command.
- Keep threadleak enabled for other unittest groups and for individual executor test files.
- Add a focused regression test for the wrapper command construction.

## Test Plan
- `python -m pytest --confcutdir=tests/unittest/others tests/unittest/others/test_unittests_wrapper.py -q`
- `python -m ruff check tests/integration/defs/test_unittests.py tests/unittest/others/test_unittests_wrapper.py`
- `python -m py_compile tests/integration/defs/test_unittests.py tests/unittest/others/test_unittests_wrapper.py`
- `git diff --check`

Refs #16284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- The change limits `threadleak=False` to the full `unittest/_torch/executor` group.
- Individual files and selector-based subsets retain thread-leak checks.
- Malformed shell syntax is handled safely.
- The option is added before case arguments.
- The scope matches the affected test-list entries.
- Focused tests, compilation, whitespace checks, and secret scanning passed.
- Full repository validation remains blocked by missing MPI libraries and an unrelated `ray_stub` import error.

## QA Engineer Review

- Added tests:
  - `test_loader_restores_stub_modules_after_context`
  - `test_executor_unittest_group_disables_threadleak_checker`
  - `test_executor_unittest_subsets_keep_threadleak_checker`
  - `test_non_executor_unittest_group_keeps_threadleak_checker`
- Existing `test_unittests_v2` coverage remains updated.
- The tests cover full executor groups, individual executor files, selector-based subsets, non-executor groups, and restoration of sentinel `defs` modules.
- Full executor-group coverage exists in `test-db` entries for:
  - `l0_dgx_b300.yml`
  - `l0_gb300_multi_gpus.yml`
  - `l0_b300.yml`
  - `l0_h100.yml`
  - `l0_cpu.yml`
- No `qa/` or `waives.txt` entries changed.
- The added test functions are not separately listed in `tests/integration/test_lists`; they validate wrapper behavior exercised by the existing integration entries.
- Verdict: **sufficient**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->