### PR TITLE
[None][perf] Avoid Kimi K3 prefill metadata D2H copies

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -168,6 +168,9 @@ class AttentionMetadata:
 
     mamba_metadata: Optional[Any] = None
     mamba_chunk_size: int = 128
+    mamba_metadata_cls: Optional[Type[Any]] = field(default=None,
+                                                   init=False,
+                                                   repr=False)
 
     # The number of tokens in the padded sequence.
     padded_num_tokens: Optional[int] = None
@@ -342,9 +345,12 @@ class AttentionMetadata:
 
         if self.mamba_metadata is None:
             if isinstance(self.kv_cache_manager, BaseMambaCacheManager):
-                from ..modules.mamba.mamba2_metadata import Mamba2Metadata
-                self.mamba_metadata = Mamba2Metadata(self.max_num_requests,
-                                                     self.mamba_chunk_size)
+                metadata_cls = self.mamba_metadata_cls
+                if metadata_cls is None:
+                    from ..modules.mamba.mamba2_metadata import Mamba2Metadata
+                    metadata_cls = Mamba2Metadata
+                self.mamba_metadata = metadata_cls(self.max_num_requests,
+                                                   self.mamba_chunk_size)
             else:
                 self.mamba_metadata = False
                 return

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_kimi_k3_custom_ops.py
@@ -31,9 +31,8 @@ The public ``trtllm::kda_prefill`` operator returns only the KDA output and
 final recurrent state. Intermediate matrices remain private runner workspace.
 """
 
-from typing import Optional, Tuple
-
 import weakref
+from typing import Optional, Tuple
 
 import torch
 
@@ -617,6 +616,7 @@ def _launch_fused_k123_inv(
     akk_out_view=None,
     cute_wrappers=None,
     varlen_pure_override=False,
+    varlen_is_aligned=None,
 ):
     """Persistent K1+K2 (writes A_kk in I+L format with diag=1) chained with
     BF16 akk_inv (in-place inversion). Final A_kk_inv = (I+L)^-1."""
@@ -632,15 +632,17 @@ def _launch_fused_k123_inv(
     T_padded = T if is_varlen else None
     has_bias = dt_bias is not None
 
-    # Auto-detect VARLEN_PURE eligibility, cached by id(cu_seqlens).
-    # First call with a given cu_seqlens object pays one GPU->CPU sync; later
-    # calls with the same tensor object are a dict lookup (~100 ns).
+    # Prefer the host-derived alignment property supplied by the model runtime.
+    # Direct low-level callers that omit it retain the cached device inference
+    # fallback for backward compatibility.
     varlen_pure = False
     if is_varlen and cu_seqlens is not None:
         if varlen_pure_override:
             # Caller (Phase 2.1 single-seq path) sentinel-padded the data for
             # this call; the cached per-object verdict stays untouched.
             varlen_pure = True
+        elif varlen_is_aligned is not None:
+            varlen_pure = varlen_is_aligned
         else:
             _vp_key = id(cu_seqlens)
             if _vp_key not in _varlen_pure_cache:
@@ -898,6 +900,8 @@ def _chunk_kda_fwd(
     return_intermediate_states: bool = False,
     cp_context=None,
     use_fused_k1234: bool = False,
+    varlen_is_aligned: bool | None = None,
+    single_sequence_length: int | None = None,
 ):
     """KDA forward — optimized, FLA-compatible interface."""
     if safe_gate and lower_bound is None:
@@ -1007,17 +1011,31 @@ def _chunk_kda_fwd(
     # Multi-seq optimization needs per-seq dynamic tensormap (Phase 2.2).
     needs_varlen_single_pad = False
     if is_varlen and cu_seqlens is not None and cu_seqlens.shape[0] == 2 and B == 1:
-        _vl_key = id(cu_seqlens)
-        if _vl_key not in _varlen_pure_cache:
-            cu_cpu = cu_seqlens.cpu().tolist()
-            sl = cu_cpu[1] - cu_cpu[0]
-            _varlen_pure_cache[_vl_key] = sl % BT == 0
-            _varlen_single_seqlen_cache[_vl_key] = sl
-            _prune_on_gc(_varlen_pure_cache, _vl_key, cu_seqlens)
-            _prune_on_gc(_varlen_single_seqlen_cache, _vl_key, cu_seqlens)
-        if not _varlen_pure_cache[_vl_key]:
-            real_T = _varlen_single_seqlen_cache[_vl_key]
-            needs_varlen_single_pad = True
+        if single_sequence_length is not None:
+            single_sequence_is_aligned = single_sequence_length % BT == 0
+            if (varlen_is_aligned is not None
+                    and varlen_is_aligned != single_sequence_is_aligned):
+                raise ValueError(
+                    "varlen_is_aligned disagrees with single_sequence_length"
+                )
+            varlen_is_aligned = single_sequence_is_aligned
+            if not single_sequence_is_aligned:
+                real_T = single_sequence_length
+                needs_varlen_single_pad = True
+        else:
+            _vl_key = id(cu_seqlens)
+            if _vl_key not in _varlen_pure_cache:
+                cu_cpu = cu_seqlens.cpu().tolist()
+                sl = cu_cpu[1] - cu_cpu[0]
+                _varlen_pure_cache[_vl_key] = sl % BT == 0
+                _varlen_single_seqlen_cache[_vl_key] = sl
+                _prune_on_gc(_varlen_pure_cache, _vl_key, cu_seqlens)
+                _prune_on_gc(_varlen_single_seqlen_cache, _vl_key,
+                             cu_seqlens)
+            varlen_is_aligned = _varlen_pure_cache[_vl_key]
+            if not varlen_is_aligned:
+                real_T = _varlen_single_seqlen_cache[_vl_key]
+                needs_varlen_single_pad = True
     varlen_pure_override = False
     if needs_varlen_single_pad:
         # q/k/v/beta already zero-padded by caller (FLA convention). Re-build g
@@ -1128,6 +1146,7 @@ def _chunk_kda_fwd(
         akk_out_view=cute_wrappers["akk_out_view"],
         cute_wrappers=cute_wrappers,
         varlen_pure_override=varlen_pure_override,
+        varlen_is_aligned=varlen_is_aligned,
     )
 
     # ===== K4: persistent kernel (eqlen + varlen via cu_seqlens) =====
@@ -1207,6 +1226,8 @@ class KdaPrefillRunner:
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         use_fused_k1234: bool = False,
+        varlen_is_aligned: Optional[bool] = None,
+        single_sequence_length: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run KDA prefill and return output plus final recurrent state."""
         if not IS_CUTLASS_DSL_AVAILABLE:
@@ -1234,6 +1255,8 @@ class KdaPrefillRunner:
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             use_fused_k1234=use_fused_k1234,
+            varlen_is_aligned=varlen_is_aligned,
+            single_sequence_length=single_sequence_length,
         )
         return result[0], result[1]
 
@@ -1261,6 +1284,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         use_fused_k1234: bool = False,
+        varlen_is_aligned: Optional[bool] = None,
+        single_sequence_length: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Run Kimi K3 KDA chunked prefill on Blackwell GPUs.
 
@@ -1289,6 +1314,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             disable_recompute=disable_recompute,
             return_intermediate_states=return_intermediate_states,
             use_fused_k1234=use_fused_k1234,
+            varlen_is_aligned=varlen_is_aligned,
+            single_sequence_length=single_sequence_length,
         )
         if final_state is None:
             final_state = q.new_empty(0, dtype=torch.float32)
@@ -1315,11 +1342,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
         disable_recompute: bool = False,
         return_intermediate_states: bool = False,
         use_fused_k1234: bool = False,
+        varlen_is_aligned: Optional[bool] = None,
+        single_sequence_length: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         del k, g, beta, A_log, scale, dt_bias, initial_state
         del chunk_indices, chunk_size, safe_gate, lower_bound
         del use_gate_in_kernel, disable_recompute, return_intermediate_states
         del use_fused_k1234
+        del varlen_is_aligned, single_sequence_length
         num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.shape[0] - 1
         output = v.new_empty(v.shape)
         if output_final_state:

