### PR TITLE
[https://nvbugs/6550727][fix] Pin `_force_non_greedy_for_capture=False` on the test double so it models a…

### DIFF
--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -1057,7 +1057,9 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
                                           max_num_tokens=32,
                                           kv_cache_manager=kv_cache_manager)
         attn_metadata.is_cuda_graph = False
-        spec_metadata = Mock()
+        # A bare Mock auto-vivifies every attribute, so the capture-only
+        # override has to be pinned off or _prepare_tp_inputs reads it as live.
+        spec_metadata = Mock(_force_non_greedy_for_capture=False)
 
         context = _create_request_with_tokens([11, 22, 33, 44], 1)
         context.context_current_position = 3


### PR DESCRIPTION
## Summary
- **Root cause**: The test passed a bare `Mock()` as `spec_metadata`, and `Mock` auto-vivifies attributes, so the capture-override `getattr(..., False)` returned a truthy child Mock and tripped the assert.
- **Fix**: Pin `_force_non_greedy_for_capture=False` on the test double so it models a real `SpecMetadata` outside warmup, leaving the production serving-correctness guard intact.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6550727


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- The mock now sets `_force_non_greedy_for_capture=False`.
- This matches `SpecMetadata` behavior outside warmup.
- The production serving-correctness guard remains unchanged.
- No API, configuration, or performance changes were found.

## QA Engineer Review

- Modified the speculative-overlap test in `tests/unittest/_torch/executor/test_pytorch_model_engine.py`.
- No integration test-list files were modified.
- Coverage in `tests/integration/test_lists/` could not be confirmed.

**Verdict: needs follow-up**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->