### PR TITLE
[TRTLLM-13409][fix] stop reporting disagg readiness for workers that have died

### DIFF
--- a/tensorrt_llm/serve/disagg_coordinator.py
+++ b/tensorrt_llm/serve/disagg_coordinator.py
@@ -324,7 +324,30 @@ class DisaggCoordinatorService(DisaggCoordinator):
                 self._ctx_router.num_prepared_servers,
                 self._gen_router.num_prepared_servers,
             )
-        return True
+        # Without a cluster manager this used to be an unconditional `True`,
+        # which made /health a standing promise rather than a statement about
+        # the workers: once startup had completed, a ctx or gen worker could
+        # die and the coordinator would keep answering 200 for it. A client
+        # polling /health then has no way to learn the group is unusable, and
+        # waits out its whole timeout on a server that can never respond.
+        #
+        # When a metadata server is configured, the routers already discover
+        # this: `_monitor_servers()` polls, `check_servers_health()` filters,
+        # and a dead worker is dropped from `servers`. Nothing consulted that.
+        # An empty list is unambiguous -- disaggregated serving needs at least
+        # one context AND one generation server, so zero of either cannot be
+        # served, whatever the cause.
+        #
+        # Deliberately NOT sticky. A metadata-driven deployment legitimately
+        # adds and removes workers, so latching "dead" on the first removal
+        # would turn a routine topology change into a permanently unhealthy
+        # coordinator. This reports the current fact and lets recovery show up
+        # as recovery.
+        #
+        # With a static server list and no metadata server there is no monitor
+        # to consult, so the lists never shrink and this stays `True` exactly
+        # as before -- no behaviour change for that deployment shape.
+        return bool(self._ctx_router.servers) and bool(self._gen_router.servers)
 
     async def cluster_info(self) -> Dict[str, Any]:
         info = {

--- a/tests/unittest/others/test_disagg_readiness_after_startup.py
+++ b/tests/unittest/others/test_disagg_readiness_after_startup.py
@@ -31,6 +31,8 @@ Two layers here, deliberately:
 """
 
 import asyncio
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Optional, TypeVar
 
 import pytest
 
@@ -46,33 +48,46 @@ from tensorrt_llm.serve.router import RoundRobinRouter
 pytestmark = pytest.mark.cpu_only
 
 
+# Truthy stand-in for a metadata server. Module-level rather than a default
+# argument: evaluating `object()` in the signature would bind one instance for
+# the life of the module anyway, so naming it says that out loud.
+_DEFAULT_METADATA_SERVER = object()
+
+# How long a test will wait for the monitor to reach the state it asserts on.
+# Generous on purpose -- it is a deadlock guard, not a timing assertion, and a
+# loaded CI worker must not be able to turn a passing test red.
+_PROGRESS_TIMEOUT_SECS = 10.0
+
+_T = TypeVar("_T")
+
+
 class _StubRouter:
     """Just the surface ``is_ready`` touches."""
 
-    def __init__(self, servers, stale=False):
+    def __init__(self, servers: Iterable[str], stale: bool = False) -> None:
         self._servers = list(servers)
         self._stale = stale
 
     @property
-    def servers(self):
+    def servers(self) -> list[str]:
         return self._servers
 
     @property
-    def num_prepared_servers(self):
+    def num_prepared_servers(self) -> int:
         return len(self._servers)
 
-    def monitoring_is_stale(self, max_age_secs):
+    def monitoring_is_stale(self, max_age_secs: float) -> bool:
         return self._stale
 
 
 def _coordinator(
-    ctx_servers,
-    gen_servers,
-    cluster_manager=None,
-    metadata_server=object(),
-    ctx_stale=False,
-    gen_stale=False,
-):
+    ctx_servers: Iterable[str],
+    gen_servers: Iterable[str],
+    cluster_manager: Optional[Any] = None,
+    metadata_server: Optional[Any] = _DEFAULT_METADATA_SERVER,
+    ctx_stale: bool = False,
+    gen_stale: bool = False,
+) -> DisaggCoordinatorService:
     """A DisaggCoordinatorService with only the readiness surface populated.
 
     __init__ builds sessions and config we do not need, so the object is
@@ -90,8 +105,30 @@ def _coordinator(
     return c
 
 
-def _ready(c):
+def _ready(c: DisaggCoordinatorService) -> bool:
     return asyncio.run(c.is_ready())
+
+
+async def _await_progress(event: asyncio.Event, what: str) -> None:
+    """Wait for the monitor to actually reach a state, instead of sleeping.
+
+    A fixed sleep asserts a timing guess: on a loaded CI worker the monitor
+    may not have completed the poll the assertions depend on, which either
+    fails the test for the wrong reason or -- worse -- lets it pass without
+    the code under test having run at all.
+    """
+    try:
+        await asyncio.wait_for(event.wait(), timeout=_PROGRESS_TIMEOUT_SECS)
+    except asyncio.TimeoutError:
+        pytest.fail(f"monitor did not {what} within {_PROGRESS_TIMEOUT_SECS}s")
+
+
+async def _run_monitored(router: RoundRobinRouter, body: Callable[[], Awaitable[_T]]) -> _T:
+    """Run ``body`` with ``router``'s monitor live, then stop it cleanly."""
+    try:
+        return await body()
+    finally:
+        await router.stop_server_monitoring()
 
 
 class TestReadinessPredicate:
@@ -176,17 +213,17 @@ class TestReadinessPredicate:
 class _StubMetadataServer:
     """Minimal JsonDictionary surface used by ``fetch_live_servers``."""
 
-    def __init__(self, entries):
+    def __init__(self, entries: dict[str, dict[str, str]]) -> None:
         # {key: {"url": ...}} for keys under 'trtllm/'
         self._entries = dict(entries)
 
-    def keys(self):
+    def keys(self) -> list[str]:
         return list(self._entries)
 
-    def get(self, key):
+    def get(self, key: str) -> Optional[dict[str, str]]:
         return self._entries.get(key)
 
-    def remove(self, key):
+    def remove(self, key: str) -> None:
         self._entries.pop(key, None)
 
 
@@ -198,16 +235,19 @@ class TestMonitorDrivesReadiness:
     """
 
     @staticmethod
-    def _router(servers, healthy, role=ServerRole.CONTEXT):
+    def _router(
+        servers: Iterable[str], healthy: set[str], role: ServerRole = ServerRole.CONTEXT
+    ) -> RoundRobinRouter:
         """A real RoundRobinRouter whose health check answers from `healthy`."""
+        servers = list(servers)
         router = RoundRobinRouter(
             server_role=role,
-            servers=list(servers),
+            servers=servers,
             metadata_server_cfg=None,
             metadata_server=_StubMetadataServer({f"trtllm/{s}": {"url": s} for s in servers}),
         )
 
-        async def _check(server_url):
+        async def _check(server_url: str) -> bool:
             return server_url in healthy
 
         router._check_server_health = _check
@@ -223,18 +263,25 @@ class TestMonitorDrivesReadiness:
 
         async def scenario():
             router = self._router(["ctx0"], healthy=set())  # worker is dead
-            # One poll, then stop: _monitor_servers loops forever by design.
-            task = asyncio.create_task(router._monitor_servers(poll_interval=0.01))
-            router._monitor_task = task
-            await asyncio.sleep(0.1)
-            still_running = not task.done()
-            servers = list(router.servers)
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            return servers, still_running
+            published = asyncio.Event()
+            inner_updated = router._on_servers_updated
+
+            def updated_then_signal(old_servers: list[str], new_servers: list[str]) -> None:
+                inner_updated(old_servers, new_servers)
+                # `_on_servers_updated` runs under the monitor's lock, after
+                # `self._servers` has been reassigned. Signalling here -- and
+                # not around the fetch -- is what makes the assertion below
+                # read a published list rather than race the publish.
+                published.set()
+
+            router._on_servers_updated = updated_then_signal
+            await router.start_server_monitoring(poll_interval=0.01)
+
+            async def body():
+                await _await_progress(published, "publish a server-list change")
+                return list(router.servers), not router._monitor_task.done()
+
+            return await _run_monitored(router, body)
 
         servers, still_running = asyncio.run(scenario())
         assert servers == [], (
@@ -254,24 +301,25 @@ class TestMonitorDrivesReadiness:
         async def scenario():
             router = self._router(["ctx0"], healthy={"ctx0"})
             calls = {"n": 0}
+            polled_again = asyncio.Event()
 
-            async def flaky_fetch():
+            async def flaky_fetch() -> dict[str, str]:
                 calls["n"] += 1
                 if calls["n"] == 1:
                     raise RuntimeError("metadata server unreachable")
+                # The retry is the whole point of the test, so wait for it
+                # rather than for a duration that merely usually contains it.
+                polled_again.set()
                 return {"trtllm/ctx0": "ctx0"}
 
             router.fetch_live_servers = flaky_fetch
-            task = asyncio.create_task(router._monitor_servers(poll_interval=0.01))
-            router._monitor_task = task
-            await asyncio.sleep(0.15)
-            alive = not task.done()
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            return alive, calls["n"]
+            await router.start_server_monitoring(poll_interval=0.01)
+
+            async def body():
+                await _await_progress(polled_again, "poll again after the error")
+                return not router._monitor_task.done(), calls["n"]
+
+            return await _run_monitored(router, body)
 
         alive, n_calls = asyncio.run(scenario())
         assert alive, "monitor task died on a transient poll error"
@@ -317,36 +365,57 @@ class TestMonitorDrivesReadiness:
 
         async def scenario():
             router = self._router(["gen0"], healthy={"gen0"}, role=ServerRole.GENERATION)
+            calls = {"n": 0}
+            failed_twice = asyncio.Event()
 
             async def always_fails():
+                calls["n"] += 1
+                # Two failures, not one: it proves the loop retried rather
+                # than merely entered once. Waiting on this is also what stops
+                # the assertions below from passing vacuously -- with a fixed
+                # sleep, a monitor that never got scheduled at all would leave
+                # `_last_successful_poll` unset and look identical to one that
+                # tried and failed.
+                if calls["n"] >= 2:
+                    failed_twice.set()
                 raise RuntimeError("metadata server unreachable")
 
             router.fetch_live_servers = always_fails
             # The real entry point: it is what records the monitor's start.
             await router.start_server_monitoring(poll_interval=0.01)
-            await asyncio.sleep(0.1)
 
-            # The precondition for the fail-open: alive, never succeeded, and
-            # still holding the list it was constructed with.
-            alive = not router._monitor_task.done()
-            never_succeeded = router._last_successful_poll is None
-            servers = list(router.servers)
+            async def body():
+                await _await_progress(failed_twice, "retry after a failed poll")
 
-            c = _coordinator(["ctx0"], [])
-            c._gen_router = router
-            c._monitor_staleness_secs = 0.05
-            ready = await c.is_ready()
+                # The precondition for the fail-open: alive, never succeeded,
+                # and still holding the list it was constructed with.
+                alive = not router._monitor_task.done()
+                never_succeeded = router._last_successful_poll is None
+                servers = list(router.servers)
 
-            # A generous window must NOT report stale, or a merely slow first
-            # poll would flap /health during startup.
-            c._monitor_staleness_secs = 30.0
-            ready_in_generous_window = await c.is_ready()
+                # Age the monitor deterministically instead of waiting out a
+                # real bound: the assertion is about the staleness arithmetic,
+                # and tying it to wall-clock would put CI load back in the
+                # loop. 60s of failing polls against a 30s bound.
+                router._monitor_started_at -= 60.0
 
-            await router.stop_server_monitoring()
-            return alive, never_succeeded, servers, ready, ready_in_generous_window
+                c = _coordinator(["ctx0"], [])
+                c._gen_router = router
+                c._monitor_staleness_secs = 30.0
+                ready = await c.is_ready()
 
-        alive, never_succeeded, servers, ready, generous = asyncio.run(scenario())
+                # A window the monitor has not yet outlived must NOT report
+                # stale, or a merely slow first poll would flap /health during
+                # startup.
+                c._monitor_staleness_secs = 300.0
+                generous = await c.is_ready()
+                return alive, never_succeeded, servers, ready, generous, calls["n"]
+
+            return await _run_monitored(router, body)
+
+        alive, never_succeeded, servers, ready, generous, n_calls = asyncio.run(scenario())
         assert alive, "monitor died; this test is meant to cover the still-running case"
+        assert n_calls >= 2, "the monitor never actually retried a failing poll"
         assert never_succeeded, "no poll should have succeeded"
         assert servers == ["gen0"], "the un-refreshed initial list is what readiness must not trust"
         assert ready is False, (

--- a/tests/unittest/others/test_disagg_readiness_after_startup.py
+++ b/tests/unittest/others/test_disagg_readiness_after_startup.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""/health must stop promising readiness once a worker is gone.
+
+Without a cluster manager ``is_ready()`` used to be an unconditional ``True``.
+That made ``/health`` a promise about startup rather than a statement about the
+workers: a ctx or gen worker could die afterwards and the coordinator kept
+answering 200 for it, so a polling client had no way to learn the group was
+unusable and waited out its whole timeout.
+
+These tests exercise ``is_ready`` directly against stub routers -- no server,
+no GPU, no event loop beyond ``asyncio.run``.
+"""
+
+import asyncio
+
+import pytest
+
+from tensorrt_llm.serve.disagg_coordinator import DisaggCoordinatorService
+
+
+class _StubRouter:
+    """Just the surface ``is_ready`` touches."""
+
+    def __init__(self, servers):
+        self._servers = list(servers)
+
+    @property
+    def servers(self):
+        return self._servers
+
+    @property
+    def num_prepared_servers(self):
+        return len(self._servers)
+
+
+def _coordinator(ctx_servers, gen_servers, cluster_manager=None):
+    """An DisaggCoordinatorService with only the readiness surface populated.
+
+    __init__ builds sessions and config we do not need, so the object is
+    created without running it -- the method under test reads three attributes.
+    """
+    c = object.__new__(DisaggCoordinatorService)
+    c._ctx_router = _StubRouter(ctx_servers)
+    c._gen_router = _StubRouter(gen_servers)
+    c._disagg_cluster_manager = cluster_manager
+    return c
+
+
+def _ready(c):
+    return asyncio.run(c.is_ready())
+
+
+def test_ready_while_both_roles_have_servers():
+    assert _ready(_coordinator(["ctx0"], ["gen0"])) is True
+
+
+@pytest.mark.parametrize(
+    "ctx,gen,gone",
+    [
+        ([], ["gen0"], "context"),
+        (["ctx0"], [], "generation"),
+        ([], [], "both"),
+    ],
+)
+def test_not_ready_once_a_role_has_no_servers(ctx, gen, gone):
+    """The regression: this returned True for every one of these."""
+    assert _ready(_coordinator(ctx, gen)) is False, (
+        f"coordinator reported ready with no {gone} server"
+    )
+
+
+def test_recovers_when_the_worker_comes_back():
+    """Deliberately not sticky.
+
+    A metadata-driven deployment adds and removes workers as a matter of
+    course. Latching 'dead' on the first removal would turn a routine topology
+    change into a permanently unhealthy coordinator.
+    """
+    c = _coordinator(["ctx0"], ["gen0"])
+    assert _ready(c) is True
+    c._gen_router._servers.clear()  # worker dies
+    assert _ready(c) is False
+    c._gen_router._servers.append("gen1")  # replacement arrives
+    assert _ready(c) is True
+
+
+def test_cluster_manager_path_is_untouched():
+    """With a cluster manager, readiness is still delegated to it verbatim."""
+    seen = {}
+
+    class _CM:
+        async def is_ready_with_router(self, n_ctx, n_gen):
+            seen["args"] = (n_ctx, n_gen)
+            return False  # distinct from what the fallback would say
+
+    c = _coordinator(["ctx0", "ctx1"], ["gen0"], cluster_manager=_CM())
+    assert _ready(c) is False, "the cluster manager's verdict must win"
+    assert seen["args"] == (2, 1), "router counts are forwarded unchanged"
+
+
+def test_static_deployment_is_unchanged():
+    """No metadata server means no monitor, so the lists never shrink.
+
+    That deployment shape keeps exactly its old behaviour -- the point of
+    keying off the server lists rather than adding a new liveness source.
+    """
+    c = _coordinator(["ctx0"], ["gen0"])
+    for _ in range(5):
+        assert _ready(c) is True


### PR DESCRIPTION
## The bug

Without a cluster manager, `DisaggCoordinatorService.is_ready()` ended in an unconditional `return True`.

That made `/health` a statement about *startup having completed*, not about the workers. Once startup finished, a ctx or gen worker could die and the coordinator kept answering **200 OK on its behalf**. A client polling `/health` had no way to learn the group was unusable, so it waited out its entire timeout against a server that could never respond.

This is distinct from a crash *during* startup — that case is connection-refused and is handled elsewhere. This one is about everything after startup succeeds.

## The information was already being collected

When a metadata server is configured, the routers already discover this and nothing consulted them:

- `Router._monitor_servers()` polls on an interval
- `check_servers_health()` filters to live servers
- a dead worker is dropped from `Router.servers`

## The fix

Key readiness off the router server lists. An empty list is unambiguous — disaggregated serving needs at least one context **and** one generation server, so zero of either cannot be served whatever the cause.

Two things in `Router` had to change before that predicate could mean anything. Both were found in review, and both were cases where the coordinator failed *open*:

**The empty state had to be reachable.** `_filter_servers_by_role()` raised `RuntimeError` on an empty live list and the monitor's `except` re-raised, so the task died with `self._servers` frozen on its last known-good value. The role could never be observed as gone — the exact case in the PR title. It now returns `[]`, and a failed poll is logged and retried instead of ending the loop.

**A monitor that has stopped keeping up must not be trusted.** Once a failed poll no longer kills the task, "the list is fresh" stops being implied by "the task is alive". `monitoring_is_stale()` reports a monitor that has ended, or that has not completed a poll within a few refresh intervals, and readiness fails closed on it. The reference point is the last successful poll, falling back to the monitor's start time — otherwise a monitor that has *never* succeeded (metadata unreachable from startup onwards, while the routers still hold the static list from the disagg config) would never age into staleness, and `/health` would promise readiness forever.

## Deliberate choices

**Not sticky.** A metadata-driven deployment adds and removes workers as a matter of course. Latching "dead" on the first removal would turn a routine topology change into a permanently unhealthy coordinator. This reports the current fact, so recovery shows up as recovery.

**A slow first poll is not staleness.** Only a poll that has not landed within the bound is. Reporting not-ready while startup is still converging would flap `/health` on every deployment — a worse failure than the one being fixed.

**Static deployments are unchanged.** With no metadata server there is no monitor, the lists never shrink, and readiness stays `True` exactly as before. That deployment shape still has no post-startup liveness signal; this PR does not claim to fix it.

**Generation-only benchmark mode is exempt from the context requirement.** `TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1` intentionally configures no context servers, so readiness requires a generation server always and a context server only when that mode is off.

**Cluster-manager path untouched.** It still delegates to `is_ready_with_router()` verbatim, with the router counts forwarded unchanged.

## Tests

`tests/unittest/others/test_disagg_readiness_after_startup.py` — no GPU, no server. Two layers, deliberately:

**`TestReadinessPredicate`** drives `is_ready()` against stub routers: ready while both roles have servers; **not** ready with no ctx, no gen, or neither (the regression — all three returned `True` before); recovery when a replacement worker arrives; the cluster manager's verdict wins with its arguments forwarded unchanged; the static deployment shape unchanged across repeated calls; generation-only mode needs no context server; stale monitoring fails closed.

**`TestMonitorDrivesReadiness`** drives a real `RoundRobinRouter` through `_monitor_servers()` with a stubbed metadata server. This layer exists because the predicate layer cannot observe whether the monitor ever *produces* the states it assumes — which is why the original revision keyed readiness off an empty list that could not occur. It asserts the empty-role transition is actually published; that the loop survives a failing poll; that a dead monitor reports stale; that a static router never does; and that a monitor which never succeeds still ages into staleness.

The file carries `pytest.mark.cpu_only` and is collected by `l0_cpu.yml` through its `unittest/others` directory entry.

## Validation status

**Readiness logic and its tests: verified on hardware.** Built from source at `c2f61a4` on an H100
node and ran the real suite — 15 passed; 15 again under `-m cpu_only`; the existing
`tests/unittest/disaggregated/test_router.py` still 86 passed; and with `router.py` reverted to
before the fail-open fix, exactly the one intended test fails and the other 14 pass. Repeat runs are
clean both idle (12/12) and under ~2x CPU oversubscription on 48 cores (12/12). Details in
[this comment](https://github.com/NVIDIA/TensorRT-LLM/pull/17206#issuecomment-5448708318).

**Still outstanding:** an end-to-end disagg deployment with a worker killed mid-benchmark. The unit
coverage above exercises the readiness predicate and the monitor that feeds it, not a real cluster.

*Note on CI collection:* the auto-generated summary below repeats that the test file has no
`test-db/` entry. It is reached through the directory entry `unittest/others` at
`tests/integration/test_lists/test-db/l0_cpu.yml:104`, combined with the file's `pytest.mark.cpu_only`
marker — confirmed by the `-m cpu_only` run above collecting all 15 tests. No per-file entry is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Readiness now fails closed when required workers are unavailable or monitoring is stale.
- Router monitoring publishes empty role lists, retries failed polls, and tracks monitor freshness correctly.
- Generation-only mode does not require context workers.
- Static deployments and cluster-manager behavior remain unchanged.
- No configuration or test-list changes were found.
- Live disaggregated deployment validation remains outstanding.

## QA Engineer Review

- Added `tests/unittest/others/test_disagg_readiness_after_startup.py`.
- Added tests for readiness predicates, worker recovery, cluster-manager delegation, static deployments, generation-only mode, stale monitors, monitor recovery, empty server lists, and dead monitors.
- The test file has no entry in `tests/integration/test_lists/test-db/` or `tests/integration/test_lists/qa/`.
- Verdict: insufficient. CPU-only coverage exists, but CI test-list coverage and live disaggregated deployment validation remain outstanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