--- a/tensorrt_llm/_torch/models/modeling_kimi_linear.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_linear.py
@@ -76,11 +76,11 @@ is validated only without block reuse (Mixed cache manager).
 
 from __future__ import annotations
 
+import copy
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-import copy
 import torch
 from torch import nn
 
@@ -95,6 +95,7 @@ from ..model_config import ModelConfig
 from ..modules.fused_moe import ConfigurableMoE, create_moe
 from ..modules.kimi_k3_moe._mlp import KimiK3MLP, KimiK3RMSNorm
 from ..modules.kimi_k3_moe.kimi_k3_moe_gate import KimiK3MoEGate
+from ..modules.kimi_kda.kimi_k3_mamba_metadata import KimiK3MambaMetadata
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..utils import ActType_TrtllmGen
@@ -334,7 +335,9 @@ class _Fp8BlockScaleWeightReadLinear(nn.Module):
         # Lazy imports: only pulled in on the FP8 path.
         from ...deep_gemm.utils.math import per_block_cast_to_fp8
         from ...quantization.utils.fp8_utils import (
-            resmooth_to_fp8_e8m0, transform_sf_into_required_layout)
+            resmooth_to_fp8_e8m0,
+            transform_sf_into_required_layout,
+        )
         # 128x128 block-scale FP8 weight, then the exact SM100 deep_gemm scale
         # preparation the shipping FP8-block-scale Linear uses: resmooth to
         # UE8M0 and pack the scale into deep_gemm's TMA-aligned MN-major
@@ -999,9 +1002,9 @@ class KimiKDARuntime(nn.Module):
         num_prefills = attn_metadata.num_contexts
         num_ctx_tokens = attn_metadata.num_ctx_tokens
         batch_size = attn_metadata.seq_lens.shape[0]
-        # index_copy_/index_select need int64 indices; the int64 mirror is
-        # prepared once per step by Mamba2Metadata.prepare() so KDA layers
-        # do not each replay an int32->int64 cast inside the decode graph.
+        # index_copy_/index_select need int64 indices; the K3 metadata prepares
+        # a mirror once per step so KDA layers do not each replay an
+        # int32-to-int64 cast inside the decode graph.
         state_indices = getattr(mamba_metadata, "state_indices_long", None)
         if state_indices is None or state_indices.shape[0] != batch_size:
             state_indices = mamba_metadata.state_indices[:batch_size].long()
@@ -1155,6 +1158,9 @@ class KimiKDARuntime(nn.Module):
             safe_gate=lower_bound is not None,
             lower_bound=lower_bound,
             cu_seqlens=cu_seqlens,
+            chunk_indices=mamba_metadata.kda_chunk_indices,
+            varlen_is_aligned=mamba_metadata.kda_varlen_is_aligned,
+            single_sequence_length=mamba_metadata.kda_single_sequence_length,
         )
 
         # Persist per-request states into the pools.
@@ -2018,6 +2024,8 @@ def _materialize(value) -> torch.Tensor:
 class KimiLinearForCausalLM(SpecDecOneEngineForCausalLM[KimiLinearModel,
                                                         Any]):
     """Kimi K3 text model (the vision tower is ignored; text-only serving)."""
+
+    mamba_metadata_cls = KimiK3MambaMetadata
 
     def __init__(self, model_config: ModelConfig):
         cfg = _get_text_config(model_config.pretrained_config)

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -378,6 +378,8 @@ class DecoderModelForCausalLM(nn.Module,
                               Generic[TModel, TConfig],
                               metaclass=PostInitCaller):
 
+    mamba_metadata_cls: type | None = None
+
     def __init__(self, model: TModel, *, config: ModelConfig[TConfig],
                  hidden_size: int, vocab_size: int):
         super().__init__()

--- a/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
+++ b/tensorrt_llm/_torch/modules/kimi_kda/_kda_kernels.py
@@ -249,7 +249,10 @@ class KDAKernelDispatch:
         safe_gate: bool,
         lower_bound: Optional[float],
         cu_seqlens: Optional[torch.Tensor],
+        chunk_indices: Optional[torch.Tensor] = None,
         chunk_size: int = 64,
