### PR TITLE
[None][perf] Eliminate KDA prefill recurrent-state copies

### DIFF
--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -53,6 +53,15 @@ other GPU architectures may be added in a future release.
   currently pins `flashinfer-python==0.6.14`, so a later
   dependency-resolving TensorRT-LLM install can replace this source revision.
 
+## Select the KDA state I/O path
+
+KDA uses fused recurrent-state pool I/O by default. Set
+`TLLM_KDA_USE_FUSED_STATE_IO=0` in the launch environment to force the legacy
+prefill gather/transpose/scatter path for A/B comparisons or debugging. Set it
+to `1` to enable the fused path; these are the only valid values. This switch
+does not change the decode state path. Unsupported batches or pool layouts
+still fall back to the legacy path automatically.
+
 ## Run the model
 
 Kimi K3 requires a multi-node launch. From the repository root, submit the

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -54,6 +54,15 @@ other GPU architectures may be added in a future release.
   currently pins `flashinfer-python==0.6.14`, so a later
   dependency-resolving TensorRT-LLM install can replace this source revision.
 
+## Select the KDA state I/O path
+
+KDA uses fused recurrent-state pool I/O by default. Set
+`TLLM_KDA_USE_FUSED_STATE_IO=0` in the launch environment to force the legacy
+prefill gather/transpose/scatter path for A/B comparisons or debugging. Set it
+to `1` to enable the fused path; these are the only valid values. This switch
+does not change the decode state path. Unsupported batches or pool layouts
+still fall back to the legacy path automatically.
+
 ## Run the model
 
 Kimi K3 requires a multi-node launch. From the repository root, submit the

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
@@ -31,9 +31,8 @@ The public ``trtllm::kda_prefill`` operator returns only the KDA output and
 final recurrent state. Intermediate matrices remain private runner workspace.
 """
 
-from typing import Optional, Tuple
-
 import weakref
+from typing import Optional, Tuple
 
 import torch
 
@@ -70,6 +69,51 @@ def _ct(t, etype):
     r = from_dlpack(t, assumed_align=16)
     r.element_type = etype
     return r
+
+
+def _fits_32bit_stride(tensor: torch.Tensor) -> bool:
+    int32_max = 2**31 - 1
+    max_offset = int(tensor.storage_offset())
+    for size, stride in zip(tensor.shape, tensor.stride()):
+        stride = abs(int(stride))
+        if stride > int32_max:
+            return False
+        if size:
+            max_offset += (int(size) - 1) * stride
+            if max_offset > int32_max:
+                return False
+    return True
+
+
+def _dynamic_dlpack_arg(tensor: torch.Tensor):
+    wrapper = from_dlpack(
+        tensor,
+        assumed_align=16,
+        use_32bit_stride=_fits_32bit_stride(tensor),
+    )
+    for dim, stride in enumerate(tensor.stride()):
+        if stride == 1:
+            return wrapper.mark_layout_dynamic(dim)
+    return wrapper
+
+
+def _layout_key(tensor: torch.Tensor):
+    return (
+        tensor.dtype,
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        _fits_32bit_stride(tensor),
+    )
+
+
+def _dynamic_vector_layout_key(tensor: torch.Tensor):
+    """Key a 1D CuTe argument whose sole extent is runtime dynamic."""
+    assert tensor.ndim == 1
+    return (
+        tensor.dtype,
+        tuple(tensor.stride()),
+        _fits_32bit_stride(tensor),
+    )
 
 
 def _current_cu_stream(device):
@@ -331,8 +375,7 @@ def _get_padded_input_buffers(B, T_padded, H, K, dtype_qkv, dtype_g, dtype_beta,
     return e
 
 
-def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT,
-                 varlen=False):
+def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT, varlen=False):
     """All beta fusion lives in akk_inv kernel epilogue (post-inv column-scale)."""
     key = (dev.index or 0, B, T, H, K_dim, V_dim, NT, N_seqs, varlen)
     if key not in _buf_cache:
@@ -475,7 +518,6 @@ def _get_buffers(dev, dtype_k, B, T, H, K_dim, V_dim, NT, N_seqs, BT,
 def _launch_k4_persistent(
     cute_wrappers,
     v_beta,
-    S_in,
     S_out,
     cu_seqlens,
     chunk_offsets,
@@ -484,6 +526,9 @@ def _launch_k4_persistent(
     H=None,
     V_dim=None,
     use_fast_sync=False,
+    state_pool=None,
+    state_indices=None,
+    has_initial_states=None,
 ):
     """Launch persistent K4 with cached CuTe wrappers.
 
