### PR TITLE
[https://nvbugs/6550708][fix] Stub `_profiler=VisualGenProfiler()` in the double (matching the sibling…

### DIFF
--- a/tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py
+++ b/tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py
@@ -24,6 +24,7 @@ from tensorrt_llm._torch.visual_gen.models.cosmos3.sampling import (
     load_scheduler,
 )
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PIPELINE_REGISTRY, AutoPipeline
+from tensorrt_llm._torch.visual_gen.profiler import VisualGenProfiler
 
 pytestmark = [pytest.mark.cosmos3, pytest.mark.usefixtures("disable_cosmos3_guardrails")]
 
@@ -524,13 +525,15 @@ class _GeneratorRecordingScheduler(_AdditiveScheduler):
 
 
 def _denoise_ready_pipeline() -> Cosmos3OmniMoTPipeline:
+    """``denoise()`` drives its profiling windows through ``self._profiler``,
+    which ``BasePipeline.__init__`` owns — so a double that skips ``__init__``
+    must supply one. Unscoped (``TLLM_PROFILE_VISUAL_GEN_START_STOP`` unset) it
+    opens no window and leaves the loop's iteration a plain ``enumerate``."""
     return _bare_pipeline(
         pipeline_config=SimpleNamespace(visual_gen_mapping=None),
         cache_accelerator=None,
-        _predenoise_pending=False,
-        _postdenoise_pending=False,
         _is_warmup=False,
-        _profile_range=None,
+        _profiler=VisualGenProfiler(),
     )
 
 


### PR DESCRIPTION
## Summary
- **Root cause**: Commit 7e6692a474 made the shared denoise loop unconditionally dereference `self._profiler`, assigned only in `BasePipeline.__init__`, but the Cosmos3 test double builds its pipeline via `object.__new__` and so never gets one.
- **Fix**: Stub `_profiler=VisualGenProfiler()` in the double (matching the sibling Qwen-Image helper the same commit fixed) and drop the three orphaned attrs; unscoped the profiler is a no-op, so iteration semantics are unchanged.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6550708


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Added `VisualGenProfiler` to the Cosmos3 denoise test double.
- Removed obsolete profiling attributes now managed by the profiler.
- The change matches the Qwen-Image helper and prevents `_profiler` `AttributeError` failures.
- The profiler remains unscoped and preserves denoise iteration behavior.
- No configuration or test-list files changed.

## QA Engineer Review

- Modified `_denoise_ready_pipeline()`.
- No test functions were added, modified, or removed.
- The change supports the existing Cosmos3 denoise tests.
- No test-list coverage reference was identified.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->