+        varlen_is_aligned: Optional[bool] = None,
+        single_sequence_length: Optional[int] = None,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run KDA chunked prefill.
 
@@ -262,6 +265,11 @@ class KDAKernelDispatch:
         On the FLA path it calls ``fla.ops.kda.chunk_kda`` directly with the
         matching flags so the semantics are byte-equivalent.
 
+        ``chunk_indices``, ``varlen_is_aligned``, and
+        ``single_sequence_length`` are prepared once from Kimi K3 runtime
+        metadata. They keep the optimized path from reading ``cu_seqlens``
+        back from the GPU in every KDA layer.
+
         State layout contract (both paths): ``initial_state`` is consumed
         and ``final_state`` returned in the V-first ``[N, H, V, K]`` layout —
         the layout of the executor's ssm pool and of the fused decode
@@ -271,10 +279,11 @@ class KDAKernelDispatch:
         a mix-up — the transpose is semantic).
         """
         use_optimized = self.prefill_kernel_path == "optimized"
-        chunk_indices = None
         if use_optimized and cu_seqlens is not None:
-            from fla.ops.utils.index import prepare_chunk_indices
-            chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+            if chunk_indices is None:
+                from fla.ops.utils.index import prepare_chunk_indices
+
+                chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
             # The persistent K123 scheduler needs at least 4 total chunks
             # (cgs_per_head = NT // 4 cooperative groups per head). The
             # eqlen path guarantees this by padding to a 256-token multiple
@@ -338,6 +347,8 @@ class KDAKernelDispatch:
                 use_gate_in_kernel=True,
                 A_log=A_log_kernel,
                 dt_bias=dt_bias_kernel,
+                varlen_is_aligned=varlen_is_aligned,
+                single_sequence_length=single_sequence_length,
             )
             if out.shape[1] != real_T:
                 out = out[:, :real_T]

--- a/tensorrt_llm/_torch/modules/kimi_kda/kimi_k3_mamba_metadata.py
+++ b/tensorrt_llm/_torch/modules/kimi_kda/kimi_k3_mamba_metadata.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Kimi K3-specific recurrent-state metadata."""
+
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import AttentionMetadata
+from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
+
+KDA_PREFILL_CHUNK_SIZE = 64
+
+
+@torch.compile(dynamic=True, fullgraph=True)
+def _prepare_kda_chunk_indices(
+    sequence_lengths: torch.Tensor,
+    chunk_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Fill FLA-compatible chunk indices without reading CUDA counts on CPU."""
+    chunk_counts = (sequence_lengths + KDA_PREFILL_CHUNK_SIZE - 1).div(
+        KDA_PREFILL_CHUNK_SIZE, rounding_mode="floor"
+    )
+    num_chunks = chunk_indices.shape[0]
+    # Supplying output_size keeps repeat_interleave from synchronizing to read
+    # sum(chunk_counts) from the device.
+    sequence_indices = torch.repeat_interleave(
+        torch.arange(sequence_lengths.shape[0], dtype=torch.long, device=sequence_lengths.device),
+        chunk_counts,
+        output_size=num_chunks,
+    )
+    chunk_starts = torch.cumsum(chunk_counts, dim=0) - chunk_counts
+    local_chunk_indices = (
+        torch.arange(num_chunks, dtype=torch.long, device=sequence_lengths.device)
+        - chunk_starts[sequence_indices]
+    )
+    chunk_indices[:, 0].copy_(sequence_indices)
+    chunk_indices[:, 1].copy_(local_chunk_indices)
+    return chunk_indices
+
+
+class KimiK3MambaMetadata(Mamba2Metadata):
+    """Mamba metadata extended with Kimi K3 KDA preparation."""
+
+    def __init__(self, max_batch_size: int, chunk_size: int) -> None:
+        super().__init__(max_batch_size, chunk_size)
+        # KDA layers use int64 pool indices. Refreshing this mirror once per
+        # step avoids an int32-to-int64 cast in each of the 69 KDA layers.
+        self._state_indices_long = torch.zeros(max_batch_size, dtype=torch.long, device="cuda")
+        self.state_indices_long = self._state_indices_long[:0]
+        self._kda_chunk_indices = torch.empty((0, 2), dtype=torch.long, device="cuda")
+        self.kda_chunk_indices: torch.Tensor | None = None
+        self.kda_varlen_is_aligned: bool | None = None
+        self.kda_single_sequence_length: int | None = None
+
+    def prepare(self, attn_metadata: AttentionMetadata) -> None:
+        super().prepare(attn_metadata)
+
+        batch_size = attn_metadata.seq_lens.shape[0]
+        self._state_indices_long[:batch_size].copy_(self.state_indices[:batch_size])
+        self.state_indices_long = self._state_indices_long[:batch_size]
+
+        context_lengths = attn_metadata.seq_lens[: attn_metadata.num_contexts].tolist()
+        self.kda_varlen_is_aligned = (
+            all(length % KDA_PREFILL_CHUNK_SIZE == 0 for length in context_lengths)
+            if context_lengths
+            else None
+        )
+        self.kda_single_sequence_length = context_lengths[0] if len(context_lengths) == 1 else None
+
+        if not context_lengths:
+            self.kda_chunk_indices = None
+            return
+
+        chunk_counts = [
+            (length + KDA_PREFILL_CHUNK_SIZE - 1) // KDA_PREFILL_CHUNK_SIZE
+            for length in context_lengths
+        ]
+        num_chunks = sum(chunk_counts)
+        if self._kda_chunk_indices.shape[0] < num_chunks:
+            self._kda_chunk_indices = torch.empty((num_chunks, 2), dtype=torch.long, device="cuda")
+        self.kda_chunk_indices = self._kda_chunk_indices[:num_chunks]
+        if num_chunks == 0:
+            return
+
+        _prepare_kda_chunk_indices(
+            attn_metadata.seq_lens_cuda[: len(context_lengths)],
+            self.kda_chunk_indices,
+        )

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_metadata.py
@@ -243,14 +243,6 @@ class Mamba2Metadata:
         self.state_indices = torch.zeros(max_batch_size,
                                          dtype=torch.int32,
                                          device="cuda")
-        # int64 mirror of state_indices, refreshed once per prepare() so
-        # per-layer consumers that need long indices (index_select /
-        # index_copy_) do not each launch an int32->int64 cast kernel
-        # inside the decode CUDA graph (69 KDA layers x ~1.7us for Kimi K3).
-        self._state_indices_long = torch.zeros(max_batch_size,
-                                               dtype=torch.long,
-                                               device="cuda")
-        self.state_indices_long = self._state_indices_long[:0]
         # Stable data_ptr() of the CUDA tensor we alias (if any) — used to
         # detect cache-manager buffer reallocation that would silently break
         # CUDA graph replays.
@@ -382,12 +374,6 @@ class Mamba2Metadata:
                     self.state_indices_cpu[i] = idx
                 self.state_indices[:batch_size].copy_(
                     self.state_indices_cpu[:batch_size], non_blocking=True)
-
-        # Refresh the int64 mirror once per step (outside the decode graph)
-        # so layers can index pools without a per-layer cast kernel.
-        self._state_indices_long[:batch_size].copy_(
-            self.state_indices[:batch_size])
-        self.state_indices_long = self._state_indices_long[:batch_size]
 
         self._prepare_replay_work_items(kv_cache_manager, batch_size,
                                         num_contexts)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2199,6 +2199,9 @@ class PyTorchModelEngine(ModelEngine):
             num_heads_per_kv=num_heads_per_kv,
             sparse_metadata_params=sparse_metadata_params,
         )
+        if isinstance(self.model, DecoderModelForCausalLM):
+            # Hybrid models may extend the default Mamba metadata contract.
+            self.attn_metadata.mamba_metadata_cls = self.model.mamba_metadata_cls
 
         return self.attn_metadata
 

--- a/tests/unittest/_torch/modules/kimi_kda/test_kda_host_metadata.py
+++ b/tests/unittest/_torch/modules/kimi_kda/test_kda_host_metadata.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Parity coverage for host-derived KDA prefill metadata."""
+
+import pytest
+import torch
+
+pytest.importorskip("fla")
+
+from tensorrt_llm._torch.modules.kimi_kda._kda_kernels import KDAKernelDispatch  # noqa: E402
+
+NUM_HEADS = 6
+HEAD_DIM = 128
+LOWER_BOUND = -5.0
+
+
+def _has_supported_gpu() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability(0) in {(10, 0), (10, 3)}
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_supported_gpu(),
+    reason="Kimi K3 is supported only on Blackwell (SM100/SM103)",
+)
+
+
+@pytest.fixture(scope="module")
+def dispatch_pair() -> tuple[KDAKernelDispatch, KDAKernelDispatch]:
+    optimized = KDAKernelDispatch(use_optimized_prefill=True, use_optimized_decode=False)
+    reference = KDAKernelDispatch(use_optimized_prefill=False, use_optimized_decode=False)
+    assert optimized.prefill_kernel_path == "optimized"
+    assert reference.prefill_kernel_path == "fla"
+    return optimized, reference
+
+
+@pytest.fixture(scope="module")
+def gate_params() -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    a_log = torch.randn(NUM_HEADS, generator=generator, dtype=torch.float32, device="cuda") * 0.5
+    dt_bias = (
+        torch.randn(
+            NUM_HEADS * HEAD_DIM,
+            generator=generator,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        * 0.1
+    )
+    return a_log, dt_bias
+
+
+def _make_inputs(total_tokens: int, seed: int) -> tuple[torch.Tensor, ...]:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+
+    def random_tensor(*shape: int, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
+        return torch.randn(*shape, generator=generator, dtype=torch.float32, device="cuda").to(
+            dtype
+        )
+
+    q = random_tensor(1, total_tokens, NUM_HEADS, HEAD_DIM)
+    k = random_tensor(1, total_tokens, NUM_HEADS, HEAD_DIM)
+    v = random_tensor(1, total_tokens, NUM_HEADS, HEAD_DIM)
+    g = random_tensor(1, total_tokens, NUM_HEADS, HEAD_DIM)
+    beta = random_tensor(1, total_tokens, NUM_HEADS, dtype=torch.float32)
+    return q, k, v, g, beta
+
+
+def _run(
+    dispatch: KDAKernelDispatch,
+    gate_params: tuple[torch.Tensor, torch.Tensor],
+    inputs: tuple[torch.Tensor, ...],
+    cu_seqlens: torch.Tensor,
+    *,
+    chunk_indices: torch.Tensor | None = None,
+    varlen_is_aligned: bool | None = None,
+    single_sequence_length: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    q, k, v, g, beta = inputs
+    a_log, dt_bias = gate_params
+    return dispatch.prefill_chunk_kda(
+        q=q.clone(),
+        k=k.clone(),
+        v=v.clone(),
+        g=g.clone(),
+        beta=beta.clone(),
+        A_log=a_log,
+        dt_bias=dt_bias,
+        scale=HEAD_DIM**-0.5,
+        initial_state=None,
+        safe_gate=True,
+        lower_bound=LOWER_BOUND,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        varlen_is_aligned=varlen_is_aligned,
+        single_sequence_length=single_sequence_length,
+    )
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    actual_float = actual.float()
+    expected_float = expected.float()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_float.flatten(), expected_float.flatten(), dim=0
+    ).item()
+    relative_l2 = ((actual_float - expected_float).norm() / (expected_float.norm() + 1e-12)).item()
+    assert cosine > 0.999
+    assert relative_l2 < 3e-2
+
+
+@pytest.mark.parametrize(
+    "sequence_lengths",
+    ([128, 256, 192], [100, 257, 219], [300]),
+    ids=("aligned", "mixed", "single_unaligned"),
+)
+@torch.no_grad()
+def test_host_metadata_bypasses_device_inference(
+    dispatch_pair: tuple[KDAKernelDispatch, KDAKernelDispatch],
+    gate_params: tuple[torch.Tensor, torch.Tensor],
+    sequence_lengths: list[int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import fla.ops.utils.index as fla_index
+
+    from tensorrt_llm._torch.custom_ops import cute_dsl_kimi_k3_custom_ops
+
+    optimized, reference = dispatch_pair
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(sequence_lengths).cumsum(0).tolist()],
+        dtype=torch.long,
+        device="cuda",
+    )
+    cache_key = id(cu_seqlens)
+    assert cache_key not in cute_dsl_kimi_k3_custom_ops._varlen_pure_cache
+    assert cache_key not in cute_dsl_kimi_k3_custom_ops._varlen_single_seqlen_cache
+
+    inputs = _make_inputs(sum(sequence_lengths), seed=700 + len(sequence_lengths))
+    chunk_indices = torch.tensor(
+        [
+            [sequence_index, chunk_index]
+            for sequence_index, length in enumerate(sequence_lengths)
+            for chunk_index in range((length + 63) // 64)
+        ],
+        dtype=torch.long,
+        device="cuda",
+    )
+    varlen_is_aligned = all(length % 64 == 0 for length in sequence_lengths)
+    single_sequence_length = sequence_lengths[0] if len(sequence_lengths) == 1 else None
+    with monkeypatch.context() as context:
+        context.setattr(
+            fla_index,
+            "prepare_chunk_indices",
+            lambda *_args, **_kwargs: pytest.fail(
+                "host metadata should bypass FLA chunk-index preparation"
+            ),
+        )
+        actual_output, actual_state = _run(
+            optimized,
+            gate_params,
+            inputs,
+            cu_seqlens,
+            chunk_indices=chunk_indices,
+            varlen_is_aligned=varlen_is_aligned,
+            single_sequence_length=single_sequence_length,
+        )
+    reference_output, reference_state = _run(
+        reference,
+        gate_params,
+        inputs,
+        cu_seqlens.clone(),
+    )
+
+    assert actual_state is not None
+    assert reference_state is not None
+    _assert_close(actual_output, reference_output)
+    _assert_close(actual_state, reference_state)
+    assert cache_key not in cute_dsl_kimi_k3_custom_ops._varlen_pure_cache
+    assert cache_key not in cute_dsl_kimi_k3_custom_ops._varlen_single_seqlen_cache

--- a/tests/unittest/_torch/modules/kimi_kda/test_kimi_k3_mamba_metadata.py
+++ b/tests/unittest/_torch/modules/kimi_kda/test_kimi_k3_mamba_metadata.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Kimi K3-specific Mamba metadata."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.kimi_kda.kimi_k3_mamba_metadata import KimiK3MambaMetadata
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _make_attention_metadata(context_lengths: list[int]) -> SimpleNamespace:
+    seq_lens = torch.tensor(context_lengths or [1], dtype=torch.int)
+    num_contexts = len(context_lengths)
+    return SimpleNamespace(
+        seq_lens=seq_lens,
+        seq_lens_cuda=seq_lens.cuda(),
+        num_contexts=num_contexts,
+        num_ctx_tokens=sum(context_lengths),
+        kv_cache_manager=None,
+        request_ids=None,
+        kv_cache_params=SimpleNamespace(
+            num_cached_tokens_per_seq=torch.zeros(num_contexts, dtype=torch.int),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "context_lengths,expected_alignment,expected_single_length",
+    [
+        ([128, 256], True, None),
+        ([128, 257], False, None),
+        ([300], False, 300),
+        ([], None, None),
+    ],
+)
+def test_prepare_derives_kda_prefill_properties(
+    context_lengths: list[int],
+    expected_alignment: bool | None,
+    expected_single_length: int | None,
+) -> None:
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+
+    metadata.prepare(_make_attention_metadata(context_lengths))
+
+    assert metadata.kda_varlen_is_aligned is expected_alignment
+    assert metadata.kda_single_sequence_length == expected_single_length
+
+
+def test_prepare_refreshes_kda_prefill_properties() -> None:
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+
+    metadata.prepare(_make_attention_metadata([300]))
+    assert metadata.kda_varlen_is_aligned is False
+    assert metadata.kda_single_sequence_length == 300
+
+    metadata.prepare(_make_attention_metadata([128, 256]))
+    assert metadata.kda_varlen_is_aligned is True
+    assert metadata.kda_single_sequence_length is None
+
+    metadata.prepare(_make_attention_metadata([]))
+    assert metadata.kda_varlen_is_aligned is None
+    assert metadata.kda_single_sequence_length is None
+
+
+@pytest.mark.parametrize(
+    "context_lengths",
+    ([128, 256], [1, 64, 65, 129], [300]),
+    ids=("aligned", "mixed", "single_unaligned"),
+)
+def test_prepare_builds_kda_chunk_indices(context_lengths: list[int]) -> None:
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+
+    metadata.prepare(_make_attention_metadata(context_lengths))
+
+    expected = torch.tensor(
+        [
+            [sequence_index, chunk_index]
+            for sequence_index, length in enumerate(context_lengths)
+            for chunk_index in range((length + 63) // 64)
+        ],
+        dtype=torch.long,
+        device="cuda",
+    )
+    torch.testing.assert_close(metadata.kda_chunk_indices, expected)
+
+
+@pytest.mark.parametrize(
+    "context_lengths",
+    ([128, 256], [1, 64, 65, 129], [300]),
+    ids=("aligned", "mixed", "single_unaligned"),
+)
+def test_prepare_kda_chunk_indices_matches_legacy_fla(context_lengths: list[int]) -> None:
+    pytest.importorskip("fla")
+    from fla.ops.utils.index import prepare_chunk_indices
+
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+    metadata.prepare(_make_attention_metadata(context_lengths))
+
+    cu_seqlens = metadata.query_start_loc_long[: len(context_lengths) + 1]
+    legacy_chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size=64)
+
+    torch.testing.assert_close(metadata.kda_chunk_indices, legacy_chunk_indices)
+
+
+def test_prepare_refreshes_kda_chunk_indices() -> None:
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+
+    metadata.prepare(_make_attention_metadata([1, 64, 65, 129]))
+    metadata.prepare(_make_attention_metadata([300]))
+
+    expected = torch.stack(
+        (
+            torch.zeros(5, dtype=torch.long, device="cuda"),
+            torch.arange(5, dtype=torch.long, device="cuda"),
+        ),
+        dim=1,
+    )
+    torch.testing.assert_close(metadata.kda_chunk_indices, expected)
+
+
+def test_prepare_refreshes_long_state_indices() -> None:
+    metadata = KimiK3MambaMetadata(max_batch_size=4, chunk_size=128)
+    metadata.state_indices[:2].copy_(torch.tensor([3, 1], dtype=torch.int32, device="cuda"))
+
+    metadata.prepare(_make_attention_metadata([128, 256]))
+
+    torch.testing.assert_close(
+        metadata.state_indices_long,
+        torch.tensor([3, 1], dtype=torch.long, device="cuda"),
+    )
+
+    metadata.state_indices[0] = 2
+    metadata.prepare(_make_attention_metadata([300]))
+
+    torch.testing.assert_close(
+        metadata.state_indices_long,
+        torch.tensor([2], dtype=torch.long, device="cuda"),
+    )


### PR DESCRIPTION
@coderabbitai summary

## Description

Move Kimi K3-specific Mamba metadata preparation into a dedicated `KimiK3MambaMetadata` subclass and generate KDA chunk indices with compiled PyTorch tensor operations on the GPU.

The legacy path prepared chunk metadata through host-visible values and FLA fallback logic, introducing device-to-host synchronization in Kimi K3 prefill. This change keeps chunk-index generation and related metadata on the GPU, passes the prepared metadata directly into the KDA dispatcher, and leaves generic Mamba2 metadata free of Kimi K3-specific state.

The change adds focused unit coverage for the new metadata implementation and checks its output against the legacy FLA implementation.

## Test Coverage

- Targeted Ruff lint and formatting checks passed.
- Python bytecode compilation checks passed.
- TensorRT-LLM native build passed on B200 (`3927/3927` targets).
- Pending: `tests/unittest/_torch/modules/kimi_kda/test_kimi_k3_mamba_metadata.py`. The remote test-container setup stopped before pytest because the image does not contain the `fla` package (`ModuleNotFoundError: No module named 'fla'`).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