@@ -498,7 +543,13 @@ def _launch_k4_persistent(
     dev = v_beta.device
     dev_idx = dev.index or 0
 
-    s_ct = cute_wrappers["s_ct"]
+    use_indexed_state = state_pool is not None
+    if use_indexed_state:
+        if state_indices is None or has_initial_states is None:
+            raise ValueError("Indexed KDA prefill requires state_indices and has_initial_states.")
+        s_ct = _dynamic_dlpack_arg(state_pool)
+    else:
+        s_ct = cute_wrappers["s_ct"]
     a_ct = cute_wrappers["a_ct"]
     b_ct = cute_wrappers["ks_ct"]  # raw k_scaled (beta absorbed in akk_inv)
     q_ct = cute_wrappers["qs_ct"]
@@ -519,6 +570,14 @@ def _launch_k4_persistent(
     else:
         cu_ct, co_ct = _get_k4_varlen_cu_co(cu_seqlens, chunk_offsets)
 
+    if use_indexed_state:
+        state_indices_ct = _dynamic_dlpack_arg(state_indices)
+        has_initial_states_ct = _dynamic_dlpack_arg(has_initial_states)
+    else:
+        # These arguments are compile-time dead on the legacy path.
+        state_indices_ct = cu_ct
+        has_initial_states_ct = cu_ct
+
     # Allocate for the maximum persistent grid once. The scheduler applies
     # min(N_seqs * H, num_sm) at runtime, so pre-minimizing here would turn
     # every distinct request count into another compiled host function.
@@ -538,7 +597,7 @@ def _launch_k4_persistent(
     # Launch on torch's CURRENT stream — see _current_cu_stream.
     stream = _current_cu_stream(dev)
 
-    k4_fn = cute_wrappers.get("_k4_fn")
+    k4_fn = None if use_indexed_state else cute_wrappers.get("_k4_fn")
     if k4_fn is None:
         # H and the state K/V dims MUST be in the key: s_ct bakes the inner
         # [H, K, V] shape and all strides at compile time
@@ -550,10 +609,26 @@ def _launch_k4_persistent(
         # regression whenever another head count compiled first in the same
         # process (isolated processes were clean). N_seqs and the token/chunk
         # counts stay runtime — only layout-baked dims belong here.
-        cache_key = (dev_idx, num_sm, H, S_out.shape[-2], V_dim)
+        if use_indexed_state:
+            cache_key = (
+                dev_idx,
+                num_sm,
+                H,
+                state_pool.shape[-1],
+                V_dim,
+                True,
+                _layout_key(state_pool),
+                # The sole dimension of these vectors is marked dynamic by
+                # _dynamic_dlpack_arg. Excluding its runtime extent lets the
+                # warmup compile serve full and underfilled context batches.
+                _dynamic_vector_layout_key(state_indices),
+                _dynamic_vector_layout_key(has_initial_states),
+            )
+        else:
+            cache_key = (dev_idx, num_sm, H, S_out.shape[-2], V_dim, False)
         k4_fn = _k4p_cache.get(cache_key)
         if k4_fn is None:
-            host_fn = _k4p_make_host(num_sm=num_sm)
+            host_fn = _k4p_make_host(num_sm=num_sm, use_indexed_state=use_indexed_state)
             k4_fn = cute.compile(
                 host_fn,
                 a_ct,
@@ -565,6 +640,8 @@ def _launch_k4_persistent(
                 o_ct,
                 gk_ct,
                 s_ct,
+                state_indices_ct,
+                has_initial_states_ct,
                 cu_ct,
                 co_ct,
                 tm_ct,
@@ -572,7 +649,8 @@ def _launch_k4_persistent(
                 stream,
             )
             _k4p_cache[cache_key] = k4_fn
-        cute_wrappers["_k4_fn"] = k4_fn
+        if not use_indexed_state:
+            cute_wrappers["_k4_fn"] = k4_fn
 
     args = (
         a_ct,
@@ -584,6 +662,8 @@ def _launch_k4_persistent(
         o_ct,
         gk_ct,
         s_ct,
+        state_indices_ct,
+        has_initial_states_ct,
         cu_ct,
         co_ct,
         tm_ct,
@@ -792,10 +872,8 @@ def _launch_fused_k123_inv(
             stream,
         )
     akk_fn = _akk_inv_cache[akk_cache_key]
-    akk_args = (akk_in_view, akk_out_view, beta_ct, B, NT, akk_cu_ct,
-                akk_ci_ct, T_val, stream)
+    akk_args = (akk_in_view, akk_out_view, beta_ct, B, NT, akk_cu_ct, akk_ci_ct, T_val, stream)
     akk_fn(*akk_args)
-
 
 
 # ========== Fused K1234 compilation cache ==========
@@ -898,14 +976,31 @@ def _chunk_kda_fwd(
     return_intermediate_states: bool = False,
     cp_context=None,
     use_fused_k1234: bool = False,
+    state_pool: torch.Tensor | None = None,
+    state_indices: torch.Tensor | None = None,
+    has_initial_states: torch.Tensor | None = None,
 ):
     """KDA forward — optimized, FLA-compatible interface."""
     if safe_gate and lower_bound is None:
         lower_bound = -5.0
 
+    use_indexed_state = state_pool is not None
+    if use_indexed_state:
+        if initial_state is not None or output_final_state:
+            raise ValueError(
+                "Indexed KDA prefill mutates state_pool in place and does not "
+                "accept initial_state or output_final_state=True."
+            )
+        if state_indices is None or has_initial_states is None:
+            raise ValueError("Indexed KDA prefill requires state_indices and has_initial_states.")
+        if use_fused_k1234:
+            raise ValueError("Indexed KDA prefill is not supported by fused K1234.")
+
     is_varlen = cu_seqlens is not None
 
     if q.shape[1] == 0:
+        if use_indexed_state:
+            raise ValueError("Indexed KDA prefill does not support an empty token batch.")
         # Zero-token call: the runtime can emit a context batch whose token
         # payload is empty (observed under the overlap scheduler + logprobs
         # flows; the FLA fallback tolerates it). No tokens means no output
@@ -923,10 +1018,8 @@ def _chunk_kda_fwd(
             # pool the initial state may alias.
             final_state = initial_state.to(torch.float32).clone()
         else:
-            final_state = torch.zeros(
-                n_seqs, H, K, V_dim, dtype=torch.float32, device=q.device)
-        return (o, final_state, None, None, None, None, None, None, None,
-                None, None, initial_state)
+            final_state = torch.zeros(n_seqs, H, K, V_dim, dtype=torch.float32, device=q.device)
+        return (o, final_state, None, None, None, None, None, None, None, None, None, initial_state)
 
     # ===== Fused K1234 path (eqlen only, single kernel launch) =====
     if use_fused_k1234 and not is_varlen:
@@ -1028,7 +1121,8 @@ def _chunk_kda_fwd(
         assert cur_T % BT == 0 and cur_T >= real_T, (
             f"varlen single-seq path expects caller-padded input "
             f"(T={cur_T}, seqlen={real_T}); see "
-            "KDAKernelDispatch.prefill_chunk_kda")
+            "KDAKernelDispatch.prefill_chunk_kda"
+        )
         g_pad = _get_g_sentinel_buffer(B, cur_T, H, K, g.dtype, g.device, real_T)
         g_pad[:, :real_T].copy_(g[:, :real_T])
         g = g_pad
@@ -1060,7 +1154,8 @@ def _chunk_kda_fwd(
             # KDAKernelDispatch.prefill_chunk_kda.
             raise ValueError(
                 f"kda_prefill requires >= 4 total varlen chunks (got {NT}); "
-                "route small varlen batches to the FLA fallback")
+                "route small varlen batches to the FLA fallback"
+            )
         N_seqs = len(cu_seqlens) - 1
     else:
         NT = T // BT
@@ -1079,24 +1174,28 @@ def _chunk_kda_fwd(
         cu_eqlen,
         co_eqlen,
         cute_wrappers,
-    ) = _get_buffers(device, k.dtype, B, T, H, K, V_dim, NT, N_seqs, BT,
-                     varlen=is_varlen)
+    ) = _get_buffers(device, k.dtype, B, T, H, K, V_dim, NT, N_seqs, BT, varlen=is_varlen)
 
     # ===== State copy on side stream, parallel with K123 =====
     # K4 needs S_out populated with initial_state. By doing this copy on a
     # side stream BEFORE K123 launches, the D2D memcpy overlaps with K123's
     # compute. Especially big win for high-N_seqs varlen where state is huge
     # (192MB for N=32, ~64us memcpy) — would otherwise serialize before K4.
-    if initial_state is None:
+    if use_indexed_state:
+        S_in = None
+        needs_copy = False
+    elif initial_state is None:
         S_in = torch.zeros(N_seqs, H, K, V_dim, dtype=torch.float32, device=device)
+        needs_copy = True
     else:
         S_in = initial_state
+        needs_copy = S_in.data_ptr() != S_out.data_ptr()
+
     # Current stream per call — never the buffer-creation-time stream (the
     # executor creates buffers under warmup's stream and calls under
     # execution_stream; syncing against a stale stream un-orders the copy).
     main_stream = torch.cuda.current_stream(device)
     side_stream = cute_wrappers["side_stream"]
-    needs_copy = S_in.data_ptr() != S_out.data_ptr()
     if needs_copy:
         side_stream.wait_stream(main_stream)
         with torch.cuda.stream(side_stream):
@@ -1145,7 +1244,6 @@ def _chunk_kda_fwd(
     _launch_k4_persistent(
         cute_wrappers,
         v,
-        S_in,
         S_out,
         cu_for_k4,
         chunk_offsets_for_k4,
@@ -1153,6 +1251,9 @@ def _chunk_kda_fwd(
         H=H,
         V_dim=V_dim,
         use_fast_sync=(not is_varlen),
+        state_pool=state_pool,
+        state_indices=state_indices,
+        has_initial_states=has_initial_states,
     )
 
     o = O_flat
@@ -1165,7 +1266,7 @@ def _chunk_kda_fwd(
         A_qk_out = A_qk_out[:, :real_T]
         A_kk_out = A_kk_out[:, :real_T]
     # multiseq_info is always None here (Phase 2.2 disabled — see above)
-    final_state = S_out if output_final_state else None
+    final_state = S_out if output_final_state and not use_indexed_state else None
 
     return (
         o,
@@ -1207,6 +1308,9 @@ class KdaPrefillRunner:
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         use_fused_k1234: bool = False,
+        state_pool: Optional[torch.Tensor] = None,
+        state_indices: Optional[torch.Tensor] = None,
+        has_initial_states: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run KDA prefill and return output plus final recurrent state."""
         if not IS_CUTLASS_DSL_AVAILABLE:
@@ -1234,8 +1338,67 @@ class KdaPrefillRunner:
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             use_fused_k1234=use_fused_k1234,
+            state_pool=state_pool,
+            state_indices=state_indices,
+            has_initial_states=has_initial_states,
         )
         return result[0], result[1]
+
+
+def _validate_indexed_state_pool(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    state_pool: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_states: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+) -> None:
+    num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+    H, K, V = q.shape[2], q.shape[3], v.shape[3]
+    if state_pool.dtype != torch.float32 or state_pool.ndim != 4:
+        raise ValueError(
+            "Expected state_pool to be a rank-4 fp32 tensor with shape [slots, H, V, K]."
+        )
+    if state_pool.shape[1:] != (H, V, K):
+        raise ValueError(
+            f"Expected state_pool shape [slots, {H}, {V}, {K}], got {tuple(state_pool.shape)}."
+        )
+    expected_inner_strides = (V * K, K, 1)
+    if state_pool.stride()[1:] != expected_inner_strides:
+        raise ValueError(
+            "Indexed KDA prefill requires dense H/V/K inner dimensions; "
+            f"expected strides {expected_inner_strides}, got "
+            f"{state_pool.stride()[1:]}."
+        )
+    if state_pool.stride(0) < H * V * K or state_pool.stride(0) % 4 != 0:
+        raise ValueError(
+            "Indexed KDA prefill requires a non-overlapping, 16-byte-aligned slot stride."
+        )
+    if state_pool.data_ptr() % 16 != 0:
+        raise ValueError("Indexed KDA prefill requires a 16-byte-aligned state pool.")
+    if state_indices.ndim != 1 or state_indices.shape[0] != num_sequences:
+        raise ValueError(
+            f"Expected state_indices shape [{num_sequences}], got {tuple(state_indices.shape)}."
+        )
+    if state_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("state_indices must have dtype int32 or int64.")
+    if not state_indices.is_contiguous():
+        raise ValueError("state_indices must be contiguous.")
+    if has_initial_states.ndim != 1 or has_initial_states.shape[0] != num_sequences:
+        raise ValueError(
+            f"Expected has_initial_states shape [{num_sequences}], got "
+            f"{tuple(has_initial_states.shape)}."
+        )
+    if has_initial_states.dtype != torch.bool or not has_initial_states.is_contiguous():
+        raise ValueError("has_initial_states must be a contiguous bool tensor.")
+    for name, tensor in (
+        ("q", q),
+        ("v", v),
+        ("state_indices", state_indices),
+        ("has_initial_states", has_initial_states),
+    ):
+        if tensor.device != state_pool.device:
+            raise ValueError(f"{name} and state_pool must be on the same device.")
 
 
 if IS_CUTLASS_DSL_AVAILABLE:
@@ -1329,3 +1492,84 @@ if IS_CUTLASS_DSL_AVAILABLE:
         else:
             final_state = q.new_empty(0, dtype=torch.float32)
         return output, final_state
+
+    @torch.library.custom_op(
+        "trtllm::kda_prefill_indexed",
+        mutates_args=("state_pool",),
+        device_types="cuda",
+    )
+    def kda_prefill_indexed(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        state_pool: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_states: torch.Tensor,
+        scale: float,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        chunk_indices: Optional[torch.Tensor] = None,
+        chunk_size: int = 64,
+        safe_gate: bool = False,
+        lower_bound: Optional[float] = None,
+        use_gate_in_kernel: bool = False,
+        A_log: Optional[torch.Tensor] = None,
+        dt_bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Run KDA prefill directly against a V-first recurrent-state pool."""
+        _validate_indexed_state_pool(
+            q,
+            v,
+            state_pool,
+            state_indices,
+            has_initial_states,
+            cu_seqlens,
+        )
+        output, _ = KdaPrefillRunner.forward(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            A_log=A_log,
+            scale=scale,
+            dt_bias=dt_bias,
+            initial_state=None,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            chunk_size=chunk_size,
+            safe_gate=safe_gate,
+            lower_bound=lower_bound,
+            use_gate_in_kernel=use_gate_in_kernel,
+            state_pool=state_pool,
+            state_indices=state_indices,
+            has_initial_states=has_initial_states,
+        )
+        return output
+
+    @kda_prefill_indexed.register_fake
+    def _(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        state_pool: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_states: torch.Tensor,
+        scale: float,
+        cu_seqlens: Optional[torch.Tensor] = None,
+        chunk_indices: Optional[torch.Tensor] = None,
+        chunk_size: int = 64,
+        safe_gate: bool = False,
+        lower_bound: Optional[float] = None,
+        use_gate_in_kernel: bool = False,
+        A_log: Optional[torch.Tensor] = None,
+        dt_bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        del q, k, g, beta, state_pool, state_indices, has_initial_states
+        del scale, cu_seqlens, chunk_indices, chunk_size, safe_gate
+        del lower_bound, use_gate_in_kernel, A_log, dt_bias
+        return v.new_empty(v.shape)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/kimi_k3_kda/k4_persistent.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/kimi_k3_kda/k4_persistent.py
@@ -479,6 +479,9 @@ def k4_persistent_kernel(
     nv_b_mn_sl: cute.ComposedLayout,
     mGkLastExp: cute.Tensor,
     mS_fp32: cute.Tensor,
+    state_indices: cute.Tensor,
+    has_initial_states: cute.Tensor,
+    use_indexed_state: cutlass.Constexpr[bool],
     cu_seqlens: cute.Tensor,
     chunk_offsets: cute.Tensor,
     mA: cute.Tensor,
@@ -651,12 +654,22 @@ def k4_persistent_kernel(
         )
         tiled_state_g2r = cute.make_tiled_copy_S(atom_state_g2r, tiled_state_r2t)
         thr_state_g2r = tiled_state_g2r.get_slice(warpgroup_tidx)
+        atom_indexed_state_g2r = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), acc_dtype, num_bits_per_copy=32
+        )
+        tiled_indexed_state_g2r = cute.make_tiled_copy_S(atom_indexed_state_g2r, tiled_state_r2t)
+        thr_indexed_state_g2r = tiled_indexed_state_g2r.get_slice(warpgroup_tidx)
 
         atom_state_r2g = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(), acc_dtype, num_bits_per_copy=128
         )
         tiled_state_r2g = cute.make_tiled_copy_D(atom_state_r2g, tiled_state_t2r)
         thr_state_r2g = tiled_state_r2g.get_slice(warpgroup_tidx)
+        atom_indexed_state_r2g = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), acc_dtype, num_bits_per_copy=32
+        )
+        tiled_indexed_state_r2g = cute.make_tiled_copy_D(atom_indexed_state_r2g, tiled_state_t2r)
+        thr_indexed_state_r2g = tiled_indexed_state_r2g.get_slice(warpgroup_tidx)
 
         atom_state_r2s = cute.make_copy_atom(
             cute.nvgpu.CopyUniversalOp(), mma_dtype, num_bits_per_copy=128
@@ -679,6 +692,9 @@ def k4_persistent_kernel(
 
         while work.is_valid_tile:
             batch_idx, head_idx, _ = work.tile_idx
+            state_idx = (
+                state_indices[batch_idx] if cutlass.const_expr(use_indexed_state) else batch_idx
+            )
             batch_start = cu_seqlens[batch_idx]
             batch_end = cu_seqlens[batch_idx + 1]
             num_chunks = cute.ceil_div(batch_end - batch_start, M)
@@ -686,12 +702,31 @@ def k4_persistent_kernel(
             # batch_start // M only works when all seq lengths are multiples of M.
             chunk_base = chunk_offsets[batch_idx]
 
-            gS_init = cute.flat_divide(mS_fp32[batch_idx, head_idx, None, None], (M6, N6))[
-                None, None, 0, 0
-            ]
-            tGR_tCgState_in = thr_state_g2r.partition_S(gS_init)
-            tGR_tCrState_in = thr_state_g2r.retile(tRrState)
-            cute.copy(tiled_state_g2r, tGR_tCgState_in, tGR_tCrState_in)
+            if cutlass.const_expr(use_indexed_state):
+                state_is_valid = has_initial_states[batch_idx]
+                if state_is_valid:
+                    state_vk = mS_fp32[state_idx, head_idx, None, None]
+                    state_kv = cute.make_tensor(
+                        state_vk.iterator,
+                        cute.make_layout((M6, N6), stride=(1, M6)),
+                    )
+                    gS_init = cute.flat_divide(state_kv, (M6, N6))[None, None, 0, 0]
+                    tGR_tCgState_in = thr_indexed_state_g2r.partition_S(gS_init)
+                    tGR_tCrState_in = thr_indexed_state_g2r.retile(tRrState)
+                    cute.copy(
+                        tiled_indexed_state_g2r,
+                        tGR_tCgState_in,
+                        tGR_tCrState_in,
+                    )
+                else:
+                    tRrState.fill(0.0)
+            else:
+                gS_init = cute.flat_divide(mS_fp32[state_idx, head_idx, None, None], (M6, N6))[
+                    None, None, 0, 0
+                ]
+                tGR_tCgState_in = thr_state_g2r.partition_S(gS_init)
+                tGR_tCrState_in = thr_state_g2r.retile(tRrState)
+                cute.copy(tiled_state_g2r, tGR_tCgState_in, tGR_tCrState_in)
             num_state_subs = tRrState.shape[2]
             for sub in cutlass.range(num_state_subs):
                 cute.copy(tiled_state_r2t, tRrState[None, 0, sub], tRT_tCtState[None, 0, sub])
@@ -736,19 +771,37 @@ def k4_persistent_kernel(
                 global_chunk = global_chunk + 1
 
             cute.arch.mbarrier_wait(mma6_done_mbar, phase=(global_chunk - 1) % 2)
-            gS_out = cute.flat_divide(mS_fp32[batch_idx, head_idx, None, None], (M6, N6))[
-                None, None, 0, 0
-            ]
-            tGR_tCgState_out = thr_state_r2g.partition_D(gS_out)
-            tGR_tCrState_out = thr_state_r2g.retile(tRrState)
             num_state_subs_final = tRrState.shape[2]
             for sub in cutlass.range(num_state_subs_final):
                 cute.copy(tiled_state_t2r, tTR_tCtState[None, 0, sub], tRrState[None, 0, sub])
             cute.arch.fence_view_async_tmem_load()
-            for sub in cutlass.range(num_state_subs_final):
-                cute.copy(
-                    tiled_state_r2g, tGR_tCrState_out[None, 0, sub], tGR_tCgState_out[None, 0, sub]
+            if cutlass.const_expr(use_indexed_state):
+                state_vk = mS_fp32[state_idx, head_idx, None, None]
+                state_kv = cute.make_tensor(
+                    state_vk.iterator,
+                    cute.make_layout((M6, N6), stride=(1, M6)),
                 )
+                gS_out = cute.flat_divide(state_kv, (M6, N6))[None, None, 0, 0]
+                tGR_tCgState_out = thr_indexed_state_r2g.partition_D(gS_out)
+                tGR_tCrState_out = thr_indexed_state_r2g.retile(tRrState)
+                for sub in cutlass.range(num_state_subs_final):
+                    cute.copy(
+                        tiled_indexed_state_r2g,
+                        tGR_tCrState_out[None, 0, sub],
+                        tGR_tCgState_out[None, 0, sub],
+                    )
+            else:
+                gS_out = cute.flat_divide(mS_fp32[state_idx, head_idx, None, None], (M6, N6))[
+                    None, None, 0, 0
+                ]
+                tGR_tCgState_out = thr_state_r2g.partition_D(gS_out)
+                tGR_tCrState_out = thr_state_r2g.retile(tRrState)
+                for sub in cutlass.range(num_state_subs_final):
+                    cute.copy(
+                        tiled_state_r2g,
+                        tGR_tCrState_out[None, 0, sub],
+                        tGR_tCgState_out[None, 0, sub],
+                    )
 
             cute.arch.mbarrier_arrive(final_state_done_mbar)
 
@@ -1258,7 +1311,7 @@ def k4_persistent_kernel(
         o_store_prod.tail()
 
 
-def make_host_fn(num_sm=148):
+def make_host_fn(num_sm=148, use_indexed_state=False):
     """Create one K4 host function for all runtime context batch sizes.
 
     ``num_seqs`` is a runtime scalar. ``H`` and the token extent come from
@@ -1266,6 +1319,7 @@ def make_host_fn(num_sm=148):
     ceiling. The scheduler computes ``min(num_seqs * H, num_sm)`` at launch.
     """
     _num_sm = num_sm
+    _use_indexed_state = use_indexed_state
 
     @cute.jit
     def host_fn(
@@ -1278,6 +1332,8 @@ def make_host_fn(num_sm=148):
         o_raw: cute.Tensor,
         gk_last_exp: cute.Tensor,
         s_fp32: cute.Tensor,
+        state_indices: cute.Tensor,
+        has_initial_states: cute.Tensor,
         cu_seqlens: cute.Tensor,
         chunk_offsets: cute.Tensor,
         tm_workspace: cute.Tensor,
@@ -1442,6 +1498,9 @@ def make_host_fn(num_sm=148):
             sl_nv_b_mn,
             gk_last_exp,
             s_fp32,
+            state_indices,
+            has_initial_states,
+            _use_indexed_state,
             cu_seqlens,
             chunk_offsets,
             a,
@@ -1453,7 +1512,6 @@ def make_host_fn(num_sm=148):
             o_out,
             tm_workspace,
             scheduler_params,
-        ).launch(grid=grid_shape, block=(threads_per_cta, 1, 1), use_pdl=True,
-                 stream=stream)
+        ).launch(grid=grid_shape, block=(threads_per_cta, 1, 1), use_pdl=True, stream=stream)
 
     return host_fn

--- a/tensorrt_llm/_torch/models/modeling_kimi_linear.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_linear.py
@@ -138,6 +138,16 @@ def _read_fused_finalize_ar_rms_max_tokens() -> int:
 
 _K3_FUSED_MOE_FINALIZE_AR_RMS_MAX_TOKENS = _read_fused_finalize_ar_rms_max_tokens()
 
+_KDA_FUSED_STATE_IO_ENV = "TLLM_KDA_USE_FUSED_STATE_IO"
+
+
+def _fused_prefill_state_io_enabled() -> bool:
+    value = os.environ.get(_KDA_FUSED_STATE_IO_ENV, "1")
+    if value not in ("0", "1"):
+        raise ValueError(f"{_KDA_FUSED_STATE_IO_ENV} must be 0 or 1, got {value!r}")
+    return value == "1"
+
+
 _KDA_INDEXED_STATE_POOL_ENABLED = os.environ.get("TLLM_KDA_ENABLE_INDEXED_STATE_POOL", "1") == "1"
 
 # Routed-expert MoE TP/EP split overrides (read per model init, not import).
@@ -1044,6 +1054,7 @@ class KimiKDARuntime(nn.Module):
 
         lin = cfg.linear_attn_config
         self.layer_idx = layer_idx
+        self._use_fused_prefill_state_io = _fused_prefill_state_io_enabled()
         self._use_indexed_ssm_pool = _KDA_INDEXED_STATE_POOL_ENABLED
         # Attention-family TP semantics (Qwen3-Next GatedDeltaNet pattern,
         # gdn_mixer.py): replicated under attention-DP — each rank runs
@@ -1336,15 +1347,23 @@ class KimiKDARuntime(nn.Module):
         # Initial states: present for continuation chunks (chunked prefill)
         # and for prefix-cache hits (block reuse), where the previous
         # conv/recurrent state was onboarded into this request's slot.
+        has_init = mamba_metadata.has_initial_states[:num_prefills]
+        use_indexed_state = self._use_fused_prefill_state_io and mixer.can_use_indexed_prefill(
+            state_pool=ssm_pool,
+            state_indices=slot_indices,
+            has_initial_states=has_init,
+            cu_seqlens=cu_seqlens,
+            num_tokens=x2d.shape[0],
+        )
         conv_q_in = conv_k_in = conv_v_in = None
         recurrent_in = None
         if mamba_metadata.use_initial_states:
-            has_init = mamba_metadata.has_initial_states[:num_prefills]
             cs = conv_pool.index_select(0, slot_indices)
             cs[~has_init] = 0
             conv_q_in, conv_k_in, conv_v_in = _kda_split_conv_sections(cs, d)
-            recurrent_in = ssm_pool.index_select(0, slot_indices)
-            recurrent_in[~has_init] = 0
+            if not use_indexed_state:
+                recurrent_in = ssm_pool.index_select(0, slot_indices)
+                recurrent_in[~has_init] = 0
 
         q, conv_q = mixer.q_conv1d(
             q_proj_states, cache=conv_q_in, output_final_state=True, cu_seqlens=cu_seqlens
@@ -1365,9 +1384,9 @@ class KimiKDARuntime(nn.Module):
         k = rearrange(k, "... (h d) -> ... h d", d=mixer.head_k_dim)
         v = rearrange(v, "... (h d) -> ... h d", d=mixer.head_dim)
 
-        # Kernel dispatch (in-tree trtllm::kda_prefill or FLA chunk_kda).
-        # Both paths exchange states in the pool's V-first [N, H, V, K]
-        # layout, so recurrent_in / final_state map to ssm_pool 1:1.
+        # The indexed optimized path reads and writes the V-first pool
+        # directly. Unsupported layouts/batches retain the original
+        # gather/transpose/op/transpose/scatter path.
         lower_bound = mixer.gate_lower_bound
         o, final_state = mixer.prefill_chunk_kda(
             q=q,
@@ -1382,13 +1401,18 @@ class KimiKDARuntime(nn.Module):
             safe_gate=lower_bound is not None,
             lower_bound=lower_bound,
             cu_seqlens=cu_seqlens,
+            state_pool=ssm_pool if use_indexed_state else None,
+            state_indices=slot_indices if use_indexed_state else None,
+            has_initial_states=has_init if use_indexed_state else None,
         )
 
         # Persist per-request states into the pools.
         conv_pool.index_copy_(
             0, slot_indices, torch.cat([conv_q, conv_k, conv_v], dim=1).to(conv_pool.dtype)
         )
-        ssm_pool.index_copy_(0, slot_indices, final_state.to(ssm_pool.dtype))
+        if not use_indexed_state:
+            assert final_state is not None
+            ssm_pool.index_copy_(0, slot_indices, final_state.to(ssm_pool.dtype))
         # Fused-verify replay caches: seed the committed conv window so the
         # first verify round convolves the correct history (pending drafts
         # are zero for a fresh request, so the tail columns are unused).

--- a/tensorrt_llm/_torch/models/modeling_kimi_linear.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_linear.py
@@ -76,11 +76,11 @@ is validated only without block reuse (Mixed cache manager).
 
 from __future__ import annotations
 
+import copy
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-import copy
 import torch
 from torch import nn
 
@@ -103,11 +103,21 @@ from .modeling_utils import DecoderModel, register_auto_model
 
 # A/B escape hatch: restore nn.Linear for the K3 latent MoE projections
 # instead of the min-latency fused GEMM op (read once at import).
-_K3_DISABLE_MIN_LATENCY_LATENT_PROJ = os.environ.get(
-    "TLLM_K3_DISABLE_MIN_LATENCY_LATENT_PROJ", "0") == "1"
+_K3_DISABLE_MIN_LATENCY_LATENT_PROJ = (
+    os.environ.get("TLLM_K3_DISABLE_MIN_LATENCY_LATENT_PROJ", "0") == "1"
+)
 
-_KDA_INDEXED_STATE_POOL_ENABLED = os.environ.get(
-    "TLLM_KDA_ENABLE_INDEXED_STATE_POOL", "1") == "1"
+_KDA_FUSED_STATE_IO_ENV = "TLLM_KDA_USE_FUSED_STATE_IO"
+
+
+def _fused_prefill_state_io_enabled() -> bool:
+    value = os.environ.get(_KDA_FUSED_STATE_IO_ENV, "1")
+    if value not in ("0", "1"):
+        raise ValueError(f"{_KDA_FUSED_STATE_IO_ENV} must be 0 or 1, got {value!r}")
+    return value == "1"
+
+
+_KDA_INDEXED_STATE_POOL_ENABLED = os.environ.get("TLLM_KDA_ENABLE_INDEXED_STATE_POOL", "1") == "1"
 
 # Routed-expert MoE TP/EP split overrides (read per model init, not import).
 # Highest precedence; either one may be set alone, the other is derived from
@@ -189,8 +199,9 @@ _KIMI_K3_FP8_WEIGHT_READ_GATE_UP_ENV = "KIMI_K3_FP8_WEIGHT_READ_GATE_UP"
 def _get_text_config(pretrained_config: "PretrainedConfig"):
     """Return the Kimi text config, unwrapping a composite kimi_k3 config."""
     if getattr(pretrained_config, "model_type", None) == "kimi_k3" or (
-            not hasattr(pretrained_config, "linear_attn_config")
-            and hasattr(pretrained_config, "text_config")):
+        not hasattr(pretrained_config, "linear_attn_config")
+        and hasattr(pretrained_config, "text_config")
+    ):
         return pretrained_config.text_config
     return pretrained_config
 
@@ -215,9 +226,9 @@ KIMI_K3_FUSED_ATTN_RES_ENV = "KIMI_K3_FUSED_ATTN_RES"
 _FUSED_ATTN_RES_ENABLED = os.environ.get(KIMI_K3_FUSED_ATTN_RES_ENV, "1") == "1"
 
 
-def _apply_attn_res_fused(prefix_sum: torch.Tensor,
-                          block_residual: torch.Tensor, proj: nn.Linear,
-                          norm: KimiK3RMSNorm) -> Optional[torch.Tensor]:
+def _apply_attn_res_fused(
+    prefix_sum: torch.Tensor, block_residual: torch.Tensor, proj: nn.Linear, norm: KimiK3RMSNorm
+) -> Optional[torch.Tensor]:
     """Fused attn_res via the in-tree ``trtllm::attn_res_fwd`` op.
 
     Returns ``None`` when the call falls outside the fused kernel's
@@ -239,14 +250,18 @@ def _apply_attn_res_fused(prefix_sum: torch.Tensor,
     layer_kernel = prefix_sum.reshape(M, 1, H).contiguous()
     block_kernel = block_residual.reshape(K, M, 1, H).contiguous()
     output, _rsigma, _probs, _logits = attn_res_op(
-        layer_kernel, block_kernel,
+        layer_kernel,
+        block_kernel,
         proj.weight.reshape(-1).to(torch.bfloat16).contiguous(),
-        norm.weight.to(torch.bfloat16).contiguous(), float(norm.eps))
+        norm.weight.to(torch.bfloat16).contiguous(),
+        float(norm.eps),
+    )
     return output.reshape(M, H)
 
 
-def _apply_attn_res(prefix_sum: torch.Tensor, block_residual: torch.Tensor,
-                    proj: nn.Linear, norm: KimiK3RMSNorm) -> torch.Tensor:
+def _apply_attn_res(
+    prefix_sum: torch.Tensor, block_residual: torch.Tensor, proj: nn.Linear, norm: KimiK3RMSNorm
+) -> torch.Tensor:
     """Exact port of HF ``modeling_kimi._apply_attn_res`` (fp32 math).
 
     prefix_sum:     ``[num_tokens, hidden_size]``
@@ -287,8 +302,10 @@ _GATE_UP_FUSED_SUFFIX = ".gate_up_proj.weight"
 def _gate_up_ckpt_keys(fused_key: str) -> Tuple[str, str]:
     """Checkpoint ``(gate_proj, up_proj)`` keys whose row-concat loads the
     fused ``gate_up_proj`` parameter named by ``fused_key``."""
-    return (fused_key.replace(_GATE_UP_FUSED_SUFFIX, ".gate_proj.weight"),
-            fused_key.replace(_GATE_UP_FUSED_SUFFIX, ".up_proj.weight"))
+    return (
+        fused_key.replace(_GATE_UP_FUSED_SUFFIX, ".gate_proj.weight"),
+        fused_key.replace(_GATE_UP_FUSED_SUFFIX, ".up_proj.weight"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -310,8 +327,9 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
     weight exactly.
     """
 
-    def __init__(self, weight_fp8: torch.Tensor, weight_scale: torch.Tensor,
-                 out_features: int) -> None:
+    def __init__(
+        self, weight_fp8: torch.Tensor, weight_scale: torch.Tensor, out_features: int
+    ) -> None:
         super().__init__()
         self.out_features = out_features
         # Buffers (not parameters): these are the module's weights post-load;
@@ -321,8 +339,7 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
         self.register_buffer("weight_scale", weight_scale, persistent=False)
 
     @staticmethod
-    def quantize_weight(
-            weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def quantize_weight(weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """BF16 ``[out, in]`` weight -> (FP8 weight, deep_gemm-ready scale).
 
         Both dims must be multiples of 128. Because the 128x128 block scale is
@@ -334,33 +351,37 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
         # Lazy imports: only pulled in on the FP8 path.
         from ...deep_gemm.utils.math import per_block_cast_to_fp8
         from ...quantization.utils.fp8_utils import (
-            resmooth_to_fp8_e8m0, transform_sf_into_required_layout)
+            resmooth_to_fp8_e8m0,
+            transform_sf_into_required_layout,
+        )
+
         # 128x128 block-scale FP8 weight, then the exact SM100 deep_gemm scale
         # preparation the shipping FP8-block-scale Linear uses: resmooth to
         # UE8M0 and pack the scale into deep_gemm's TMA-aligned MN-major
         # layout. fp8_swap_ab_gemm runs with disable_ue8m0_cast=True, so it
         # consumes this pre-formatted scale directly (a plain FP32 block scale
         # would be misread and produce garbage).
-        weight_fp8, weight_scale = per_block_cast_to_fp8(weight,
-                                                         use_ue8m0=False)
+        weight_fp8, weight_scale = per_block_cast_to_fp8(weight, use_ue8m0=False)
         weight_fp8, weight_scale = resmooth_to_fp8_e8m0(
-            weight_fp8.contiguous(), weight_scale.contiguous().float())
-        weight_scale = transform_sf_into_required_layout(weight_scale,
-                                                         mn=weight_fp8.shape[0],
-                                                         k=weight_fp8.shape[1],
-                                                         recipe=(1, 128, 128),
-                                                         is_sfa=False)
+            weight_fp8.contiguous(), weight_scale.contiguous().float()
+        )
+        weight_scale = transform_sf_into_required_layout(
+            weight_scale,
+            mn=weight_fp8.shape[0],
+            k=weight_fp8.shape[1],
+            recipe=(1, 128, 128),
+            is_sfa=False,
+        )
         return weight_fp8, weight_scale
 
     @classmethod
-    def from_linear(cls,
-                    linear: nn.Linear) -> "_Fp8BlockScaleWeightReadLinear":
+    def from_linear(cls, linear: nn.Linear) -> "_Fp8BlockScaleWeightReadLinear":
         assert linear.bias is None, "FP8 weight read expects a bias-free Linear"
         weight_fp8, weight_scale = cls.quantize_weight(linear.weight.data)
         return cls(weight_fp8, weight_scale, linear.out_features)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        out_shape = x.shape[:-1] + (self.out_features, )
+        out_shape = x.shape[:-1] + (self.out_features,)
         out = torch.ops.trtllm.fp8_swap_ab_gemm(
             x.reshape(-1, x.shape[-1]),
             self.weight,
@@ -372,7 +393,8 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
 
 
 def _convert_moe_mlps_to_fp8_weight_read(
-        model: nn.Module, include_fused_gate_up: bool = True) -> int:
+    model: nn.Module, include_fused_gate_up: bool = True
+) -> int:
     """Swap the replicated MoE-layer MLP projections to an FP8 weight read.
 
     Targets the shared-expert MLP (gate/up/down) and the latent up/down
@@ -389,8 +411,7 @@ def _convert_moe_mlps_to_fp8_weight_read(
         nonlocal count
         child = getattr(parent, attr, None)
         if isinstance(child, nn.Linear):
-            setattr(parent, attr,
-                    _Fp8BlockScaleWeightReadLinear.from_linear(child))
+            setattr(parent, attr, _Fp8BlockScaleWeightReadLinear.from_linear(child))
             # Release the original BF16 weight storage now. The loader holds a
             # transient name->Parameter map that keeps it alive until load
             # returns, so without this the FP8 copy is purely additive and
@@ -409,9 +430,11 @@ def _convert_moe_mlps_to_fp8_weight_read(
             # only pays off when attention DP re-reads it per rank per step;
             # under TP the bf16 GEMM overlaps on the aux stream and the FP8
             # quantize+GEMM would serialize onto the critical path.
-            shared_attrs = (("gate_proj", "up_proj", "gate_up_proj",
-                             "down_proj") if include_fused_gate_up else
-                            ("gate_proj", "up_proj", "down_proj"))
+            shared_attrs = (
+                ("gate_proj", "up_proj", "gate_up_proj", "down_proj")
+                if include_fused_gate_up
+                else ("gate_proj", "up_proj", "down_proj")
+            )
             for attr in shared_attrs:
                 _swap(shared, attr)
         for attr in ("routed_expert_down_proj", "routed_expert_up_proj"):
@@ -464,18 +487,15 @@ def _convert_kda_projections_to_fp8_weight_read(model: nn.Module) -> int:
 
         # Projections that read the same normed hidden (g_proj only in the
         # full-rank-gate config; the low-rank g_a/g_b gate stays BF16).
-        group = [(a, getattr(mixer, a, None))
-                 for a in ("q_proj", "k_proj", "v_proj", "g_proj")]
+        group = [(a, getattr(mixer, a, None)) for a in ("q_proj", "k_proj", "v_proj", "g_proj")]
         group = [(a, c) for a, c in group if isinstance(c, nn.Linear)]
 
         if group:
             # One fused FP8 weight [sum(out), in]; row slices equal the
             # individually quantized weights (see quantize_weight).
             fused_bf16 = torch.cat([c.weight.data for _, c in group], dim=0)
-            fused_fp8, fused_scale = _Fp8BlockScaleWeightReadLinear.quantize_weight(
-                fused_bf16)
-            fused = _Fp8BlockScaleWeightReadLinear(fused_fp8, fused_scale,
-                                                   fused_bf16.shape[0])
+            fused_fp8, fused_scale = _Fp8BlockScaleWeightReadLinear.quantize_weight(fused_bf16)
+            fused = _Fp8BlockScaleWeightReadLinear(fused_fp8, fused_scale, fused_bf16.shape[0])
             mixer.qkvg_proj = fused
             mixer.qkvg_split_sizes = [c.out_features for _, c in group]
             del fused_bf16
@@ -485,13 +505,12 @@ def _convert_kda_projections_to_fp8_weight_read(model: nn.Module) -> int:
             offset = 0
             for attr, child in group:
                 n = child.out_features
-                _, own_scale = _Fp8BlockScaleWeightReadLinear.quantize_weight(
-                    child.weight.data)
+                _, own_scale = _Fp8BlockScaleWeightReadLinear.quantize_weight(child.weight.data)
                 setattr(
-                    mixer, attr,
-                    _Fp8BlockScaleWeightReadLinear(fused.weight[offset:offset +
-                                                                n], own_scale,
-                                                   n))
+                    mixer,
+                    attr,
+                    _Fp8BlockScaleWeightReadLinear(fused.weight[offset : offset + n], own_scale, n),
+                )
                 # Free the original BF16 storage (the loader's transient
                 # name->Parameter map keeps it alive until load returns, so
                 # without this the FP8 copy is purely additive on the tight
@@ -504,8 +523,7 @@ def _convert_kda_projections_to_fp8_weight_read(model: nn.Module) -> int:
         # hidden-reading group; convert it on its own.
         o_proj = getattr(mixer, "o_proj", None)
         if isinstance(o_proj, nn.Linear):
-            setattr(mixer, "o_proj",
-                    _Fp8BlockScaleWeightReadLinear.from_linear(o_proj))
+            setattr(mixer, "o_proj", _Fp8BlockScaleWeightReadLinear.from_linear(o_proj))
             o_proj.weight.data = o_proj.weight.data.new_empty(0)
             count += 1
 
@@ -539,8 +557,7 @@ def _convert_mla_projections_to_fp8_weight_read(model: nn.Module) -> int:
         nonlocal count
         child = getattr(parent, attr, None)
         if isinstance(child, nn.Linear):
-            setattr(parent, attr,
-                    _Fp8BlockScaleWeightReadLinear.from_linear(child))
+            setattr(parent, attr, _Fp8BlockScaleWeightReadLinear.from_linear(child))
             # Free the original BF16 storage now (as in the MLP/KDA conversions
             # above): the loader's transient name->Parameter map would otherwise
             # keep it alive until load returns, making the FP8 copy purely
@@ -575,19 +592,22 @@ def _convert_mla_projections_to_fp8_weight_read(model: nn.Module) -> int:
 class KimiK3MoERuntime(nn.Module):
     """Kimi K3 latent MoE block backed by ConfigurableMoE/TRTLLM-Gen."""
 
-    def __init__(self,
-                 model_config: ModelConfig,
-                 cfg,
-                 layer_idx: int,
-                 aux_stream: Optional[torch.cuda.Stream] = None):
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        cfg,
+        layer_idx: int,
+        aux_stream: Optional[torch.cuda.Stream] = None,
+    ):
         super().__init__()
         self.layer_idx = layer_idx
         self.hidden_size = cfg.hidden_size
         self.num_experts = cfg.num_experts
         self.top_k = cfg.num_experts_per_token
         self.moe_hidden_size = cfg.routed_expert_hidden_size
-        assert self.moe_hidden_size is not None, \
+        assert self.moe_hidden_size is not None, (
             "Kimi K3 runtime expects the latent MoE (routed_expert_hidden_size)"
+        )
 
         situ_beta = getattr(cfg, "activation_situ_beta", None) or 1.0
         situ_linear_beta = getattr(cfg, "activation_situ_linear_beta", None)
@@ -602,12 +622,12 @@ class KimiK3MoERuntime(nn.Module):
         # 3-run bisect on 62b20dd868), and the bs1-latency win is irrelevant
         # at DEP batch sizes. KIMI_K3_ROUTER_BF16=1/0 forces either path.
         _router_bf16_env = os.environ.get("KIMI_K3_ROUTER_BF16")
-        _router_bf16 = (_router_bf16_env == "1"
-                        if _router_bf16_env is not None else
-                        not model_config.mapping.enable_attention_dp)
-        self.gate = KimiK3MoEGate(
-            cfg,
-            logits_gemm_dtype=torch.bfloat16 if _router_bf16 else None)
+        _router_bf16 = (
+            _router_bf16_env == "1"
+            if _router_bf16_env is not None
+            else not model_config.mapping.enable_attention_dp
+        )
+        self.gate = KimiK3MoEGate(cfg, logits_gemm_dtype=torch.bfloat16 if _router_bf16 else None)
 
         routed_moe_model_config = self._routed_moe_model_config(model_config)
         routed_quant_config = QuantConfig(quant_algo=QuantAlgo.W4A8_MXFP4_MXFP8)
@@ -678,21 +698,20 @@ class KimiK3MoERuntime(nn.Module):
         self.aux_stream = aux_stream
         self.moe_main_event = torch.cuda.Event()
         self.moe_shared_event = torch.cuda.Event()
-        self.routed_expert_down_proj = nn.Linear(cfg.hidden_size,
-                                                 self.moe_hidden_size,
-                                                 bias=False,
-                                                 dtype=dtype)
-        self.routed_expert_up_proj = nn.Linear(self.moe_hidden_size,
-                                               cfg.hidden_size,
-                                               bias=False,
-                                               dtype=dtype)
-        assert getattr(cfg, "latent_moe_use_norm", False), \
+        self.routed_expert_down_proj = nn.Linear(
+            cfg.hidden_size, self.moe_hidden_size, bias=False, dtype=dtype
+        )
+        self.routed_expert_up_proj = nn.Linear(
+            self.moe_hidden_size, cfg.hidden_size, bias=False, dtype=dtype
+        )
+        assert getattr(cfg, "latent_moe_use_norm", False), (
             "Kimi K3 runtime expects latent_moe_use_norm=True"
+        )
         # Stock fused RMSNorm (flashinfer kernel; the no-flashinfer
         # fallback is the same fp32-variance eager math as KimiK3RMSNorm).
-        self.routed_expert_norm = RMSNorm(hidden_size=self.moe_hidden_size,
-                                          eps=cfg.rms_norm_eps,
-                                          dtype=dtype)
+        self.routed_expert_norm = RMSNorm(
+            hidden_size=self.moe_hidden_size, eps=cfg.rms_norm_eps, dtype=dtype
+        )
 
     @staticmethod
     def _select_moe_tp_ep(mapping: Mapping) -> Tuple[int, int]:
@@ -742,16 +761,19 @@ class KimiK3MoERuntime(nn.Module):
         if moe_tp < 1 or moe_ep < 1 or moe_tp * moe_ep != mapping.tp_size:
             raise ValueError(
                 f"Kimi K3 routed MoE split moe_tp={moe_tp} x moe_ep={moe_ep} "
-                f"must multiply to tp_size={mapping.tp_size}.")
+                f"must multiply to tp_size={mapping.tp_size}."
+            )
         if moe_tp > 1 and mapping.enable_attention_dp:
             raise NotImplementedError(
                 "Kimi K3 MoE tensor parallelism requires "
                 "enable_attention_dp=false (the attention-DP dispatch/combine "
-                "path is validated for EP-only splits).")
+                "path is validated for EP-only splits)."
+            )
         logger.info_once(
             f"Kimi K3 routed MoE parallelism: moe_tp={moe_tp}, "
             f"moe_ep={moe_ep} (tp_size={mapping.tp_size})",
-            key="kimi_k3_moe_tp_ep_split")
+            key="kimi_k3_moe_tp_ep_split",
+        )
 
         mapping_dict = mapping.to_dict()
         mapping_dict["moe_cluster_size"] = 1
@@ -767,8 +789,7 @@ class KimiK3MoERuntime(nn.Module):
         routed_model_config._frozen = True
         return routed_model_config
 
-    def forward(self, hidden_states: torch.Tensor,
-                all_rank_num_tokens=None) -> torch.Tensor:
+    def forward(self, hidden_states: torch.Tensor, all_rank_num_tokens=None) -> torch.Tensor:
         """``hidden_states``: ``[num_tokens, hidden_size]`` bf16."""
         identity = hidden_states
         router_logits = self.gate.compute_logits(hidden_states)
@@ -784,13 +805,14 @@ class KimiK3MoERuntime(nn.Module):
             # replaced the projection module, call it directly: its weight is
             # an e4m3 buffer the bf16 dsv3 op must not read, and its forward
             # is already a single fused GEMM (fp8_swap_ab_gemm).
-            if (_K3_DISABLE_MIN_LATENCY_LATENT_PROJ or not isinstance(
-                    self.routed_expert_down_proj, nn.Linear)):
+            if _K3_DISABLE_MIN_LATENCY_LATENT_PROJ or not isinstance(
+                self.routed_expert_down_proj, nn.Linear
+            ):
                 routed_in = self.routed_expert_down_proj(hidden_states)
             else:
                 routed_in = torch.ops.trtllm.dsv3_fused_a_gemm_op(
-                    hidden_states, self.routed_expert_down_proj.weight.t(),
-                    None, None)
+                    hidden_states, self.routed_expert_down_proj.weight.t(), None, None
+                )
             y = self.routed_experts(
                 routed_in,
                 router_logits,
@@ -799,11 +821,13 @@ class KimiK3MoERuntime(nn.Module):
             # EP partial latent sums are completed by the wrapper's own
             # reduction BEFORE the (nonlinear) latent norm.
             y = self.routed_expert_norm(y)
-            if (_K3_DISABLE_MIN_LATENCY_LATENT_PROJ or not isinstance(
-                    self.routed_expert_up_proj, nn.Linear)):
+            if _K3_DISABLE_MIN_LATENCY_LATENT_PROJ or not isinstance(
+                self.routed_expert_up_proj, nn.Linear
+            ):
                 return self.routed_expert_up_proj(y)
             return torch.ops.trtllm.dsv3_fused_a_gemm_op(
-                y, self.routed_expert_up_proj.weight.t(), None, None)
+                y, self.routed_expert_up_proj.weight.t(), None, None
+            )
 
         # Shared experts are replicated (computed once per rank) and depend
         # only on the block input, not on the routed dispatch/expert/combine
@@ -818,7 +842,8 @@ class KimiK3MoERuntime(nn.Module):
             self.moe_main_event,
             self.moe_shared_event,
             self.aux_stream,
-            disable_on_compile=True)
+            disable_on_compile=True,
+        )
         return routed_out + shared_out
 
 
@@ -828,11 +853,10 @@ class KimiK3MoERuntime(nn.Module):
 
 
 def _kda_split_conv_sections(
-        cs: torch.Tensor, d: int) -> Tuple[torch.Tensor, torch.Tensor,
-                                           torch.Tensor]:
+    cs: torch.Tensor, d: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Split a gathered ``[N, 3D, W]`` conv-cache into contiguous q/k/v."""
-    return (cs[:, :d].contiguous(), cs[:, d:2 * d].contiguous(),
-            cs[:, 2 * d:].contiguous())
+    return (cs[:, :d].contiguous(), cs[:, d : 2 * d].contiguous(), cs[:, 2 * d :].contiguous())
 
 
 class KimiKDARuntime(nn.Module):
@@ -844,13 +868,16 @@ class KimiKDARuntime(nn.Module):
     ``model.layers.N.self_attn.q_proj.weight`` maps identically).
     """
 
-    def __init__(self, cfg, layer_idx: int, mapping=None,
-                 allreduce_strategy=AllReduceStrategy.AUTO):
+    def __init__(
+        self, cfg, layer_idx: int, mapping=None, allreduce_strategy=AllReduceStrategy.AUTO
+    ):
         super().__init__()
         # Lazy import: pulls in fla/einops.
         from ..modules.kimi_kda.kimi_kda_mixer import KimiKDALinearAttention
+
         lin = cfg.linear_attn_config
         self.layer_idx = layer_idx
+        self._use_fused_prefill_state_io = _fused_prefill_state_io_enabled()
         self._use_indexed_ssm_pool = _KDA_INDEXED_STATE_POOL_ENABLED
         # Attention-family TP semantics (Qwen3-Next GatedDeltaNet pattern,
         # gdn_mixer.py): replicated under attention-DP — each rank runs
@@ -858,21 +885,20 @@ class KimiKDARuntime(nn.Module):
         # mapping.tp_size otherwise: every rank holds the same batch, runs
         # its 1/tp head slice, and the row-sharded o_proj partials are
         # all-reduced at the end of forward().
-        if (mapping is not None and mapping.tp_size > 1
-                and not mapping.enable_attention_dp):
+        if mapping is not None and mapping.tp_size > 1 and not mapping.enable_attention_dp:
             self._kda_tp_size = mapping.tp_size
         else:
             self._kda_tp_size = 1
-        self._kda_tp_rank = (mapping.tp_rank
-                             if self._kda_tp_size > 1 else 0)
-        self._o_allreduce = (AllReduce(mapping=mapping,
-                                       strategy=allreduce_strategy,
-                                       dtype=torch.bfloat16)
-                             if self._kda_tp_size > 1 else None)
+        self._kda_tp_rank = mapping.tp_rank if self._kda_tp_size > 1 else 0
+        self._o_allreduce = (
+            AllReduce(mapping=mapping, strategy=allreduce_strategy, dtype=torch.bfloat16)
+            if self._kda_tp_size > 1
+            else None
+        )
         num_heads = lin["num_heads"]
         assert num_heads % self._kda_tp_size == 0, (
-            f"KDA num_heads {num_heads} not divisible by "
-            f"tp_size {self._kda_tp_size}")
+            f"KDA num_heads {num_heads} not divisible by tp_size {self._kda_tp_size}"
+        )
         self.mixer = KimiKDALinearAttention(
             hidden_size=cfg.hidden_size,
             num_heads=num_heads // self._kda_tp_size,
@@ -885,8 +911,7 @@ class KimiKDARuntime(nn.Module):
             layer_idx=layer_idx,
             # Use TLLM_KDA_ENABLE_OPT_PREFILL=0 to opt out of the optimized
             # prefill kernel.
-            use_optimized_prefill=os.getenv("TLLM_KDA_ENABLE_OPT_PREFILL",
-                                            "1") == "1",
+            use_optimized_prefill=os.getenv("TLLM_KDA_ENABLE_OPT_PREFILL", "1") == "1",
             use_optimized_decode=True,
         )
         self.proj_size = (num_heads // self._kda_tp_size) * lin["head_dim"]
@@ -921,20 +946,24 @@ class KimiKDARuntime(nn.Module):
            ``A_log`` / ``dt_bias`` / ``o_norm.weight``.
         """
         mixer = self.mixer
-        if (mixer._dispatch.decode_kernel_path != "optimized"
-                or not mixer.use_full_rank_gate):
+        if mixer._dispatch.decode_kernel_path != "optimized" or not mixer.use_full_rank_gate:
             return
         if mixer.q_proj.weight.device.type != "cuda":
             return
         with torch.no_grad():
-            mods = (mixer.q_proj, mixer.k_proj, mixer.v_proj, mixer.g_proj,
-                    mixer.f_a_proj, mixer.b_proj)
-            fused = torch.cat([m.weight.data for m in mods],
-                              dim=0).contiguous()
+            mods = (
+                mixer.q_proj,
+                mixer.k_proj,
+                mixer.v_proj,
+                mixer.g_proj,
+                mixer.f_a_proj,
+                mixer.b_proj,
+            )
+            fused = torch.cat([m.weight.data for m in mods], dim=0).contiguous()
             off = 0
             for m in mods:
                 n = m.weight.shape[0]
-                m.weight.data = fused[off:off + n]
+                m.weight.data = fused[off : off + n]
                 off += n
             self._build_decode_kernel_constants()
             # Publish last: `_in_proj_weight is not None` gates the fast path.
@@ -943,15 +972,30 @@ class KimiKDARuntime(nn.Module):
     def _build_decode_kernel_constants(self) -> None:
         """Kernel-layout constants shared by both finalize variants."""
         mixer = self.mixer
-        self._w_q_t = (mixer.q_conv1d.weight.detach().squeeze(1).transpose(
-            0, 1).to(torch.bfloat16).contiguous())
-        self._w_k_t = (mixer.k_conv1d.weight.detach().squeeze(1).transpose(
-            0, 1).to(torch.bfloat16).contiguous())
-        self._w_v_t = (mixer.v_conv1d.weight.detach().squeeze(1).transpose(
-            0, 1).to(torch.bfloat16).contiguous())
+        self._w_q_t = (
+            mixer.q_conv1d.weight.detach()
+            .squeeze(1)
+            .transpose(0, 1)
+            .to(torch.bfloat16)
+            .contiguous()
+        )
+        self._w_k_t = (
+            mixer.k_conv1d.weight.detach()
+            .squeeze(1)
+            .transpose(0, 1)
+            .to(torch.bfloat16)
+            .contiguous()
+        )
+        self._w_v_t = (
+            mixer.v_conv1d.weight.detach()
+            .squeeze(1)
+            .transpose(0, 1)
+            .to(torch.bfloat16)
+            .contiguous()
+        )
         self._A_log_f32 = mixer.A_log.detach().float().contiguous()
         self._dt_bias_f32 = mixer.dt_bias.detach().float().contiguous()
-        self._onorm_w_f32 = (mixer.o_norm.weight.detach().float().contiguous())
+        self._onorm_w_f32 = mixer.o_norm.weight.detach().float().contiguous()
 
     def finalize_decode_weights_fp8(self) -> None:
         """FP8 counterpart of ``finalize_decode_weights()``.
@@ -969,8 +1013,7 @@ class KimiKDARuntime(nn.Module):
         the BF16 finalize.
         """
         mixer = self.mixer
-        if (mixer._dispatch.decode_kernel_path != "optimized"
-                or not mixer.use_full_rank_gate):
+        if mixer._dispatch.decode_kernel_path != "optimized" or not mixer.use_full_rank_gate:
             return
         fused_qkvg = getattr(mixer, "qkvg_proj", None)
         split_sizes = getattr(mixer, "qkvg_split_sizes", None)
@@ -980,19 +1023,19 @@ class KimiKDARuntime(nn.Module):
             return
         with torch.no_grad():
             mods = (mixer.f_a_proj, mixer.b_proj)
-            fused = torch.cat([m.weight.data for m in mods],
-                              dim=0).contiguous()
+            fused = torch.cat([m.weight.data for m in mods], dim=0).contiguous()
             off = 0
             for m in mods:
                 n = m.weight.shape[0]
-                m.weight.data = fused[off:off + n]
+                m.weight.data = fused[off : off + n]
                 off += n
             self._build_decode_kernel_constants()
             # Publish last: gates the FP8 decode fast path.
             self._in_proj_small_weight = fused
 
-    def forward(self, hidden_states: torch.Tensor,
-                attn_metadata: AttentionMetadata) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, attn_metadata: AttentionMetadata
+    ) -> torch.Tensor:
         """``hidden_states``: flattened ``[num_tokens, hidden]`` (ctx tokens
         first, then one token per generation request)."""
         mamba_metadata = attn_metadata.mamba_metadata
@@ -1005,11 +1048,10 @@ class KimiKDARuntime(nn.Module):
         state_indices = getattr(mamba_metadata, "state_indices_long", None)
         if state_indices is None or state_indices.shape[0] != batch_size:
             state_indices = mamba_metadata.state_indices[:batch_size].long()
-        cu_seqlens = mamba_metadata.query_start_loc_long[:num_prefills + 1]
+        cu_seqlens = mamba_metadata.query_start_loc_long[: num_prefills + 1]
         num_decodes = batch_size - num_prefills
 
-        layer_cache = attn_metadata.kv_cache_manager.mamba_layer_cache(
-            self.layer_idx)
+        layer_cache = attn_metadata.kv_cache_manager.mamba_layer_cache(self.layer_idx)
         conv_pool = layer_cache.conv  # [slots, 3D, W] bf16
         ssm_pool = layer_cache.temporal  # [slots, H, V, K] fp32
 
@@ -1025,7 +1067,8 @@ class KimiKDARuntime(nn.Module):
                     ssm_pool,
                     state_indices[:num_prefills],
                     layer_cache,
-                ))
+                )
+            )
         if num_decodes > 0:
             decode_rows = hidden_states.shape[0] - num_ctx_tokens
             if decode_rows == num_decodes:
@@ -1039,8 +1082,11 @@ class KimiKDARuntime(nn.Module):
                         layer_cache,
                         ssm_state_indices=(
                             mamba_metadata.state_indices[num_prefills:batch_size]
-                            if self._use_indexed_ssm_pool else None),
-                    ))
+                            if self._use_indexed_ssm_pool
+                            else None
+                        ),
+                    )
+                )
             else:
                 # Speculative verification: each generation request carries
                 # 1 + draft_len tokens (drafts are padded to the static max,
@@ -1049,8 +1095,8 @@ class KimiKDARuntime(nn.Module):
                 # and kv_cache_manager.update_mamba_states() promotes the
                 # accepted step after sampling.
                 assert decode_rows % num_decodes == 0, (
-                    f"ragged generation batch: {decode_rows} tokens for "
-                    f"{num_decodes} requests")
+                    f"ragged generation batch: {decode_rows} tokens for {num_decodes} requests"
+                )
                 outputs.append(
                     self._forward_verify(
                         hidden_states[num_ctx_tokens:],
@@ -1059,7 +1105,8 @@ class KimiKDARuntime(nn.Module):
                         conv_pool,
                         ssm_pool,
                         state_indices[num_prefills:],
-                    ))
+                    )
+                )
         out = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
         if self._o_allreduce is not None:
             # Head-sharded TP: every rank ran its head shard on the same
