### PR TITLE
[https://nvbugs/6550126][fix] Renamed the integration test's kwarg and its constant to…

### DIFF
--- a/tests/integration/defs/examples/visual_gen/test_visual_gen.py
+++ b/tests/integration/defs/examples/visual_gen/test_visual_gen.py
@@ -96,8 +96,8 @@ WAN22_LPIPS_FRAME_RATE = 16.0
 
 # QwenImage (text-to-image) — default-setting LPIPS golden.
 # Params mirror the QwenImage 20B reference defaults (pipeline_qwen_image.py).
-# NOTE: QwenImage's forward CFG knob is ``true_cfg_scale`` (not ``guidance_scale``),
-# and real-CFG only engages when a negative prompt is supplied.
+# NOTE: QwenImage's forward CFG knob is ``negative_prompt_cfg_scale`` (not
+# ``guidance_scale``), and negative-prompt CFG only engages when it is > 1.0.
 QWENIMAGE_MODEL_SUBPATH = "qwen-image"
 QWEN_IMAGE_EDIT_MODEL_SUBPATH = "Qwen-Image-Edit-2511"
 QWENIMAGE_LPIPS_PROMPT = "a tiny astronaut hatching from an egg on the moon"
@@ -105,7 +105,7 @@ QWENIMAGE_LPIPS_NEGATIVE_PROMPT = ""
 QWENIMAGE_LPIPS_HEIGHT = 1328
 QWENIMAGE_LPIPS_WIDTH = 1328
 QWENIMAGE_LPIPS_NUM_INFERENCE_STEPS = 50
-QWENIMAGE_LPIPS_TRUE_CFG_SCALE = 4.0
+QWENIMAGE_LPIPS_NEGATIVE_PROMPT_CFG_SCALE = 4.0
 QWENIMAGE_LPIPS_SEED = 42
 QWENIMAGE_LPIPS_THRESHOLD = 0.05
 QWEN_IMAGE_LAYERED_LPIPS_PROMPT = ""
@@ -890,7 +890,7 @@ def _generate_qwenimage_lpips_image(model_path, output_path, *, enable_cuda_grap
                 height=QWENIMAGE_LPIPS_HEIGHT,
                 width=QWENIMAGE_LPIPS_WIDTH,
                 num_inference_steps=QWENIMAGE_LPIPS_NUM_INFERENCE_STEPS,
-                true_cfg_scale=QWENIMAGE_LPIPS_TRUE_CFG_SCALE,
+                negative_prompt_cfg_scale=QWENIMAGE_LPIPS_NEGATIVE_PROMPT_CFG_SCALE,
                 seed=QWENIMAGE_LPIPS_SEED,
             )
         generated_image = result.image[0].detach().cpu()

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -137,8 +137,6 @@ examples/test_ray.py::test_ray_disaggregated_serving[tp2] SKIP (https://nvbugs/5
 examples/visual_gen/test_visual_gen.py::test_cosmos3_nano_t2i_lpips_against_golden SKIP (https://nvbugs/6418815)
 examples/visual_gen/test_visual_gen.py::test_cosmos3_nano_t2v_lpips_against_golden SKIP (https://nvbugs/6437341)
 examples/visual_gen/test_visual_gen.py::test_ltx2_cuda_graph_trtllm_backend SKIP (https://nvbugs/6463822)
-examples/visual_gen/test_visual_gen.py::test_qwenimage_cuda_graph_lpips_against_golden SKIP (https://nvbugs/6550126)
-examples/visual_gen/test_visual_gen.py::test_qwenimage_lpips_against_golden SKIP (https://nvbugs/6550126)
 examples/visual_gen/test_visual_gen.py::test_wan22_t2v_lpips_against_golden SKIP (https://nvbugs/6535765)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[cfg2_ulysses2] SKIP (https://nvbugs/6535765)
 examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_golden_multi_gpu[ulysses4] SKIP (https://nvbugs/6535765)


### PR DESCRIPTION
## Summary
- **Root cause**: PR #16384 (commit c083da6b64, "Qwen Image CFG parallelism") renamed `QwenImagePipeline.forward()`'s CFG kwarg `true_cfg_scale` → `negative_prompt_cfg_scale` and updated the three unit-test files, but left the integration LPIPS call site on the old name, so `forward()` raised `TypeError: unexpected keyword argument 'true_cfg_scale'`.
- **Fix**: Renamed the integration test's kwarg and its constant to `negative_prompt_cfg_scale` / `QWENIMAGE_LPIPS_NEGATIVE_PROMPT_CFG_SCALE`, corrected the stale explanatory comment, and removed the two now-obsolete `waives.txt` entries for this bug (the Qwen-Image-**Layered** call site at line 980 correctly keeps `true_cfg_scale`, since that pipeline's signature is unchanged).
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6550126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dev Engineer Review

- Renamed the Qwen Image LPIPS argument and constant from `true_cfg_scale` to `negative_prompt_cfg_scale`.
- Updated the activation comment to match `QwenImagePipeline.forward()`.
- Preserved `true_cfg_scale` for Qwen-Image-Layered because its API is unchanged.
- Removed two obsolete QwenImage entries from `waives.txt`.
- The affected LPIPS tests previously raised `TypeError`. The numerical result remains `0.009006`.
- The changes are consistent with the updated API and do not change test scope or performance.

## QA Engineer Review

- Modified the Qwen Image LPIPS test configuration in `tests/integration/defs/examples/visual_gen/test_visual_gen.py`.
- The CUDA-graph and LPIPS golden-comparison waiver entries were removed from `tests/integration/test_lists/waives.txt`.
- No test functions were added, modified, or removed.
- The affected tests are no longer waived and are covered by the existing visual-generation test configuration.
- Verdict: sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->