@@ -1071,8 +1118,9 @@ class KimiKDARuntime(nn.Module):
         """True when the manager allocated the fused-verify replay caches."""
         return getattr(layer_cache, "kda_qkg_cache", None) is not None
 
-    def _sync_kda_replay_conv_window(self, layer_cache, slot_indices,
-                                     conv_q, conv_k, conv_v) -> None:
+    def _sync_kda_replay_conv_window(
+        self, layer_cache, slot_indices, conv_q, conv_k, conv_v
+    ) -> None:
         """Seed the replay conv caches' committed window from FLA windows.
 
         The fused verify kernel keeps its own extended fp32 dim-contiguous
@@ -1085,15 +1133,24 @@ class KimiKDARuntime(nn.Module):
         if not self._has_kda_replay_caches(layer_cache):
             return
         w = self.mixer.conv_size
-        for cache, window in ((layer_cache.kda_conv_q, conv_q),
-                              (layer_cache.kda_conv_k, conv_k),
-                              (layer_cache.kda_conv_v, conv_v)):
-            cache[:, :, :w - 1].index_copy_(
-                0, slot_indices, window[:, :, 1:].to(cache.dtype))
+        for cache, window in (
+            (layer_cache.kda_conv_q, conv_q),
+            (layer_cache.kda_conv_k, conv_k),
+            (layer_cache.kda_conv_v, conv_v),
+        ):
+            cache[:, :, : w - 1].index_copy_(0, slot_indices, window[:, :, 1:].to(cache.dtype))
 
-    def _forward_prefill(self, x2d, cu_seqlens, mamba_metadata, num_prefills,
-                         conv_pool, ssm_pool, slot_indices,
-                         layer_cache=None) -> torch.Tensor:
+    def _forward_prefill(
+        self,
+        x2d,
+        cu_seqlens,
+        mamba_metadata,
+        num_prefills,
+        conv_pool,
+        ssm_pool,
+        slot_indices,
+        layer_cache=None,
+    ) -> torch.Tensor:
         from einops import rearrange
 
         mixer = self.mixer
@@ -1107,28 +1164,33 @@ class KimiKDARuntime(nn.Module):
         # Initial states: present for continuation chunks (chunked prefill)
         # and for prefix-cache hits (block reuse), where the previous
         # conv/recurrent state was onboarded into this request's slot.
+        has_init = mamba_metadata.has_initial_states[:num_prefills]
+        use_indexed_state = self._use_fused_prefill_state_io and mixer.can_use_indexed_prefill(
+            state_pool=ssm_pool,
+            state_indices=slot_indices,
+            has_initial_states=has_init,
+            cu_seqlens=cu_seqlens,
+            num_tokens=x2d.shape[0],
+        )
         conv_q_in = conv_k_in = conv_v_in = None
         recurrent_in = None
         if mamba_metadata.use_initial_states:
-            has_init = mamba_metadata.has_initial_states[:num_prefills]
             cs = conv_pool.index_select(0, slot_indices)
             cs[~has_init] = 0
             conv_q_in, conv_k_in, conv_v_in = _kda_split_conv_sections(cs, d)
-            recurrent_in = ssm_pool.index_select(0, slot_indices)
-            recurrent_in[~has_init] = 0
+            if not use_indexed_state:
+                recurrent_in = ssm_pool.index_select(0, slot_indices)
+                recurrent_in[~has_init] = 0
 
-        q, conv_q = mixer.q_conv1d(q_proj_states,
-                                   cache=conv_q_in,
-                                   output_final_state=True,
-                                   cu_seqlens=cu_seqlens)
-        k, conv_k = mixer.k_conv1d(k_proj_states,
-                                   cache=conv_k_in,
-                                   output_final_state=True,
-                                   cu_seqlens=cu_seqlens)
-        v, conv_v = mixer.v_conv1d(v_proj_states,
-                                   cache=conv_v_in,
-                                   output_final_state=True,
-                                   cu_seqlens=cu_seqlens)
+        q, conv_q = mixer.q_conv1d(
+            q_proj_states, cache=conv_q_in, output_final_state=True, cu_seqlens=cu_seqlens
+        )
+        k, conv_k = mixer.k_conv1d(
+            k_proj_states, cache=conv_k_in, output_final_state=True, cu_seqlens=cu_seqlens
+        )
+        v, conv_v = mixer.v_conv1d(
+            v_proj_states, cache=conv_v_in, output_final_state=True, cu_seqlens=cu_seqlens
+        )
 
         g = mixer.f_b_proj(mixer.f_a_proj(x))
         g = rearrange(g, "... (h d) -> ... h d", d=mixer.head_dim)
@@ -1138,9 +1200,9 @@ class KimiKDARuntime(nn.Module):
         k = rearrange(k, "... (h d) -> ... h d", d=mixer.head_k_dim)
         v = rearrange(v, "... (h d) -> ... h d", d=mixer.head_dim)
 
-        # Kernel dispatch (in-tree trtllm::kda_prefill or FLA chunk_kda).
-        # Both paths exchange states in the pool's V-first [N, H, V, K]
-        # layout, so recurrent_in / final_state map to ssm_pool 1:1.
+        # The indexed optimized path reads and writes the V-first pool
+        # directly. Unsupported layouts/batches retain the original
+        # gather/transpose/op/transpose/scatter path.
         lower_bound = mixer.gate_lower_bound
         o, final_state = mixer.prefill_chunk_kda(
             q=q,
@@ -1155,24 +1217,35 @@ class KimiKDARuntime(nn.Module):
             safe_gate=lower_bound is not None,
             lower_bound=lower_bound,
             cu_seqlens=cu_seqlens,
+            state_pool=ssm_pool if use_indexed_state else None,
+            state_indices=slot_indices if use_indexed_state else None,
+            has_initial_states=has_init if use_indexed_state else None,
         )
 
         # Persist per-request states into the pools.
         conv_pool.index_copy_(
-            0, slot_indices,
-            torch.cat([conv_q, conv_k, conv_v], dim=1).to(conv_pool.dtype))
-        ssm_pool.index_copy_(0, slot_indices, final_state.to(ssm_pool.dtype))
+            0, slot_indices, torch.cat([conv_q, conv_k, conv_v], dim=1).to(conv_pool.dtype)
+        )
+        if not use_indexed_state:
+            assert final_state is not None
+            ssm_pool.index_copy_(0, slot_indices, final_state.to(ssm_pool.dtype))
         # Fused-verify replay caches: seed the committed conv window so the
         # first verify round convolves the correct history (pending drafts
         # are zero for a fresh request, so the tail columns are unused).
-        self._sync_kda_replay_conv_window(layer_cache, slot_indices, conv_q,
-                                          conv_k, conv_v)
+        self._sync_kda_replay_conv_window(layer_cache, slot_indices, conv_q, conv_k, conv_v)
 
         return self._output_gate_and_proj(x, o)
 
-    def _forward_decode(self, x2d, conv_pool, ssm_pool, slot_indices,
-                        mamba_metadata=None, layer_cache=None,
-                        ssm_state_indices=None) -> torch.Tensor:
+    def _forward_decode(
+        self,
+        x2d,
+        conv_pool,
+        ssm_pool,
+        slot_indices,
+        mamba_metadata=None,
+        layer_cache=None,
+        ssm_state_indices=None,
+    ) -> torch.Tensor:
         """Plain T=1 decode, fast path.
 
         Calls ``trtllm::kda_decode`` directly with kernel-native layouts
@@ -1195,24 +1268,25 @@ class KimiKDARuntime(nn.Module):
         otherwise the state uses the batch-row-dense static layout.
         """
         mixer = self.mixer
-        if (mixer.decode_kernel_path != "optimized"
-                or mixer.wrong_state_layout):
+        if mixer.decode_kernel_path != "optimized" or mixer.wrong_state_layout:
             ssm_state_indices = None
         if ssm_state_indices is not None:
             logger.info_once(
                 "Kimi K3 KDA indexed recurrent-state pool path is active",
-                key="kimi_k3_kda_indexed_state_pool")
+                key="kimi_k3_kda_indexed_state_pool",
+            )
         else:
             logger.info_once(
-                "Kimi K3 KDA static recurrent-state path is active",
-                key="kimi_k3_kda_static_state")
-        if ((self._in_proj_weight is None
-             and self._in_proj_small_weight is None)
-                or mamba_metadata is None
-                or ssm_pool.dtype != torch.float32):
-            return self._forward_decode_ref(x2d, conv_pool, ssm_pool,
-                                            slot_indices, layer_cache,
-                                            ssm_state_indices)
+                "Kimi K3 KDA static recurrent-state path is active", key="kimi_k3_kda_static_state"
+            )
+        if (
+            (self._in_proj_weight is None and self._in_proj_small_weight is None)
+            or mamba_metadata is None
+            or ssm_pool.dtype != torch.float32
+        ):
+            return self._forward_decode_ref(
+                x2d, conv_pool, ssm_pool, slot_indices, layer_cache, ssm_state_indices
+            )
 
         d = self.proj_size
         hd = mixer.head_dim
@@ -1230,35 +1304,31 @@ class KimiKDARuntime(nn.Module):
             if torch.cuda.is_current_stream_capturing():
                 # Never allocate inside CUDA graph capture; the reference
                 # path is capture-safe (just slower).
-                return self._forward_decode_ref(x2d, conv_pool, ssm_pool,
-                                                slot_indices, layer_cache,
-                                                ssm_state_indices)
-            buf = torch.empty(3,
-                              max(conv_pool.shape[0], B),
-                              d,
-                              W - 1,
-                              dtype=torch.bfloat16,
-                              device=x2d.device)
+                return self._forward_decode_ref(
+                    x2d, conv_pool, ssm_pool, slot_indices, layer_cache, ssm_state_indices
+                )
+            buf = torch.empty(
+                3, max(conv_pool.shape[0], B), d, W - 1, dtype=torch.bfloat16, device=x2d.device
+            )
             self._cs_dense = buf
 
         if self._in_proj_weight is not None:
             # One GEMV over [q | k | v | g | f_a | b]; slices below are views.
             proj = torch.nn.functional.linear(x2d, self._in_proj_weight)
-            x_qkv = proj[:, :3 * d]
-            onorm_g = proj[:, 3 * d:4 * d]
-            f_a = proj[:, 4 * d:4 * d + hd]
-            beta = proj[:, 4 * d + hd:4 * d + hd + H]
+            x_qkv = proj[:, : 3 * d]
+            onorm_g = proj[:, 3 * d : 4 * d]
+            f_a = proj[:, 4 * d : 4 * d + hd]
+            beta = proj[:, 4 * d + hd : 4 * d + hd + H]
         else:
             # FP8 weight read (KIMI_K3_KDA_GLUE_FP8=1): the loader's fused
             # FP8 [q | k | v | g] GEMM plus one BF16 GEMV over [f_a | b];
             # slices below are views.
             qkvg = mixer.qkvg_proj(x2d)
-            small = torch.nn.functional.linear(x2d,
-                                               self._in_proj_small_weight)
-            x_qkv = qkvg[:, :3 * d]
-            onorm_g = qkvg[:, 3 * d:4 * d]
+            small = torch.nn.functional.linear(x2d, self._in_proj_small_weight)
+            x_qkv = qkvg[:, : 3 * d]
+            onorm_g = qkvg[:, 3 * d : 4 * d]
             f_a = small[:, :hd]
-            beta = small[:, hd:hd + H]
+            beta = small[:, hd : hd + H]
         g = mixer.f_b_proj(f_a)  # [B, d]
 
         # Gather the HF-layout conv windows once, then repack the
@@ -1268,13 +1338,14 @@ class KimiKDARuntime(nn.Module):
         cs_dense = buf[:, :B]
         cs_dense.copy_(cs.view(B, 3, d, W)[:, :, :, 1:].permute(1, 0, 2, 3))
 
-        state = (ssm_pool if ssm_state_indices is not None else
-                 ssm_pool.index_select(0, slot_indices))
+        state = (
+            ssm_pool if ssm_state_indices is not None else ssm_pool.index_select(0, slot_indices)
+        )
 
         o = mixer._dispatch.decode_kda(
             x_q=x_qkv[:, :d].unflatten(-1, (H, hd)).unsqueeze(0),
-            x_k=x_qkv[:, d:2 * d].unflatten(-1, (H, hd)).unsqueeze(0),
-            x_v=x_qkv[:, 2 * d:].unflatten(-1, (H, hd)).unsqueeze(0),
+            x_k=x_qkv[:, d : 2 * d].unflatten(-1, (H, hd)).unsqueeze(0),
+            x_v=x_qkv[:, 2 * d :].unflatten(-1, (H, hd)).unsqueeze(0),
             w_q_t=self._w_q_t,
             w_k_t=self._w_k_t,
             w_v_t=self._w_v_t,
@@ -1293,7 +1364,7 @@ class KimiKDARuntime(nn.Module):
             onorm_weight=self._onorm_w_f32,
             out=None,
             ssm_state_indices=ssm_state_indices,
-            cu_seqlens=mamba_metadata._arange_buffer[:B + 1],
+            cu_seqlens=mamba_metadata._arange_buffer[: B + 1],
             scale=hd**-0.5,
             onorm_eps=mixer.o_norm.eps,
             lower_bound=mixer.gate_lower_bound,
@@ -1312,16 +1383,15 @@ class KimiKDARuntime(nn.Module):
         conv_pool.index_copy_(0, slot_indices, new_win)
         # Fused-verify replay caches (spec decoding only): keep the
         # committed conv window in sync with the plain-decode advance.
-        self._sync_kda_replay_conv_window(layer_cache, slot_indices,
-                                          new_win[:, :d],
-                                          new_win[:, d:2 * d],
-                                          new_win[:, 2 * d:])
+        self._sync_kda_replay_conv_window(
+            layer_cache, slot_indices, new_win[:, :d], new_win[:, d : 2 * d], new_win[:, 2 * d :]
+        )
 
         return mixer.o_proj(o.view(B, d))
 
-    def _forward_decode_ref(self, x2d, conv_pool, ssm_pool, slot_indices,
-                            layer_cache=None,
-                            ssm_state_indices=None) -> torch.Tensor:
+    def _forward_decode_ref(
+        self, x2d, conv_pool, ssm_pool, slot_indices, layer_cache=None, ssm_state_indices=None
+    ) -> torch.Tensor:
         from ..modules.kimi_kda.kimi_kda_mixer import KimiKDACachedState
 
         mixer = self.mixer
@@ -1334,8 +1404,11 @@ class KimiKDARuntime(nn.Module):
             conv_state_q=conv_q,
             conv_state_k=conv_k,
             conv_state_v=conv_v,
-            recurrent_state=(ssm_pool if ssm_state_indices is not None else
-                             ssm_pool.index_select(0, slot_indices)),
+            recurrent_state=(
+                ssm_pool
+                if ssm_state_indices is not None
+                else ssm_pool.index_select(0, slot_indices)
+            ),
         )
         out, new_cache = mixer.forward_decode(
             x,
@@ -1356,8 +1429,7 @@ class KimiKDARuntime(nn.Module):
             ).to(conv_pool.dtype),
         )
         if ssm_state_indices is None:
-            ssm_pool.index_copy_(
-                0, slot_indices, new_cache.recurrent_state.to(ssm_pool.dtype))
+            ssm_pool.index_copy_(0, slot_indices, new_cache.recurrent_state.to(ssm_pool.dtype))
         # Fused-verify replay caches: keep the committed conv window in
         # sync with the plain-decode advance. NOTE: this path is only
         # correct for requests with no pending accepted drafts
@@ -1365,15 +1437,19 @@ class KimiKDARuntime(nn.Module):
         # pools lag by the pending prefix and only the fused verify kernel
         # can advance them. The spec workers pad drafts to the static max,
         # so drafted batches always take the verify path.
-        self._sync_kda_replay_conv_window(layer_cache, slot_indices,
-                                          new_cache.conv_state_q,
-                                          new_cache.conv_state_k,
-                                          new_cache.conv_state_v)
+        self._sync_kda_replay_conv_window(
+            layer_cache,
+            slot_indices,
+            new_cache.conv_state_q,
+            new_cache.conv_state_k,
+            new_cache.conv_state_v,
+        )
 
         return out.squeeze(1)
 
-    def _forward_verify(self, x2d, num_steps, layer_cache, conv_pool,
-                        ssm_pool, slot_indices) -> torch.Tensor:
+    def _forward_verify(
+        self, x2d, num_steps, layer_cache, conv_pool, ssm_pool, slot_indices
+    ) -> torch.Tensor:
         """Speculative verification: advance each request ``num_steps``
         tokens (1 golden + ``num_steps - 1`` padded drafts).
 
@@ -1395,15 +1471,16 @@ class KimiKDARuntime(nn.Module):
             assert self.mixer.verify_kernel_path == "optimized", (
                 "KDA replay caches are allocated but the fused verify "
                 "kernel is unavailable; the legacy intermediate buffers "
-                "were not allocated so there is no fallback")
-            return self._forward_verify_fused(x2d, num_steps, layer_cache,
-                                              ssm_pool, slot_indices)
-        return self._forward_verify_sequential(x2d, num_steps, layer_cache,
-                                               conv_pool, ssm_pool,
-                                               slot_indices)
+                "were not allocated so there is no fallback"
+            )
+            return self._forward_verify_fused(x2d, num_steps, layer_cache, ssm_pool, slot_indices)
+        return self._forward_verify_sequential(
+            x2d, num_steps, layer_cache, conv_pool, ssm_pool, slot_indices
+        )
 
-    def _forward_verify_fused(self, x2d, num_steps, layer_cache, ssm_pool,
-                              slot_indices) -> torch.Tensor:
+    def _forward_verify_fused(
+        self, x2d, num_steps, layer_cache, ssm_pool, slot_indices
+    ) -> torch.Tensor:
         """Fused multi-token verify via ``trtllm::kda_mtp_decode``.
 
         Token layout: the kernel indexes each request's new tokens at
@@ -1431,16 +1508,18 @@ class KimiKDARuntime(nn.Module):
         beta = mixer.b_proj(x).view(1, T_total, H)
 
         w_q, w_k, w_v = self._get_mtp_conv_weights()
-        lower_bound = (mixer.gate_lower_bound_override
-                       if mixer.gate_lower_bound_override is not None else
-                       mixer.gate_lower_bound)
+        lower_bound = (
+            mixer.gate_lower_bound_override
+            if mixer.gate_lower_bound_override is not None
+            else mixer.gate_lower_bound
+        )
 
         pending = layer_cache.prev_num_accepted_tokens[slot_indices].to(
-            torch.int32)  # accepted drafts of the previous round, per req
-        cu_seqlens = torch.arange(0, (num_decodes + 1) * num_steps,
-                                  num_steps,
-                                  dtype=torch.int32,
-                                  device=x2d.device)
+            torch.int32
+        )  # accepted drafts of the previous round, per req
+        cu_seqlens = torch.arange(
+            0, (num_decodes + 1) * num_steps, num_steps, dtype=torch.int32, device=x2d.device
+        )
         cu_seqlens[:num_decodes].sub_(pending)
 
         out = mixer._dispatch.mtp_verify(
@@ -1481,13 +1560,14 @@ class KimiKDARuntime(nn.Module):
             mixer = self.mixer
             cached = tuple(
                 conv.weight.detach().squeeze(1).float().contiguous()
-                for conv in (mixer.q_conv1d, mixer.k_conv1d, mixer.v_conv1d))
+                for conv in (mixer.q_conv1d, mixer.k_conv1d, mixer.v_conv1d)
+            )
             self._mtp_conv_weights = cached
         return cached
 
-    def _forward_verify_sequential(self, x2d, num_steps, layer_cache,
-                                   conv_pool, ssm_pool,
-                                   slot_indices) -> torch.Tensor:
+    def _forward_verify_sequential(
+        self, x2d, num_steps, layer_cache, conv_pool, ssm_pool, slot_indices
+    ) -> torch.Tensor:
         """Sequential per-step FLA verification (legacy intermediate-buffer
         path). Live pools are read-only here; ``update_mamba_states()``
         commits the accepted step's state after sampling.
@@ -1499,7 +1579,8 @@ class KimiKDARuntime(nn.Module):
         intermediate_ssm = layer_cache.intermediate_ssm
         assert intermediate_conv is not None and intermediate_ssm is not None, (
             "speculative verification requires the cache manager's "
-            "SpeculativeState (legacy intermediate-buffer path)")
+            "SpeculativeState (legacy intermediate-buffer path)"
+        )
 
         mixer = self.mixer
         d = self.proj_size
@@ -1522,15 +1603,15 @@ class KimiKDARuntime(nn.Module):
         step_outputs: List[torch.Tensor] = []
         for t in range(num_steps):
             # ShortConvolution.step updates the (gathered) caches in place.
-            q_t, conv_q = mixer.q_conv1d(q_proj_states[:, t:t + 1],
-                                         cache=conv_q,
-                                         output_final_state=True)
-            k_t, conv_k = mixer.k_conv1d(k_proj_states[:, t:t + 1],
-                                         cache=conv_k,
-                                         output_final_state=True)
-            v_t, conv_v = mixer.v_conv1d(v_proj_states[:, t:t + 1],
-                                         cache=conv_v,
-                                         output_final_state=True)
+            q_t, conv_q = mixer.q_conv1d(
+                q_proj_states[:, t : t + 1], cache=conv_q, output_final_state=True
+            )
+            k_t, conv_k = mixer.k_conv1d(
+                k_proj_states[:, t : t + 1], cache=conv_k, output_final_state=True
+            )
+            v_t, conv_v = mixer.v_conv1d(
+                v_proj_states[:, t : t + 1], cache=conv_v, output_final_state=True
+            )
 
             q_t = rearrange(q_t, "... (h d) -> ... h d", d=mixer.head_k_dim)
             k_t = rearrange(k_t, "... (h d) -> ... h d", d=mixer.head_k_dim)
@@ -1540,8 +1621,8 @@ class KimiKDARuntime(nn.Module):
                 q=q_t,
                 k=k_t,
                 v=v_t,
-                g=g[:, t:t + 1],
-                beta=beta[:, t:t + 1],
+                g=g[:, t : t + 1],
+                beta=beta[:, t : t + 1],
                 A_log=mixer.A_log,
                 dt_bias=mixer.dt_bias,
                 initial_state=state,
@@ -1556,17 +1637,17 @@ class KimiKDARuntime(nn.Module):
 
             # Batch-row indexed ([:num_decodes] prefix), matching
             # update_mamba_states()'s intermediate_state_indices.
-            intermediate_conv[:num_decodes, t] = torch.cat(
-                [conv_q, conv_k, conv_v], dim=1).to(intermediate_conv.dtype)
-            intermediate_ssm[:num_decodes, t] = state.to(
-                intermediate_ssm.dtype)
+            intermediate_conv[:num_decodes, t] = torch.cat([conv_q, conv_k, conv_v], dim=1).to(
+                intermediate_conv.dtype
+            )
+            intermediate_ssm[:num_decodes, t] = state.to(intermediate_ssm.dtype)
 
         o = torch.cat(step_outputs, dim=1)  # [B, T, H, V]
         return self._output_gate_and_proj(x, o)
 
-    def _output_gate_and_proj(self, x: torch.Tensor,
-                              o: torch.Tensor) -> torch.Tensor:
+    def _output_gate_and_proj(self, x: torch.Tensor, o: torch.Tensor) -> torch.Tensor:
         from einops import rearrange
+
         mixer = self.mixer
         if mixer.use_full_rank_gate:
             g_out = mixer.g_proj(x)
@@ -1586,13 +1667,13 @@ class KimiKDARuntime(nn.Module):
 @dataclass
 class _MLAStepRuntime:
     """Per-forward MLA runtime inputs shared by all MLA layers."""
+
     ctx_rts: List["KimiK3MLARuntimeInputs"] = field(default_factory=list)
     ctx_lens: List[int] = field(default_factory=list)
     gen_rt: Optional["KimiK3MLARuntimeInputs"] = None
 
 
-def _build_mla_step_runtime(
-        attn_metadata: AttentionMetadata) -> _MLAStepRuntime:
+def _build_mla_step_runtime(attn_metadata: AttentionMetadata) -> _MLAStepRuntime:
     from ..modules.kimi_k3_mla import KimiK3MLARuntimeInputs
 
     rt = _MLAStepRuntime()
@@ -1626,8 +1707,7 @@ def _build_mla_step_runtime(
                 # KDA layers use the outer metadata's mamba_metadata; skip
                 # re-preparing it for the derived MLA-only metadata.
                 mamba_metadata=False,
-                enable_flash_mla=getattr(attn_metadata, "enable_flash_mla",
-                                         False),
+                enable_flash_mla=getattr(attn_metadata, "enable_flash_mla", False),
             )
             md.prepare()
             rt.ctx_rts.append(
@@ -1636,7 +1716,8 @@ def _build_mla_step_runtime(
                     request_ids=[attn_metadata.request_ids[i]],
                     seq_lens=[ctx_len],
                     num_cached_tokens_per_seq=[cached],
-                ))
+                )
+            )
             rt.ctx_lens.append(ctx_len)
 
     if batch_size - num_contexts > 0:
@@ -1652,17 +1733,23 @@ def _build_mla_step_runtime(
 class KimiMLARuntime(nn.Module):
     """Wraps ``KimiK3MLAAttention`` with the mixed-batch executor dispatch."""
 
-    def __init__(self, cfg, layer_idx: int, mapping=None, quant_config=None,
-                 allreduce_strategy=AllReduceStrategy.AUTO):
+    def __init__(
+        self,
+        cfg,
+        layer_idx: int,
+        mapping=None,
+        quant_config=None,
+        allreduce_strategy=AllReduceStrategy.AUTO,
+    ):
         super().__init__()
         import os
 
         from ..modules.kimi_k3_mla import KimiK3MLAAttention
+
         max_positions = min(
             cfg.max_position_embeddings,
-            int(
-                os.environ.get(_KIMI_K3_MLA_MAX_POSITIONS_ENV,
-                               _KIMI_K3_MLA_MAX_POSITIONS_DEFAULT)))
+            int(os.environ.get(_KIMI_K3_MLA_MAX_POSITIONS_ENV, _KIMI_K3_MLA_MAX_POSITIONS_DEFAULT)),
+        )
         self.layer_idx = layer_idx
         # The trtllm-gen MLA generation kernels group query heads per CTA and
         # require numHeadsQ divisible by the group size (a power of two, up
@@ -1686,19 +1773,19 @@ class KimiMLARuntime(nn.Module):
         # a single latent KV head the TP ranks hold duplicated KV cache,
         # exactly like DeepSeek MLA under TP (attention-DP dedups it).
         self._mla_tp_size = (
-            mapping.tp_size if (mapping is not None
-                                and not mapping.enable_attention_dp
-                                and mapping.tp_size > 1)
-            else 1)
-        self._mla_tp_rank = (mapping.tp_rank
-                             if self._mla_tp_size > 1 else 0)
+            mapping.tp_size
+            if (mapping is not None and not mapping.enable_attention_dp and mapping.tp_size > 1)
+            else 1
+        )
+        self._mla_tp_rank = mapping.tp_rank if self._mla_tp_size > 1 else 0
         assert padded_heads % self._mla_tp_size == 0, (
-            f"padded MLA heads {padded_heads} not divisible by "
-            f"tp_size {self._mla_tp_size}")
-        self._o_allreduce = (AllReduce(mapping=mapping,
-                                       strategy=allreduce_strategy,
-                                       dtype=torch.bfloat16)
-                             if self._mla_tp_size > 1 else None)
+            f"padded MLA heads {padded_heads} not divisible by tp_size {self._mla_tp_size}"
+        )
+        self._o_allreduce = (
+            AllReduce(mapping=mapping, strategy=allreduce_strategy, dtype=torch.bfloat16)
+            if self._mla_tp_size > 1
+            else None
+        )
         self.mixer = KimiK3MLAAttention(
             hidden_size=cfg.hidden_size,
             num_heads=padded_heads // self._mla_tp_size,
@@ -1715,23 +1802,20 @@ class KimiMLARuntime(nn.Module):
             quant_config=quant_config,
         )
 
-    def forward(self, hidden_states: torch.Tensor,
-                attn_metadata: AttentionMetadata,
-                mla_rt: _MLAStepRuntime) -> torch.Tensor:
+    def forward(
+        self, hidden_states: torch.Tensor, attn_metadata: AttentionMetadata, mla_rt: _MLAStepRuntime
+    ) -> torch.Tensor:
         num_ctx_tokens = attn_metadata.num_ctx_tokens
         outputs: List[torch.Tensor] = []
         offset = 0
         for ctx_rt, ctx_len in zip(mla_rt.ctx_rts, mla_rt.ctx_lens):
             outputs.append(
-                self.mixer.forward_prefill(
-                    hidden_states[offset:offset + ctx_len], ctx_rt))
+                self.mixer.forward_prefill(hidden_states[offset : offset + ctx_len], ctx_rt)
+            )
             offset += ctx_len
-        assert offset == num_ctx_tokens, (
-            f"MLA context split mismatch: {offset} != {num_ctx_tokens}")
+        assert offset == num_ctx_tokens, f"MLA context split mismatch: {offset} != {num_ctx_tokens}"
         if hidden_states.shape[0] > num_ctx_tokens:
-            outputs.append(
-                self.mixer.forward_decode(hidden_states[num_ctx_tokens:],
-                                          mla_rt.gen_rt))
+            outputs.append(self.mixer.forward_decode(hidden_states[num_ctx_tokens:], mla_rt.gen_rt))
         out = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
         if self._o_allreduce is not None:
             # Head-sharded TP: sum the row-sharded o_proj partials across
@@ -1746,12 +1830,13 @@ class KimiMLARuntime(nn.Module):
 
 
 class KimiLinearDecoderLayer(nn.Module):
-
-    def __init__(self,
-                 model_config: ModelConfig,
-                 cfg,
-                 layer_idx: int,
-                 aux_stream: Optional[torch.cuda.Stream] = None):
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        cfg,
+        layer_idx: int,
+        aux_stream: Optional[torch.cuda.Stream] = None,
+    ):
         super().__init__()
         self.layer_idx = layer_idx
         self.hidden_size = cfg.hidden_size
@@ -1760,44 +1845,46 @@ class KimiLinearDecoderLayer(nn.Module):
         self.is_kda = _is_kda_layer(cfg, layer_idx)
         is_mla = _is_mla_layer(cfg, layer_idx)
         if self.is_kda == is_mla:
-            raise ValueError(
-                f"Kimi K3 layer {layer_idx} must be exactly one of KDA/MLA")
+            raise ValueError(f"Kimi K3 layer {layer_idx} must be exactly one of KDA/MLA")
 
         if self.is_kda:
             self.self_attn = KimiKDARuntime(
                 cfg,
                 layer_idx,
                 mapping=model_config.mapping,
-                allreduce_strategy=model_config.allreduce_strategy)
+                allreduce_strategy=model_config.allreduce_strategy,
+            )
         else:
             # Forward only the KV-cache quantization to the MLA attention
             # backends (enables FP8 KV cache). The attention projection
             # weights themselves stay BF16 — the model-level weight-quant
             # algo must not leak into the attention backend's weight paths.
             mla_quant_config = None
-            kv_quant_algo = (model_config.quant_config.kv_cache_quant_algo
-                             if model_config.quant_config is not None else
-                             None)
+            kv_quant_algo = (
+                model_config.quant_config.kv_cache_quant_algo
+                if model_config.quant_config is not None
+                else None
+            )
             if kv_quant_algo is not None:
-                mla_quant_config = QuantConfig(
-                    kv_cache_quant_algo=kv_quant_algo)
+                mla_quant_config = QuantConfig(kv_cache_quant_algo=kv_quant_algo)
             self.self_attn = KimiMLARuntime(
                 cfg,
                 layer_idx,
                 mapping=model_config.mapping,
                 quant_config=mla_quant_config,
-                allreduce_strategy=model_config.allreduce_strategy)
+                allreduce_strategy=model_config.allreduce_strategy,
+            )
 
-        self.is_moe = (cfg.num_experts is not None
-                       and layer_idx >= cfg.first_k_dense_replace
-                       and layer_idx % getattr(cfg, "moe_layer_freq", 1) == 0)
+        self.is_moe = (
+            cfg.num_experts is not None
+            and layer_idx >= cfg.first_k_dense_replace
+            and layer_idx % getattr(cfg, "moe_layer_freq", 1) == 0
+        )
         if self.is_moe:
-            self.block_sparse_moe = KimiK3MoERuntime(model_config, cfg,
-                                                     layer_idx, aux_stream)
+            self.block_sparse_moe = KimiK3MoERuntime(model_config, cfg, layer_idx, aux_stream)
         else:
             situ_beta = getattr(cfg, "activation_situ_beta", None) or 1.0
-            situ_linear_beta = getattr(cfg, "activation_situ_linear_beta",
-                                       None)
+            situ_linear_beta = getattr(cfg, "activation_situ_linear_beta", None)
             # Dense-MLP TP semantics (DeepSeek _compute_mlp_tp_size
             # pattern): replicated under attention-DP — each rank runs
             # only its own tokens, so a weight shard would need an extra
@@ -1806,54 +1893,55 @@ class KimiLinearDecoderLayer(nn.Module):
             # all-reduced right after the call in forward().
             self._mlp_tp_size = (
                 model_config.mapping.tp_size
-                if (not model_config.mapping.enable_attention_dp
+                if (
+                    not model_config.mapping.enable_attention_dp
                     and model_config.mapping.tp_size > 1
-                    and cfg.intermediate_size % model_config.mapping.tp_size
-                    == 0)
-                else 1)
+                    and cfg.intermediate_size % model_config.mapping.tp_size == 0
+                )
+                else 1
+            )
             self.mlp = KimiK3MLP(
                 hidden_size=cfg.hidden_size,
                 intermediate_size=cfg.intermediate_size // self._mlp_tp_size,
                 situ_beta=situ_beta,
                 situ_linear_beta=situ_linear_beta,
                 use_fused_activation=True,
-                dtype=dtype)
-            self._mlp_allreduce = (AllReduce(
-                mapping=model_config.mapping,
-                strategy=model_config.allreduce_strategy,
-                dtype=dtype) if self._mlp_tp_size > 1 else None)
+                dtype=dtype,
+            )
+            self._mlp_allreduce = (
+                AllReduce(
+                    mapping=model_config.mapping,
+                    strategy=model_config.allreduce_strategy,
+                    dtype=dtype,
+                )
+                if self._mlp_tp_size > 1
+                else None
+            )
 
         # Stock fused RMSNorm for the plain (whole-tensor) norms; numerics
         # are drop-in for KimiK3RMSNorm (fp32 variance, weight applied
         # after downcast, use_gemma=False).
-        self.input_layernorm = RMSNorm(hidden_size=cfg.hidden_size,
-                                       eps=cfg.rms_norm_eps,
-                                       dtype=dtype)
-        self.post_attention_layernorm = RMSNorm(hidden_size=cfg.hidden_size,
-                                                eps=cfg.rms_norm_eps,
-                                                dtype=dtype)
+        self.input_layernorm = RMSNorm(
+            hidden_size=cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype
+        )
 
         # Attention residual scheme (always on for K3). The res norms stay
         # KimiK3RMSNorm: they are consumed field-wise (.weight/.eps) by
         # _apply_attn_res and the fused attn_res op, never called as
         # modules.
         self.attn_res_block_size = cfg.attn_res_block_size
-        assert self.attn_res_block_size is not None, \
+        assert self.attn_res_block_size is not None, (
             "Kimi K3 runtime expects attn_res_block_size to be set"
-        self.self_attention_res_norm = KimiK3RMSNorm(cfg.hidden_size,
-                                                     eps=cfg.rms_norm_eps,
-                                                     dtype=dtype)
-        self.mlp_res_norm = KimiK3RMSNorm(cfg.hidden_size,
-                                          eps=cfg.rms_norm_eps,
-                                          dtype=dtype)
-        self.self_attention_res_proj = nn.Linear(cfg.hidden_size,
-                                                 1,
-                                                 bias=False,
-                                                 dtype=dtype)
-        self.mlp_res_proj = nn.Linear(cfg.hidden_size,
-                                      1,
-                                      bias=False,
-                                      dtype=dtype)
+        )
+        self.self_attention_res_norm = KimiK3RMSNorm(
+            cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype
+        )
+        self.mlp_res_norm = KimiK3RMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype)
+        self.self_attention_res_proj = nn.Linear(cfg.hidden_size, 1, bias=False, dtype=dtype)
+        self.mlp_res_proj = nn.Linear(cfg.hidden_size, 1, bias=False, dtype=dtype)
 
     def forward(
         self,
@@ -1871,35 +1959,37 @@ class KimiLinearDecoderLayer(nn.Module):
         prefix_sum = hidden_states
 
         if block_residual.shape[0] > 0:
-            hidden_states = _apply_attn_res(prefix_sum, block_residual,
-                                            self.self_attention_res_proj,
-                                            self.self_attention_res_norm)
+            hidden_states = _apply_attn_res(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+            )
 
         if self.layer_idx % self.attn_res_block_size == 0:
-            block_residual = torch.cat(
-                (block_residual, prefix_sum.unsqueeze(0)), dim=0)
+            block_residual = torch.cat((block_residual, prefix_sum.unsqueeze(0)), dim=0)
             prefix_sum = None
 
         hidden_states = self.input_layernorm(hidden_states)
         if self.is_kda:
             hidden_states = self.self_attn(hidden_states, attn_metadata)
         else:
-            hidden_states = self.self_attn(hidden_states, attn_metadata,
-                                           mla_rt)
+            hidden_states = self.self_attn(hidden_states, attn_metadata, mla_rt)
 
         if prefix_sum is not None:
             prefix_sum = prefix_sum + hidden_states
         else:
             prefix_sum = hidden_states
 
-        hidden_states = _apply_attn_res(prefix_sum, block_residual,
-                                        self.mlp_res_proj, self.mlp_res_norm)
+        hidden_states = _apply_attn_res(
+            prefix_sum, block_residual, self.mlp_res_proj, self.mlp_res_norm
+        )
 
         hidden_states = self.post_attention_layernorm(hidden_states)
         if self.is_moe:
             hidden_states = self.block_sparse_moe(
-                hidden_states,
-                getattr(attn_metadata, "all_rank_num_tokens", None))
+                hidden_states, getattr(attn_metadata, "all_rank_num_tokens", None)
+            )
         else:
             hidden_states = self.mlp(hidden_states)
             if getattr(self, "_mlp_allreduce", None) is not None:
@@ -1916,7 +2006,6 @@ class KimiLinearDecoderLayer(nn.Module):
 
 
 class KimiLinearModel(DecoderModel):
-
     def __init__(self, model_config: ModelConfig):
         super().__init__(model_config)
         cfg = _get_text_config(model_config.pretrained_config)
@@ -1928,27 +2017,21 @@ class KimiLinearModel(DecoderModel):
         # dispatch/combine collectives.
         self.aux_stream = torch.cuda.Stream()
 
-        self.embed_tokens = nn.Embedding(cfg.vocab_size,
-                                         cfg.hidden_size,
-                                         dtype=dtype)
-        self.layers = nn.ModuleList([
-            KimiLinearDecoderLayer(model_config, cfg, layer_idx,
-                                   self.aux_stream)
-            for layer_idx in range(cfg.num_hidden_layers)
-        ])
-        self.norm = RMSNorm(hidden_size=cfg.hidden_size,
-                            eps=cfg.rms_norm_eps,
-                            dtype=dtype)
+        self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.hidden_size, dtype=dtype)
+        self.layers = nn.ModuleList(
+            [
+                KimiLinearDecoderLayer(model_config, cfg, layer_idx, self.aux_stream)
+                for layer_idx in range(cfg.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(hidden_size=cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype)
 
         # KimiK3RMSNorm (not RMSNorm): consumed field-wise (.weight/.eps)
         # by _apply_attn_res and the fused attn_res op.
-        self.output_attn_res_norm = KimiK3RMSNorm(cfg.hidden_size,
-                                                  eps=cfg.rms_norm_eps,
-                                                  dtype=dtype)
-        self.output_attn_res_proj = nn.Linear(cfg.hidden_size,
-                                              1,
-                                              bias=False,
-                                              dtype=dtype)
+        self.output_attn_res_norm = KimiK3RMSNorm(
+            cfg.hidden_size, eps=cfg.rms_norm_eps, dtype=dtype
+        )
+        self.output_attn_res_proj = nn.Linear(cfg.hidden_size, 1, bias=False, dtype=dtype)
 
         self.has_mla = any(not layer.is_kda for layer in self.layers)
 
@@ -1962,8 +2045,7 @@ class KimiLinearModel(DecoderModel):
         **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError(
-                "You must specify exactly one of input_ids or inputs_embeds")
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -1973,17 +2055,16 @@ class KimiLinearModel(DecoderModel):
         assert hidden_states.shape[0] == num_tokens, (
             f"Kimi K3 does not support padded batches "
             f"(got {hidden_states.shape[0]} rows, metadata says {num_tokens} "
-            "tokens); disable CUDA graphs and the overlap scheduler.")
+            "tokens); disable CUDA graphs and the overlap scheduler."
+        )
 
-        mla_rt = (_build_mla_step_runtime(attn_metadata)
-                  if self.has_mla else None)
+        mla_rt = _build_mla_step_runtime(attn_metadata) if self.has_mla else None
 
-        block_residual = hidden_states.new_zeros(0, hidden_states.shape[0],
-                                                 hidden_states.shape[1])
+        block_residual = hidden_states.new_zeros(0, hidden_states.shape[0], hidden_states.shape[1])
         for layer in self.layers:
-            hidden_states, block_residual = layer(hidden_states,
-                                                  block_residual,
-                                                  attn_metadata, mla_rt)
+            hidden_states, block_residual = layer(
+                hidden_states, block_residual, attn_metadata, mla_rt
+            )
             if spec_metadata is not None:
                 # DFlash hidden-state capture. K3's attn-residual scheme
                 # already folds the residual into the running prefix sum
@@ -1992,12 +2073,11 @@ class KimiLinearModel(DecoderModel):
                 # is trained against this prefix sum or some other tap point
                 # must be confirmed against the K3 drafter training recipe
                 # before real weights are used.
-                spec_metadata.maybe_capture_hidden_states(
-                    layer.layer_idx, hidden_states, None)
+                spec_metadata.maybe_capture_hidden_states(layer.layer_idx, hidden_states, None)
 
-        hidden_states = _apply_attn_res(hidden_states, block_residual,
-                                        self.output_attn_res_proj,
-                                        self.output_attn_res_norm)
+        hidden_states = _apply_attn_res(
+            hidden_states, block_residual, self.output_attn_res_proj, self.output_attn_res_norm
+        )
         return self.norm(hidden_states)
 
 
@@ -2015,14 +2095,12 @@ def _materialize(value) -> torch.Tensor:
 
 @register_auto_model("KimiK3ForConditionalGeneration")
 @register_auto_model("KimiLinearForCausalLM")
-class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
-                                                        Any]):
+class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel, Any]):
     """Kimi K3 text model (the vision tower is ignored; text-only serving)."""
 
     def __init__(self, model_config: ModelConfig):
         cfg = _get_text_config(model_config.pretrained_config)
-        assert model_config.mapping.pp_size == 1, \
-            "Kimi K3 does not support pipeline parallelism"
+        assert model_config.mapping.pp_size == 1, "Kimi K3 does not support pipeline parallelism"
         spec_config = getattr(model_config, "spec_config", None)
         # Supported spec-dec modes:
         # - SA (suffix automaton): one-engine in-forward drafting, no draft
@@ -2037,13 +2115,17 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
         #   (examples/kimi_k3/make_synthetic_dflash_drafter.py).
         # Modes needing draft heads (MTP/Eagle) are blocked until a
         # draft-head checkpoint exists.
-        assert spec_config is None or spec_config.spec_dec_mode.is_sa() \
-            or spec_config.spec_dec_mode.is_dflash(), \
-            "Kimi K3 supports speculative decoding only with SA or DFlash"
-        super().__init__(KimiLinearModel(model_config),
-                         model_config,
-                         hidden_size=cfg.hidden_size,
-                         vocab_size=cfg.vocab_size)
+        assert (
+            spec_config is None
+            or spec_config.spec_dec_mode.is_sa()
+            or spec_config.spec_dec_mode.is_dflash()
+        ), "Kimi K3 supports speculative decoding only with SA or DFlash"
+        super().__init__(
+            KimiLinearModel(model_config),
+            model_config,
+            hidden_size=cfg.hidden_size,
+            vocab_size=cfg.vocab_size,
+        )
 
     @classmethod
     def get_model_defaults(cls, llm_args) -> dict:
@@ -2106,8 +2188,7 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
             else:
                 # Runtime wrapper modules hold the parity-tested mixers as a
                 # "mixer" submodule; the checkpoint names have no such scope.
-                ckpt_key = prefix + name.replace(".self_attn.mixer.",
-                                                 ".self_attn.")
+                ckpt_key = prefix + name.replace(".self_attn.mixer.", ".self_attn.")
             name_map[name] = ckpt_key
             if name.endswith(_GATE_UP_FUSED_SUFFIX):
                 # Fused [gate | up] MLP layout (dense mlp / shared_experts):
@@ -2135,9 +2216,7 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
     def load_weights(self, weights: Dict):
         from .modeling_utils import run_concurrently
 
-        prefix = ("language_model."
-                  if any(k.startswith("language_model.") for k in weights)
-                  else "")
+        prefix = "language_model." if any(k.startswith("language_model.") for k in weights) else ""
 
         params = self._trunk_parameters()
         name_map, expected_keys, expert_jobs = self.checkpoint_name_plan(prefix)
@@ -2147,25 +2226,27 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
         relevant_ckpt_keys = {
             k
             for k in ckpt_keys
-            if not (k.startswith("vision_tower.")
-                    or k.startswith("mm_projector."))
+            if not (k.startswith("vision_tower.") or k.startswith("mm_projector."))
         }
         missing = sorted(expected_keys - ckpt_keys)
         if missing:
             raise KeyError(
                 f"Kimi K3 load_weights: {len(missing)} expected checkpoint "
-                f"keys are missing, e.g. {missing[:10]}")
+                f"keys are missing, e.g. {missing[:10]}"
+            )
         unexpected = relevant_ckpt_keys - expected_keys
         # Non-local experts and (in layer-truncated debug mode) extra layers
         # are expected leftovers.
         surprising = sorted(
-            k for k in unexpected
-            if ".block_sparse_moe.experts." not in k
-            and not k.startswith(f"{prefix}model.layers."))
+            k
+            for k in unexpected
+            if ".block_sparse_moe.experts." not in k and not k.startswith(f"{prefix}model.layers.")
+        )
         if surprising:
             logger.warning(
                 f"Kimi K3 load_weights: {len(surprising)} unmatched "
-                f"checkpoint keys, e.g. {surprising[:10]}")
+                f"checkpoint keys, e.g. {surprising[:10]}"
+            )
 
         device = next(self.parameters()).device
 
@@ -2208,14 +2289,14 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                     # the SiTU gate/up pairs stay aligned. shared_tp_rank
                     # == tp_rank in every mode that shards these.
                     lo = shared_tp_rank * inter
-                    gate = gate[lo:lo + inter]
-                    up = up[lo:lo + inter]
-                if (gate.shape != (inter, param.shape[1])
-                        or up.shape != gate.shape):
+                    gate = gate[lo : lo + inter]
+                    up = up[lo : lo + inter]
+                if gate.shape != (inter, param.shape[1]) or up.shape != gate.shape:
                     raise ValueError(
                         f"{name}: checkpoint gate/up shapes "
                         f"{tuple(gate.shape)} / {tuple(up.shape)} do not "
-                        f"concat to param shape {tuple(param.shape)}")
+                        f"concat to param shape {tuple(param.shape)}"
+                    )
                 param.data[:inter].copy_(gate.to(param.dtype))
                 param.data[inter:].copy_(up.to(param.dtype))
                 return
@@ -2233,14 +2314,15 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                 assert src.numel() > param.numel(), (name, src.shape)
                 if kda_tp_size > 1:
                     lo = kda_tp_rank * param.numel()
-                    src = src[lo:lo + param.numel()]
+                    src = src[lo : lo + param.numel()]
                 else:
-                    tail = src[param.numel():]
+                    tail = src[param.numel() :]
                     if tail.abs().max().item() != 0.0:
                         raise ValueError(
                             f"{name}: expected zero padding beyond "
-                            f"{param.numel()} entries, got nonzero tail")
-                    src = src[:param.numel()]
+                            f"{param.numel()} entries, got nonzero tail"
+                        )
+                    src = src[: param.numel()]
             if src.shape != param.shape:
                 # KDA head-shard (attention-DP off): every mismatching KDA
                 # tensor is head-major with the checkpoint exactly
@@ -2251,17 +2333,22 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                 # mismatches are the padding branches below), so shape
                 # ratios alone identify the KDA slices.
                 if kda_tp_size > 1 and ".self_attn." in name:
-                    if (src.shape[0] == param.shape[0] * kda_tp_size
-                            and src.shape[1:] == param.shape[1:]):
+                    if (
+                        src.shape[0] == param.shape[0] * kda_tp_size
+                        and src.shape[1:] == param.shape[1:]
+                    ):
                         s = param.shape[0]
                         lo = kda_tp_rank * s
-                        param.data.copy_(src[lo:lo + s].to(param.dtype))
+                        param.data.copy_(src[lo : lo + s].to(param.dtype))
                         return
-                    if (src.dim() == 2 and src.shape[0] == param.shape[0]
-                            and src.shape[1] == param.shape[1] * kda_tp_size):
+                    if (
+                        src.dim() == 2
+                        and src.shape[0] == param.shape[0]
+                        and src.shape[1] == param.shape[1] * kda_tp_size
+                    ):
                         s = param.shape[1]
                         lo = kda_tp_rank * s
-                        param.data.copy_(src[:, lo:lo + s].to(param.dtype))
+                        param.data.copy_(src[:, lo : lo + s].to(param.dtype))
                         return
                 # MLA head-shard (attention-DP off): the checkpoint holds
                 # the real 96 heads; the param holds this rank's slice of
@@ -2273,29 +2360,30 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                 # KDA layers never reach here: their identically named
                 # g/o projections match the exact-ratio branch above.
                 if mla_tp_size > 1 and ".self_attn." in name:
-                    if (name.endswith((".q_b_proj.weight",
-                                       ".kv_b_proj.weight",
-                                       ".g_proj.weight"))
-                            and src.shape[1:] == param.shape[1:]
-                            and src.shape[0] < param.shape[0] * mla_tp_size):
+                    if (
+                        name.endswith((".q_b_proj.weight", ".kv_b_proj.weight", ".g_proj.weight"))
+                        and src.shape[1:] == param.shape[1:]
+                        and src.shape[0] < param.shape[0] * mla_tp_size
+                    ):
                         s = param.shape[0]
                         lo = mla_tp_rank * s
                         param.data.zero_()
                         n = max(0, min(src.shape[0] - lo, s))
                         if n > 0:
-                            param.data[:n].copy_(src[lo:lo + n].to(
-                                param.dtype))
+                            param.data[:n].copy_(src[lo : lo + n].to(param.dtype))
                         return
-                    if (name.endswith(".o_proj.weight") and src.dim() == 2
-                            and src.shape[0] == param.shape[0]
-                            and src.shape[1] < param.shape[1] * mla_tp_size):
+                    if (
+                        name.endswith(".o_proj.weight")
+                        and src.dim() == 2
+                        and src.shape[0] == param.shape[0]
+                        and src.shape[1] < param.shape[1] * mla_tp_size
+                    ):
                         s = param.shape[1]
                         lo = mla_tp_rank * s
                         param.data.zero_()
                         n = max(0, min(src.shape[1] - lo, s))
                         if n > 0:
-                            param.data[:, :n].copy_(src[:, lo:lo + n].to(
-                                param.dtype))
+                            param.data[:, :n].copy_(src[:, lo : lo + n].to(param.dtype))
                         return
                 # Shared-expert TP (direct MoE path): the module holds a
                 # 1/tp shard of the FFN dim — column shard for gate/up
@@ -2305,42 +2393,50 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                     # MLP (attention-DP off): the fused gate_up_proj is
                     # sliced in its dedicated branch above; here the
                     # unfused halves (if ever configured) and down_proj.
-                    if (name.endswith((".gate_proj.weight",
-                                       ".up_proj.weight"))
-                            and src.shape[0] % param.shape[0] == 0
-                            and src.shape[1:] == param.shape[1:]):
+                    if (
+                        name.endswith((".gate_proj.weight", ".up_proj.weight"))
+                        and src.shape[0] % param.shape[0] == 0
+                        and src.shape[1:] == param.shape[1:]
+                    ):
                         lo = shared_tp_rank * param.shape[0]
-                        param.data.copy_(
-                            src[lo:lo + param.shape[0]].to(param.dtype))
+                        param.data.copy_(src[lo : lo + param.shape[0]].to(param.dtype))
                         return
-                    if (name.endswith(".down_proj.weight")
-                            and src.shape[1] % param.shape[1] == 0
-                            and src.shape[0] == param.shape[0]):
+                    if (
+                        name.endswith(".down_proj.weight")
+                        and src.shape[1] % param.shape[1] == 0
+                        and src.shape[0] == param.shape[0]
+                    ):
                         lo = shared_tp_rank * param.shape[1]
-                        param.data.copy_(
-                            src[:, lo:lo + param.shape[1]].to(param.dtype))
+                        param.data.copy_(src[:, lo : lo + param.shape[1]].to(param.dtype))
                         return
                 # MLA head padding (96 -> 128 query heads, see
                 # KimiMLARuntime): pad the head-major output rows
                 # (q_b_proj / kv_b_proj / g_proj) or the head-major input
                 # columns (o_proj) with zeros. KDA layers' identically named
                 # projections match exactly and never take this path.
-                if (".self_attn." in name and name.endswith(
-                    (".q_b_proj.weight", ".kv_b_proj.weight", ".g_proj.weight"))
-                        and src.shape[1:] == param.shape[1:]
-                        and src.shape[0] < param.shape[0]):
+                if (
+                    ".self_attn." in name
+                    and name.endswith((".q_b_proj.weight", ".kv_b_proj.weight", ".g_proj.weight"))
+                    and src.shape[1:] == param.shape[1:]
+                    and src.shape[0] < param.shape[0]
+                ):
                     param.data.zero_()
-                    param.data[:src.shape[0]].copy_(src.to(param.dtype))
+                    param.data[: src.shape[0]].copy_(src.to(param.dtype))
                     return
-                if (".self_attn." in name and name.endswith(".o_proj.weight")
-                        and src.shape[0] == param.shape[0]
-                        and src.shape[1] < param.shape[1]):
+                if (
+                    ".self_attn." in name
+                    and name.endswith(".o_proj.weight")
+                    and src.shape[0] == param.shape[0]
+                    and src.shape[1] < param.shape[1]
+                ):
                     param.data.zero_()
-                    param.data[:, :src.shape[1]].copy_(src.to(param.dtype))
+                    param.data[:, : src.shape[1]].copy_(src.to(param.dtype))
                     return
-                raise ValueError(f"{name}: checkpoint shape "
-                                 f"{tuple(src.shape)} != param shape "
-                                 f"{tuple(param.shape)}")
+                raise ValueError(
+                    f"{name}: checkpoint shape "
+                    f"{tuple(src.shape)} != param shape "
+                    f"{tuple(param.shape)}"
+                )
             param.data.copy_(src.to(param.dtype))
 
         def load_expert(
@@ -2384,15 +2480,14 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
         # trays). Instead, group the rank-local expert tensors by shard file
         # and stream each file through a short-lived handle:
         # open -> copy -> close (unmap) -> fadvise(DONTNEED).
-        ckpt_dir = getattr(self.model_config.pretrained_config,
-                           "_name_or_path", None)
-        index_path = os.path.join(ckpt_dir or "",
-                                  "model.safetensors.index.json")
+        ckpt_dir = getattr(self.model_config.pretrained_config, "_name_or_path", None)
+        index_path = os.path.join(ckpt_dir or "", "model.safetensors.index.json")
         if expert_jobs and os.path.isfile(index_path):
             import json as _json
             from contextlib import ExitStack
 
             from safetensors import safe_open
+
             with open(index_path) as f:
                 weight_map = _json.load(f)["weight_map"]
             per_file: Dict[str, list] = {}
@@ -2453,8 +2548,7 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                 for file_name in files:
                     drop_file_pages(file_name)
 
-            run_concurrently(load_expert_file, sorted(per_file.items()),
-                             num_workers=4)
+            run_concurrently(load_expert_file, sorted(per_file.items()), num_workers=4)
             run_concurrently(load_split_file_expert, split_file_jobs, num_workers=4)
         else:
             run_concurrently(load_experts_from_weights, expert_jobs, num_workers=4)
@@ -2481,12 +2575,9 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
         # the bf16 wrapper fast path; KIMI_K3_KDA_GLUE_FP8=1 instead rebuilds
         # the wrapper fast path on top of the FP8 modules after the
         # conversion (finalize_decode_weights_fp8), so neither is traded away.
-        fp8_weight_read = (is_sm_100f() and os.environ.get(
-            _KIMI_K3_FP8_WEIGHT_READ_ENV, "1") != "0")
-        kda_fp8 = fp8_weight_read and os.environ.get(
-            _KIMI_K3_FP8_WEIGHT_READ_KDA_ENV, "1") != "0"
-        kda_glue_fp8 = kda_fp8 and os.environ.get(
-            _KIMI_K3_KDA_GLUE_FP8_ENV, "1") != "0"
+        fp8_weight_read = is_sm_100f() and os.environ.get(_KIMI_K3_FP8_WEIGHT_READ_ENV, "1") != "0"
+        kda_fp8 = fp8_weight_read and os.environ.get(_KIMI_K3_FP8_WEIGHT_READ_KDA_ENV, "1") != "0"
+        kda_glue_fp8 = kda_fp8 and os.environ.get(_KIMI_K3_KDA_GLUE_FP8_ENV, "1") != "0"
 
         # Build the KDA decode fast-path constants (fused in-projection
         # weight views + kernel-layout conv weights + fp32 params). Must
@@ -2496,27 +2587,29 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
             if getattr(layer, "is_kda", False):
                 if not kda_fp8:
                     layer.self_attn.finalize_decode_weights()
-                num_kda_fused += int(
-                    layer.self_attn._in_proj_weight is not None)
+                num_kda_fused += int(layer.self_attn._in_proj_weight is not None)
         logger.info(
             f"Kimi K3: loaded {len(param_jobs)} parameters and the expert "
             f"slices of {len(expert_jobs)} MoE layers; fused decode "
-            f"in-projections on {num_kda_fused} KDA layers")
+            f"in-projections on {num_kda_fused} KDA layers"
+        )
 
         # FP8 block-scale weight read for the replicated MoE-layer MLPs. The
         # DeepGEMM fp8_swap_ab_gemm kernel is Blackwell-only; keep BF16 on any
         # other SM or when explicitly disabled.
         if fp8_weight_read:
-            gate_up_default = ("1" if self.model_config.mapping.
-                               enable_attention_dp else "0")
+            gate_up_default = "1" if self.model_config.mapping.enable_attention_dp else "0"
             n_fp8 = _convert_moe_mlps_to_fp8_weight_read(
                 self.model,
                 include_fused_gate_up=os.environ.get(
-                    _KIMI_K3_FP8_WEIGHT_READ_GATE_UP_ENV,
-                    gate_up_default) != "0")
+                    _KIMI_K3_FP8_WEIGHT_READ_GATE_UP_ENV, gate_up_default
+                )
+                != "0",
+            )
             logger.info(
                 f"Kimi K3: reading {n_fp8} MoE-layer MLP projections "
-                f"(shared-expert + latent) at FP8 block-scale")
+                f"(shared-expert + latent) at FP8 block-scale"
+            )
             # The KDA q/k/v/g/o projections are the largest single replicated
             # weight read; convert them to the same FP8 block-scale read unless
             # kept in BF16 for accuracy (their own switch — the recurrent core
@@ -2526,7 +2619,8 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                 logger.info(
                     f"Kimi K3: reading {n_kda} KDA q/k/v/g/o projections "
                     f"at FP8 block-scale (q/k/v/g fused into one decode GEMM "
-                    f"per layer)")
+                    f"per layer)"
+                )
                 if kda_glue_fp8:
                     # Rebuild the wrapper decode fast path on top of the FP8
                     # modules (must run after the conversion above so the
@@ -2536,12 +2630,11 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                     for layer in self.model.layers:
                         if getattr(layer, "is_kda", False):
                             layer.self_attn.finalize_decode_weights_fp8()
-                            n_glue += int(
-                                layer.self_attn._in_proj_small_weight
-                                is not None)
+                            n_glue += int(layer.self_attn._in_proj_small_weight is not None)
                     logger.info(
                         f"Kimi K3: FP8 fused decode glue on {n_glue} KDA "
-                        f"layers ({_KIMI_K3_KDA_GLUE_FP8_ENV}=1)")
+                        f"layers ({_KIMI_K3_KDA_GLUE_FP8_ENV}=1)"
+                    )
             # The MLA q_a/q_b/o and output-gate projections are the remaining
             # replicated attention weight read the MLP and KDA passes above
             # leave in BF16; convert them to the same FP8 block-scale read
@@ -2550,5 +2643,5 @@ class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
             if os.environ.get(_KIMI_K3_FP8_WEIGHT_READ_MLA_ENV, "1") != "0":
                 n_mla = _convert_mla_projections_to_fp8_weight_read(self.model)
                 logger.info(
-                    f"Kimi K3: reading {n_mla} MLA q_a/q_b/o/g projections "
-                    f"at FP8 block-scale")
+                    f"Kimi K3: reading {n_mla} MLA q_a/q_b/o/g projections at FP8 block-scale"
+                )

--- a/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
+++ b/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
@@ -234,6 +234,56 @@ class KDAKernelDispatch:
         _load_mtp_module()  # registers trtllm::kda_mtp_decode
         return torch.ops.trtllm.kda_mtp_decode(**kwargs)
 
+    def can_use_indexed_prefill(
+        self,
+        *,
+        state_pool: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_states: torch.Tensor,
+        cu_seqlens: Optional[torch.Tensor],
+        num_tokens: int,
+        chunk_size: int = 64,
+    ) -> bool:
+        """Return whether prefill can update this V-first pool directly."""
+        if self.prefill_kernel_path != "optimized" or num_tokens == 0:
+            return False
+        if state_pool.dtype != torch.float32 or state_pool.ndim != 4:
+            return False
+        _, H, V, K = state_pool.shape
+        if state_pool.stride()[1:] != (V * K, K, 1):
+            return False
+        if state_pool.stride(0) < H * V * K or state_pool.stride(0) % 4:
+            return False
+        if state_pool.data_ptr() % 16:
+            return False
+        num_sequences = state_indices.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
+        if (
+            state_indices.ndim != 1
+            or state_indices.shape[0] != num_sequences
+            or state_indices.dtype not in (torch.int32, torch.int64)
+            or not state_indices.is_contiguous()
+        ):
+            return False
+        if (
+            has_initial_states.ndim != 1
+            or has_initial_states.shape[0] != num_sequences
+            or has_initial_states.dtype != torch.bool
+            or not has_initial_states.is_contiguous()
+        ):
+            return False
+        if (
+            state_pool.device != state_indices.device
+            or state_pool.device != has_initial_states.device
+        ):
+            return False
+        if cu_seqlens is not None:
+            from fla.ops.utils.index import prepare_chunk_indices
+
+            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+            if chunk_indices.shape[0] < 4:
+                return False
+        return True
+
     def prefill_chunk_kda(
         self,
         *,
@@ -250,6 +300,9 @@ class KDAKernelDispatch:
         lower_bound: Optional[float],
         cu_seqlens: Optional[torch.Tensor],
         chunk_size: int = 64,
+        state_pool: Optional[torch.Tensor] = None,
+        state_indices: Optional[torch.Tensor] = None,
+        has_initial_states: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run KDA chunked prefill.
 
@@ -262,18 +315,26 @@ class KDAKernelDispatch:
         On the FLA path it calls ``fla.ops.kda.chunk_kda`` directly with the
         matching flags so the semantics are byte-equivalent.
 
-        State layout contract (both paths): ``initial_state`` is consumed
-        and ``final_state`` returned in the V-first ``[N, H, V, K]`` layout —
-        the layout of the executor's ssm pool and of the fused decode
-        kernel. The in-tree prefill op natively uses the FLA-default K-first
-        ``[N, H, K, V]`` layout, so the optimized path transposes at both
-        boundaries (K == V == 128 for Kimi K3, so shapes alone cannot catch
-        a mix-up — the transpose is semantic).
+        The legacy contract consumes ``initial_state`` and returns
+        ``final_state`` in V-first ``[N, H, V, K]`` layout. When
+        ``state_pool`` is provided, the optimized kernel instead reads and
+        writes selected pool rows in place using ``state_indices`` and
+        ``has_initial_states``. The pool may have an arbitrary aligned slot
+        stride, while its inner H/V/K dimensions must be dense.
         """
+        use_indexed_state = state_pool is not None
+        if use_indexed_state and (
+            initial_state is not None or state_indices is None or has_initial_states is None
+        ):
+            raise ValueError(
+                "Indexed KDA prefill requires state_indices and "
+                "has_initial_states, and does not accept initial_state."
+            )
         use_optimized = self.prefill_kernel_path == "optimized"
         chunk_indices = None
         if use_optimized and cu_seqlens is not None:
             from fla.ops.utils.index import prepare_chunk_indices
+
             chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
             # The persistent K123 scheduler needs at least 4 total chunks
             # (cgs_per_head = NT // 4 cooperative groups per head). The
@@ -286,6 +347,12 @@ class KDAKernelDispatch:
             # pre-transforms below: the FLA path applies both in-kernel.
             if chunk_indices.shape[0] < 4:
                 use_optimized = False
+
+        if use_indexed_state and not use_optimized:
+            raise RuntimeError(
+                "Indexed KDA prefill requires the optimized prefill path; "
+                "use the legacy state path for this batch."
+            )
 
         if use_optimized:
             import torch.nn.functional as F
@@ -316,6 +383,30 @@ class KDAKernelDispatch:
             dt_bias_kernel = dt_bias.detach() if dt_bias is not None else None
 
             _load_prefill_module()  # registers trtllm::kda_prefill
+
+            if use_indexed_state:
+                out = torch.ops.trtllm.kda_prefill_indexed(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g,
+                    beta=beta,
+                    state_pool=state_pool,
+                    state_indices=state_indices,
+                    has_initial_states=has_initial_states,
+                    scale=scale,
+                    cu_seqlens=cu_seqlens,
+                    chunk_indices=chunk_indices,
+                    chunk_size=chunk_size,
+                    safe_gate=safe_gate,
+                    lower_bound=lower_bound,
+                    use_gate_in_kernel=True,
+                    A_log=A_log_kernel,
+                    dt_bias=dt_bias_kernel,
+                )
+                if out.shape[1] != real_T:
+                    out = out[:, :real_T]
+                return out, None
 
             if initial_state is not None:
                 # Pool V-first [N, H, V, K] -> op K-first [N, H, K, V].

--- a/tensorrt_llm/_torch/modules/kimi_kda/kimi_kda_mixer.py
+++ b/tensorrt_llm/_torch/modules/kimi_kda/kimi_kda_mixer.py
@@ -303,6 +303,10 @@ class KimiKDALinearAttention(nn.Module):
         """
         return self._dispatch.prefill_chunk_kda(**kwargs)
 
+    def can_use_indexed_prefill(self, **kwargs) -> bool:
+        """Return whether prefill can update a recurrent-state pool directly."""
+        return self._dispatch.can_use_indexed_prefill(**kwargs)
+
     # ------------------------------------------------------------------
     # Prefill entry (Goal 2.1 pass path).
     # ------------------------------------------------------------------
@@ -414,11 +418,9 @@ class KimiKDALinearAttention(nn.Module):
         assert q_len == 1, f"KimiKDALinearAttention.forward_decode expects T=1, got T={q_len}"
 
         if self._dispatch.decode_kernel_path == KimiKDAKernelPath.OPTIMIZED:
-            return self._decode_via_optimized(hidden_states, cache, b,
-                                              ssm_state_indices)
+            return self._decode_via_optimized(hidden_states, cache, b, ssm_state_indices)
         if ssm_state_indices is not None:
-            raise ValueError(
-                "ssm_state_indices requires the optimized KDA decode kernel")
+            raise ValueError("ssm_state_indices requires the optimized KDA decode kernel")
         return self._decode_via_fla(hidden_states, cache, b)
 
     # ------------------------------------------------------------------
@@ -452,19 +454,20 @@ class KimiKDALinearAttention(nn.Module):
         # their own calls.
         fused_qkvg = getattr(self, "qkvg_proj", None)
         if fused_qkvg is not None:
-            parts = fused_qkvg(hidden_states).split(self.qkvg_split_sizes,
-                                                    dim=-1)
-            q_proj_states, k_proj_states, v_proj_states = parts[0], parts[
-                1], parts[2]
-            onorm_g_hidden = parts[3] if self.use_full_rank_gate else \
-                self.g_b_proj(self.g_a_proj(hidden_states))
+            parts = fused_qkvg(hidden_states).split(self.qkvg_split_sizes, dim=-1)
+            q_proj_states, k_proj_states, v_proj_states = parts[0], parts[1], parts[2]
+            onorm_g_hidden = (
+                parts[3] if self.use_full_rank_gate else self.g_b_proj(self.g_a_proj(hidden_states))
+            )
         else:
             q_proj_states = self.q_proj(hidden_states)
             k_proj_states = self.k_proj(hidden_states)
             v_proj_states = self.v_proj(hidden_states)
-            onorm_g_hidden = self.g_proj(hidden_states) \
-                if self.use_full_rank_gate else \
-                self.g_b_proj(self.g_a_proj(hidden_states))
+            onorm_g_hidden = (
+                self.g_proj(hidden_states)
+                if self.use_full_rank_gate
+                else self.g_b_proj(self.g_a_proj(hidden_states))
+            )
 
         g_hidden = self.f_b_proj(self.f_a_proj(hidden_states))
 
@@ -526,17 +529,13 @@ class KimiKDALinearAttention(nn.Module):
         if cache is not None and cache.recurrent_state is not None:
             if ssm_state_indices is not None:
                 if self.wrong_state_layout:
-                    raise ValueError(
-                        "ssm_state_indices is incompatible with wrong_state_layout"
-                    )
+                    raise ValueError("ssm_state_indices is incompatible with wrong_state_layout")
                 state_full = cache.recurrent_state
             else:
-                state_full = cache.recurrent_state.to(
-                    dtype=torch.float32).contiguous()
+                state_full = cache.recurrent_state.to(dtype=torch.float32).contiguous()
         else:
             if ssm_state_indices is not None:
-                raise ValueError(
-                    "ssm_state_indices requires a recurrent state pool")
+                raise ValueError("ssm_state_indices requires a recurrent state pool")
             state_full = torch.zeros(b, HV, V_dim, K_dim, device=dev, dtype=torch.float32)
 
         # The decode op requires fp32 A_log/dt_bias even in a bf16-cast module.

--- a/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_state_pool.py
+++ b/tests/unittest/_torch/modules/kimi_kda/test_kda_prefill_state_pool.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A/B coverage for direct KDA prefill recurrent-state pool access."""
+
+import os
+import statistics
+
+import pytest
+import torch
+
+pytest.importorskip("fla")
+
+from tensorrt_llm._torch.modules.kimi_kda._kda_kernels import KDAKernelDispatch  # noqa: E402
+
+HEAD_DIM = 128
+LOWER_BOUND = -5.0
+PERF_ENV = "TLLM_RUN_KDA_PREFILL_POOL_PERF"
+RUN_PERF = os.environ.get(PERF_ENV, "0")
+if RUN_PERF not in ("0", "1"):
+    raise ValueError(f"{PERF_ENV} must be 0 or 1, got {RUN_PERF!r}")
+
+
+def _has_supported_gpu() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability(0) in {(10, 0), (10, 3)}
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_supported_gpu(),
+    reason="Kimi K3 is supported only on Blackwell (SM100/SM103)",
+)
+
+
+@pytest.fixture(scope="module")
+def dispatch() -> KDAKernelDispatch:
+    result = KDAKernelDispatch(
+        use_optimized_prefill=True,
+        use_optimized_decode=False,
+    )
+    assert result.prefill_kernel_path == "optimized"
+    return result
+
+
+def _make_state_pool(layout: str, slots: int, heads: int) -> torch.Tensor:
+    inner = heads * HEAD_DIM * HEAD_DIM
+    if layout == "dense":
+        return torch.empty(
+            slots,
+            heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            dtype=torch.float32,
+            device="cuda",
+        )
+    if layout == "cpp_envelope":
+        slot_stride = inner + 256
+        storage = torch.empty(slots * slot_stride, dtype=torch.float32, device="cuda")
+        return torch.as_strided(
+            storage,
+            (slots, heads, HEAD_DIM, HEAD_DIM),
+            (slot_stride, HEAD_DIM * HEAD_DIM, HEAD_DIM, 1),
+        )
+    if layout == "v2_page_scale":
+        page_index_scale = 3
+        raw = torch.empty(
+            slots * page_index_scale,
+            heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        return raw.as_strided(
+            (slots, heads, HEAD_DIM, HEAD_DIM),
+            (raw.stride(0) * page_index_scale, *raw.stride()[1:]),
+        )
+    raise ValueError(f"Unknown state-pool layout: {layout}")
+
+
+def _seed_state_pool(pool: torch.Tensor, seed: int) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    values = torch.randn(
+        pool.shape,
+        generator=generator,
+        dtype=torch.float32,
+        device=pool.device,
+    )
+    value_axis = torch.linspace(0.5, 1.5, HEAD_DIM, dtype=torch.float32, device=pool.device).view(
+        1, 1, HEAD_DIM, 1
+    )
+    key_axis = torch.linspace(-0.25, 0.25, HEAD_DIM, dtype=torch.float32, device=pool.device).view(
+        1, 1, 1, HEAD_DIM
+    )
+    pool.copy_(values * value_axis + key_axis)
+
+
+def _make_inputs(heads: int, lens: list[int], seed: int):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    total_tokens = sum(lens)
+
+    def _random(*shape, dtype=torch.bfloat16):
+        return torch.randn(
+            *shape,
+            generator=generator,
+            dtype=torch.float32,
+            device="cuda",
+        ).to(dtype)
+
+    q = _random(1, total_tokens, heads, HEAD_DIM)
+    k = _random(1, total_tokens, heads, HEAD_DIM)
+    v = _random(1, total_tokens, heads, HEAD_DIM)
+    g = _random(1, total_tokens, heads, HEAD_DIM)
+    beta = _random(1, total_tokens, heads, dtype=torch.float32)
+    A_log = _random(heads, dtype=torch.float32) * 0.5
+    dt_bias = _random(heads * HEAD_DIM, dtype=torch.float32) * 0.1
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(lens).cumsum(0).tolist()],
+        dtype=torch.long,
+        device="cuda",
+    )
+    return q, k, v, g, beta, A_log, dt_bias, cu_seqlens
+
+
+def _run_legacy(
+    dispatch: KDAKernelDispatch,
+    inputs,
+    state_pool: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_states: torch.Tensor,
+) -> torch.Tensor:
+    q, k, v, g, beta, A_log, dt_bias, cu_seqlens = inputs
+    initial_state = state_pool.index_select(0, state_indices)
+    initial_state[~has_initial_states] = 0
+    output, final_state = dispatch.prefill_chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=HEAD_DIM**-0.5,
+        initial_state=initial_state,
+        safe_gate=True,
+        lower_bound=LOWER_BOUND,
+        cu_seqlens=cu_seqlens,
+    )
+    assert final_state is not None
+    state_pool.index_copy_(0, state_indices, final_state)
+    return output
+
+
+def _run_indexed(
+    dispatch: KDAKernelDispatch,
+    inputs,
+    state_pool: torch.Tensor,
+    state_indices: torch.Tensor,
+    has_initial_states: torch.Tensor,
+) -> torch.Tensor:
+    q, k, v, g, beta, A_log, dt_bias, cu_seqlens = inputs
+    assert dispatch.can_use_indexed_prefill(
+        state_pool=state_pool,
+        state_indices=state_indices,
+        has_initial_states=has_initial_states,
+        cu_seqlens=cu_seqlens,
+        num_tokens=q.shape[1],
+    )
+    output, final_state = dispatch.prefill_chunk_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=HEAD_DIM**-0.5,
+        initial_state=None,
+        safe_gate=True,
+        lower_bound=LOWER_BOUND,
+        cu_seqlens=cu_seqlens,
+        state_pool=state_pool,
+        state_indices=state_indices,
+        has_initial_states=has_initial_states,
+    )
+    assert final_state is None
+    return output
+
+
+@pytest.mark.parametrize(
+    "layout",
+    ["dense", "cpp_envelope", "v2_page_scale"],
+)
+@torch.no_grad()
+def test_indexed_state_pool_matches_legacy(
+    dispatch: KDAKernelDispatch,
+    layout: str,
+) -> None:
+    heads, slots = 4, 9
+    inputs = _make_inputs(heads, [64, 128, 96], seed=1234)
+    state_indices = torch.tensor([7, 2, 5], dtype=torch.int64, device="cuda")
+    state_modes = (
+        torch.tensor([False, False, False], device="cuda"),
+        torch.tensor([True, True, True], device="cuda"),
+        torch.tensor([True, False, True], device="cuda"),
+    )
+
+    for case_idx, has_initial_states in enumerate(state_modes):
+        legacy_pool = _make_state_pool(layout, slots, heads)
+        indexed_pool = _make_state_pool(layout, slots, heads)
+        _seed_state_pool(legacy_pool, seed=100 + case_idx)
+        indexed_pool.copy_(legacy_pool)
+        untouched = indexed_pool.clone()
+
+        legacy_output = _run_legacy(
+            dispatch,
+            inputs,
+            legacy_pool,
+            state_indices,
+            has_initial_states,
+        ).clone()
+        indexed_output = _run_indexed(
+            dispatch,
+            inputs,
+            indexed_pool,
+            state_indices,
+            has_initial_states,
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(indexed_output, legacy_output, rtol=0, atol=0)
+        torch.testing.assert_close(
+            indexed_pool.index_select(0, state_indices),
+            legacy_pool.index_select(0, state_indices),
+            rtol=0,
+            atol=0,
+        )
+        unselected = torch.ones(slots, dtype=torch.bool, device="cuda")
+        unselected[state_indices] = False
+        assert torch.equal(indexed_pool[unselected], untouched[unselected])
+
+
+@pytest.mark.parametrize("has_initial_state", [False, True], ids=["fresh", "carried"])
+@torch.no_grad()
+def test_indexed_state_pool_matches_saturated_e2e_schedule(
+    dispatch: KDAKernelDispatch,
+    has_initial_state: bool,
+) -> None:
+    """Cover the H=96 persistent schedule on the executor's CUDA stream."""
+    heads, slots = 96, 6
+    inputs = _make_inputs(heads, [1150, 1200], seed=5678)
+    state_indices = torch.tensor([5, 3], dtype=torch.int64, device="cuda")
+    has_initial_states = torch.full((2,), has_initial_state, dtype=torch.bool, device="cuda")
+    legacy_pool = _make_state_pool("dense", slots, heads)
+    indexed_pool = _make_state_pool("dense", slots, heads)
+    _seed_state_pool(legacy_pool, seed=9)
+    indexed_pool.copy_(legacy_pool)
+
+    legacy_output = _run_legacy(
+        dispatch,
+        inputs,
+        legacy_pool,
+        state_indices,
+        has_initial_states,
+    ).clone()
+    torch.cuda.synchronize()
+
+    q, k, v, g, beta, A_log, dt_bias, cu_seqlens = inputs
+    execution_stream = torch.cuda.Stream()
+    with torch.cuda.stream(execution_stream):
+        torch.cuda._sleep(1 << 28)
+        streamed_inputs = (
+            q * 1.0,
+            k * 1.0,
+            v * 1.0,
+            g * 1.0,
+            beta * 1.0,
+            A_log,
+            dt_bias,
+            cu_seqlens,
+        )
+        indexed_output = _run_indexed(
+            dispatch,
+            streamed_inputs,
+            indexed_pool,
+            state_indices,
+            has_initial_states,
+        )
+        indexed_output = indexed_output * 1.0
+        indexed_state = indexed_pool.index_select(0, state_indices) * 1.0
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(indexed_output, legacy_output, rtol=0, atol=0)
+    torch.testing.assert_close(
+        indexed_state,
+        legacy_pool.index_select(0, state_indices),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.no_grad()
+def test_indexed_state_pool_reuses_compile_across_batch_sizes(
+    dispatch: KDAKernelDispatch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warmup must cover full and underfilled context batches."""
+    from tensorrt_llm._torch.custom_ops import cute_dsl_kimi_k3_custom_ops
+
+    heads, slots = 5, 8
+    warmup_inputs = _make_inputs(heads, [64, 192], seed=6001)
+    warmup_pool = _make_state_pool("dense", slots, heads)
+    _seed_state_pool(warmup_pool, seed=61)
+    _run_indexed(
+        dispatch,
+        warmup_inputs,
+        warmup_pool,
+        torch.tensor([6, 2], dtype=torch.int64, device="cuda"),
+        torch.tensor([True, False], device="cuda"),
+    )
+    torch.cuda.synchronize()
+
+    inputs = _make_inputs(heads, [64, 64, 128], seed=6002)
+    state_indices = torch.tensor([7, 3, 1], dtype=torch.int64, device="cuda")
+    has_initial_states = torch.tensor([True, False, True], device="cuda")
+    legacy_pool = _make_state_pool("dense", slots, heads)
+    indexed_pool = _make_state_pool("dense", slots, heads)
+    _seed_state_pool(legacy_pool, seed=62)
+    indexed_pool.copy_(legacy_pool)
+
+    legacy_output = _run_legacy(
+        dispatch,
+        inputs,
+        legacy_pool,
+        state_indices,
+        has_initial_states,
+    ).clone()
+
+    def unexpected_compile(*args, **kwargs):
+        pytest.fail("changing only the runtime context batch size recompiled a CuTe kernel")
+
+    monkeypatch.setattr(cute_dsl_kimi_k3_custom_ops.cute, "compile", unexpected_compile)
+
+    indexed_output = _run_indexed(
+        dispatch,
+        inputs,
+        indexed_pool,
+        state_indices,
+        has_initial_states,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(indexed_output, legacy_output, rtol=0, atol=0)
+    torch.testing.assert_close(indexed_pool, legacy_pool, rtol=0, atol=0)
+
+
+@torch.no_grad()
+def test_indexed_state_pool_removes_full_state_copies(
+    dispatch: KDAKernelDispatch,
+) -> None:
+    from torch.profiler import ProfilerActivity, profile
+
+    heads, slots = 4, 9
+    inputs = _make_inputs(heads, [64, 128, 96], seed=4321)
+    state_indices = torch.tensor([7, 2, 5], dtype=torch.int64, device="cuda")
+    has_initial_states = torch.tensor([True, False, True], device="cuda")
+    legacy_pool = _make_state_pool("dense", slots, heads)
+    indexed_pool = _make_state_pool("dense", slots, heads)
+    _seed_state_pool(legacy_pool, seed=5)
+    indexed_pool.copy_(legacy_pool)
+
+    _run_legacy(dispatch, inputs, legacy_pool, state_indices, has_initial_states)
+    _run_indexed(dispatch, inputs, indexed_pool, state_indices, has_initial_states)
+    torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as legacy_profile:
+        _run_legacy(dispatch, inputs, legacy_pool, state_indices, has_initial_states)
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as indexed_profile:
+        _run_indexed(dispatch, inputs, indexed_pool, state_indices, has_initial_states)
+    torch.cuda.synchronize()
+
+    legacy_counts = {event.key: event.count for event in legacy_profile.key_averages()}
+    indexed_counts = {event.key: event.count for event in indexed_profile.key_averages()}
+    assert legacy_counts.get("aten::index_select", 0) >= 1
+    assert legacy_counts.get("aten::index_copy_", 0) >= 1
+    assert indexed_counts.get("aten::index_select", 0) == 0
+    assert indexed_counts.get("aten::index_copy_", 0) == 0
+    assert legacy_counts.get("aten::contiguous", 0) >= (
+        indexed_counts.get("aten::contiguous", 0) + 2
+    )
+
+
+def _measure_ms(fn, iterations: int = 20) -> list[float]:
+    samples = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+@pytest.mark.skipif(
+    RUN_PERF == "0",
+    reason=f"Set {PERF_ENV}=1 to run the KDA prefill A/B microbenchmark.",
+)
+@torch.no_grad()
+def test_indexed_state_pool_is_faster(
+    dispatch: KDAKernelDispatch,
+) -> None:
+    # Match one K3 attention-DP context from the 8K/1K E2E workload. Each
+    # rank owns all 96 KDA heads, so this also matches its 6 MiB state row.
+    heads, slots = 96, 4
+    inputs = _make_inputs(heads, [8192], seed=2026)
+    state_indices = torch.tensor([3], dtype=torch.int64, device="cuda")
+    has_initial_states = torch.ones(1, dtype=torch.bool, device="cuda")
+    legacy_pool = _make_state_pool("dense", slots, heads)
+    indexed_pool = _make_state_pool("dense", slots, heads)
+    _seed_state_pool(legacy_pool, seed=8)
+    indexed_pool.copy_(legacy_pool)
+
+    legacy_output = _run_legacy(
+        dispatch,
+        inputs,
+        legacy_pool,
+        state_indices,
+        has_initial_states,
+    ).clone()
+    indexed_output = _run_indexed(
+        dispatch,
+        inputs,
+        indexed_pool,
+        state_indices,
+        has_initial_states,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(indexed_output, legacy_output, rtol=0, atol=0)
+    torch.testing.assert_close(indexed_pool, legacy_pool, rtol=0, atol=0)
+
+    for _ in range(3):
+        _run_legacy(dispatch, inputs, legacy_pool, state_indices, has_initial_states)
+        _run_indexed(dispatch, inputs, indexed_pool, state_indices, has_initial_states)
+    torch.cuda.synchronize()
+
+    legacy_samples = _measure_ms(
+        lambda: _run_legacy(dispatch, inputs, legacy_pool, state_indices, has_initial_states)
+    )
+    indexed_samples = _measure_ms(
+        lambda: _run_indexed(dispatch, inputs, indexed_pool, state_indices, has_initial_states)
+    )
+    torch.testing.assert_close(indexed_pool, legacy_pool, rtol=0, atol=0)
+    legacy_ms = statistics.median(legacy_samples)
+    indexed_ms = statistics.median(indexed_samples)
+    speedup = legacy_ms / indexed_ms
+    state_mib = state_indices.numel() * heads * HEAD_DIM * HEAD_DIM * 4 / 2**20
+    print(
+        f"KDA prefill state-pool A/B: legacy={legacy_ms:.3f} ms, "
+        f"indexed={indexed_ms:.3f} ms, speedup={speedup:.3f}x, "
+        f"state={state_mib:.1f} MiB"
+    )
+    assert indexed_ms < legacy_ms


### PR DESCRIPTION
@coderabbitai summary

## Description

KDA prefill currently performs two full FP32 recurrent-state copies because the
cache manager stores states in V-first layout (`[slot, H, V, K]`) while the
optimized prefill path consumes and returns K-first tensors (`[B, H, K, V]`).

This change lets the optimized K4 prefill kernel load and store selected cache
slots directly. The caller passes the recurrent-state pool, slot indices, and
per-sequence initial-state validity to the prefill operator, avoiding the legacy
gather/transpose/scatter path. Dense pools, padded per-slot strides, and the
MambaCacheManagerV2 page-index-scaled layout are supported.

`TLLM_KDA_USE_FUSED_STATE_IO=0` retains the legacy prefill path for A/B testing
and debugging. The optimization is restricted to prefill; decode and verify
routing remain unchanged from the target branch.

No public API or dependency changes are introduced.

## Test Coverage

- Pre-commit hooks passed for the squashed commit.
- B200-02: `test_kda_prefill_state_pool.py` — 7 passed, 1 opt-in performance
  test skipped. Coverage includes legacy/direct numerical A/B checks, dense and
  strided cache layouts, saturated E2E-shaped inputs, 8K-context parity, and
  compile-cache reuse across batch sizes.
- GB300 disaggregated Kimi K3 A/B runs showed no accuracy regression and an
  approximately 16% long steady-state throughput improvement.
- Decode methods and routing are AST-identical to the shared base. The existing
  strided indexed-decode test showed the same fail-then-pass NaN flake on both
  the target base and this branch, with no branch-specific regression.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
