### PR TITLE
[https://nvbugs/6550275][fix] Bound V2 residency for non-droppable state pools

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2151,6 +2151,43 @@ class KVCacheManagerV2(BaseResourceManager):
         kv_cache = self.kv_cache_map.get(request_id)
         return kv_cache is not None and kv_cache.is_active
 
+    def max_resident_sequences(self) -> Optional[int]:
+        """Upper bound on sequences that can co-reside at ``max_seq_len``.
+
+        MAX_UTILIZATION admits new sequences up to ``max_batch_size`` and
+        relies on suspend/resume to survive over-subscription. That recovery
+        only works while some resident sequence can still be evicted to free
+        the pages a suspended one needs to resume. A sequence whose state is
+        non-droppable (a hybrid Mamba recurrent state is fixed-size per
+        sequence and cannot be recomputed from tokens) contributes no
+        evictable pages, so once every sequence is suspended the pool can no
+        longer drain and the scheduler makes no further progress.
+
+        Returns None when no such non-droppable pool exists, keeping the
+        unbounded MAX_UTILIZATION behavior for plain attention models.
+        """
+        state_pool_groups = {
+            pool_group_id
+            for pool_group_id, _, kind in self._stats_life_cycle_metadata().values()
+            if kind != "attention"
+        }
+        if not state_pool_groups:
+            return None
+
+        # Charging every attention pool the full max_seq_len is deliberately
+        # worst-case: a genuinely sliding-window pool needs fewer pages per
+        # sequence, so the bound errs low rather than over-admitting.
+        pages_per_seq = math.ceil(self.max_seq_len / self.tokens_per_block)
+        # A state pool holds one fixed slot per sequence; an attention pool
+        # must hold every page of each resident sequence.
+        return max(
+            1,
+            min(
+                stat.total // (1 if pool_group_id in state_pool_groups else pages_per_seq)
+                for pool_group_id, stat in enumerate(self._get_storage_statistics(GPU_LEVEL))
+            ),
+        )
+
     def _effective_draft_len(self, req: LlmRequest) -> int:
         """Draft token length to use for next-step KV capacity calculation.
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -2165,11 +2165,23 @@ class KVCacheManagerV2(BaseResourceManager):
         evictable pages, so once every sequence is suspended the pool can no
         longer drain and the scheduler makes no further progress.
 
-        Returns None when no such non-droppable pool exists, keeping the
-        unbounded MAX_UTILIZATION behavior for plain attention models.
+        Returns None when no rank has such a non-droppable pool, keeping the
+        unbounded MAX_UTILIZATION behavior for plain attention models. When
+        one exists, every rank contributes its local full-sequence capacity
+        so pipeline-parallel ranks admit the same request set even when some
+        ranks contain only attention layers or no local layers.
         """
         life_cycle_metadata = self._stats_life_cycle_metadata()
-        if not any(kind != "attention" for _, _, kind in life_cycle_metadata.values()):
+        has_non_droppable_pool = any(
+            kind != "attention" for _, _, kind in life_cycle_metadata.values()
+        )
+        dist = None
+        if self.mapping.world_size > 1:
+            dist = Distributed.get(self.mapping)
+            has_non_droppable_pool = bool(
+                dist.allreduce(int(has_non_droppable_pool), op=ReduceOp.MAX)
+            )
+        if not has_non_droppable_pool:
             return None
 
         # A physical group can host multiple lifecycle variants. V2 allocates
@@ -2179,14 +2191,20 @@ class KVCacheManagerV2(BaseResourceManager):
         for pool_group_id, _, kind in life_cycle_metadata.values():
             slots_per_pool_group[pool_group_id] += attention_slots if kind == "attention" else 1
 
-        storage_stats = self._get_storage_statistics(GPU_LEVEL)
-        return max(
-            1,
-            min(
+        if slots_per_pool_group:
+            storage_stats = self._get_storage_statistics(GPU_LEVEL)
+            local_capacity = min(
                 storage_stats[pool_group_id].total // slots_per_sequence
                 for pool_group_id, slots_per_sequence in slots_per_pool_group.items()
-            ),
-        )
+            )
+        else:
+            # A PP rank with no local cache layers must not constrain ranks
+            # that do own physical cache pools.
+            local_capacity = sys.maxsize
+
+        if dist is not None:
+            local_capacity = dist.allreduce(local_capacity, op=ReduceOp.MIN)
+        return max(1, int(local_capacity))
 
     def _effective_draft_len(self, req: LlmRequest) -> int:
         """Draft token length to use for next-step KV capacity calculation.

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -183,6 +183,9 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.chunk_unit_size = 0
         self.max_context_length = max_num_tokens
         self.tokens_per_block = kv_cache_manager.tokens_per_block
+        # Cap on concurrently-started sequences, None when unbounded. See
+        # KVCacheManagerV2.max_resident_sequences() for why it is needed.
+        self.max_resident_sequences = kv_cache_manager.max_resident_sequences()
         draft_mgr_name = (
             type(draft_kv_cache_manager).__name__ if draft_kv_cache_manager is not None else "None"
         )
@@ -192,6 +195,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         logger.info(
             f"KVCacheV2Scheduler: tokens_per_block={self.tokens_per_block}, "
             f"max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}, "
+            f"max_resident_sequences={self.max_resident_sequences}, "
             f"draft_mgr={draft_mgr_name}, cross_mgr={cross_mgr_name}, "
             f"enable_prefix_aware_scheduling={enable_prefix_aware_scheduling}"
         )
@@ -400,8 +404,24 @@ class KVCacheV2Scheduler(RequestScheduler):
 
         # --- Phase 2: schedule deferred context / encoder requests ---
         # Generation PEFT pages are now fully committed in the budget.
+        #
+        # Starting a new sequence is what grows the resident set, so the
+        # residency cap is enforced here. Requests already started keep
+        # their slot; the rest wait in the queue until one drains.
+        residency_cap = self.max_resident_sequences
+        num_started = (
+            sum(1 for r in requests_list if self._is_started_request(r))
+            if residency_cap is not None
+            else 0
+        )
+
         for req in pending_ctx:
             if budget.requests_full:
+                break
+            # Read before scheduling: _try_schedule_context advances the
+            # request past its first chunk.
+            is_new_sequence = residency_cap is not None and req.is_first_context_chunk
+            if is_new_sequence and num_started >= residency_cap:
                 break
             peft_pages = budget.peft_pages_needed(req)
             if peft_pages is None:
@@ -418,6 +438,8 @@ class KVCacheV2Scheduler(RequestScheduler):
                     break
                 if action is ScheduleAction.SKIP:
                     continue
+                if is_new_sequence:
+                    num_started += 1
                 has_chunking = has_chunking or chunking_flag
                 scheduled_ctx.append(req)
                 budget.commit(req, tokens, peft_pages)

--- a/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_manager_v2.py
@@ -13,13 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import torch
 
+from tensorrt_llm._torch.distributed.communicator import ReduceOp
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import BlockReusePolicy, KVCacheManagerV2
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings import DataType
@@ -48,8 +50,10 @@ def _make_residency_manager(
     reserve_draft_tokens: int,
     life_cycle_metadata: dict[int, tuple[int, int | None, str]],
     pool_group_totals: list[int],
+    world_size: int = 1,
 ) -> KVCacheManagerV2:
     manager = object.__new__(KVCacheManagerV2)
+    manager.mapping = SimpleNamespace(world_size=world_size)
     manager.max_seq_len = max_seq_len
     manager.tokens_per_block = tokens_per_block
     manager.num_extra_kv_tokens = num_extra_kv_tokens
@@ -101,6 +105,74 @@ def test_max_resident_sequences_sums_coalesced_life_cycles() -> None:
 
     # Each sequence consumes 2 + 1 + 2 slots from the shared physical group.
     assert manager.max_resident_sequences() == 10
+
+
+def test_max_resident_sequences_returns_none_for_attention_only() -> None:
+    manager = _make_residency_manager(
+        max_seq_len=31,
+        tokens_per_block=16,
+        num_extra_kv_tokens=0,
+        reserve_draft_tokens=0,
+        life_cycle_metadata={0: (0, 31, "attention")},
+        pool_group_totals=[4],
+    )
+
+    assert manager.max_resident_sequences() is None
+
+
+def test_max_resident_sequences_floors_zero_capacity_at_one() -> None:
+    manager = _make_residency_manager(
+        max_seq_len=31,
+        tokens_per_block=16,
+        num_extra_kv_tokens=0,
+        reserve_draft_tokens=0,
+        life_cycle_metadata={0: (0, None, "ssm")},
+        pool_group_totals=[0],
+    )
+
+    assert manager.max_resident_sequences() == 1
+
+
+def test_max_resident_sequences_syncs_attention_only_pp_rank() -> None:
+    manager = _make_residency_manager(
+        max_seq_len=31,
+        tokens_per_block=16,
+        num_extra_kv_tokens=0,
+        reserve_draft_tokens=0,
+        life_cycle_metadata={0: (0, 31, "attention")},
+        pool_group_totals=[8],
+        world_size=2,
+    )
+
+    with patch("tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2.Distributed.get") as get_dist:
+        get_dist.return_value.allreduce.side_effect = [1, 3]
+
+        assert manager.max_resident_sequences() == 3
+
+        get_dist.return_value.allreduce.assert_has_calls(
+            [call(0, op=ReduceOp.MAX), call(4, op=ReduceOp.MIN)]
+        )
+
+
+def test_max_resident_sequences_ignores_pp_rank_without_cache_layers() -> None:
+    manager = _make_residency_manager(
+        max_seq_len=31,
+        tokens_per_block=16,
+        num_extra_kv_tokens=0,
+        reserve_draft_tokens=0,
+        life_cycle_metadata={},
+        pool_group_totals=[],
+        world_size=2,
+    )
+
+    with patch("tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2.Distributed.get") as get_dist:
+        get_dist.return_value.allreduce.side_effect = [1, 7]
+
+        assert manager.max_resident_sequences() == 7
+
+        get_dist.return_value.allreduce.assert_has_calls(
+            [call(0, op=ReduceOp.MAX), call(sys.maxsize, op=ReduceOp.MIN)]
+        )
 
 
 class _FakeKVCache:

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -160,6 +160,7 @@ def make_kv_cache_manager(
     resize_context_fn=None,
     prepare_disagg_gen_init_fn=None,
     try_allocate_generation_fn=None,
+    max_resident_sequences=None,
 ):
     mgr = Mock()
     mgr.tokens_per_block = tokens_per_block
@@ -170,6 +171,9 @@ def make_kv_cache_manager(
     mgr.try_allocate_generation.side_effect = try_allocate_generation_fn or (lambda req: True)
     mgr.suspend_request.return_value = None
     mgr.is_request_active.side_effect = lambda req_id: mgr.kv_cache_map[req_id].is_active
+    # Must be pinned: a bare Mock() is not None, so the scheduler's residency
+    # gate would compare an int against a child Mock and raise TypeError.
+    mgr.max_resident_sequences.return_value = max_resident_sequences
     return mgr
 
 
@@ -2215,6 +2219,53 @@ class TestEdgeCases:
         assert ids(out.fitting_disagg_gen_init_requests) == [1]
         assert ids(out.generation_requests) == [2]
         assert ids(out.context_requests) == [4]
+
+
+# ===========================================================================
+# Residency Cap (non-droppable state pools)
+# ===========================================================================
+
+
+class TestResidencyCap:
+    """A manager reporting max_resident_sequences bounds newly started
+    sequences, so a pool whose state cannot be evicted never over-subscribes.
+    """
+
+    def test_none_leaves_admission_unbounded(self):
+        """Plain attention models report None and keep MAX_UTILIZATION behavior."""
+        mgr = make_kv_cache_manager(max_resident_sequences=None)
+        sched = make_scheduler(mgr)
+        reqs = [make_ctx_request(i, context_remaining_length=10) for i in range(20)]
+        out = sched.schedule_request(reqs, set())
+        assert len(out.context_requests) == 20
+
+    def test_caps_newly_started_sequences(self):
+        mgr = make_kv_cache_manager(max_resident_sequences=3)
+        sched = make_scheduler(mgr)
+        reqs = [make_ctx_request(i, context_remaining_length=10) for i in range(20)]
+        out = sched.schedule_request(reqs, set())
+        assert ids(out.context_requests) == [0, 1, 2]
+
+    def test_already_started_sequences_consume_the_cap(self):
+        """In-progress generation holds its slot, so no new context is admitted."""
+        mgr = make_kv_cache_manager(max_resident_sequences=2)
+        sched = make_scheduler(mgr)
+        reqs = [
+            make_gen_request(0),
+            make_gen_request(1),
+            make_ctx_request(2, context_remaining_length=10),
+        ]
+        out = sched.schedule_request(reqs, set())
+        assert ids(out.generation_requests) == [0, 1]
+        assert ids(out.context_requests) == []
+
+    def test_continuing_chunk_is_not_charged_again(self):
+        """Only a first chunk starts a sequence; later chunks keep their slot."""
+        mgr = make_kv_cache_manager(max_resident_sequences=1)
+        sched = make_scheduler(mgr)
+        req = make_ctx_request(0, context_remaining_length=10, is_first_context_chunk=False)
+        out = sched.schedule_request([req], set())
+        assert ids(out.context_requests) == [0]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- **Regression and exact V1/V2 difference:** PR #16598 enabled KV-cache manager V2 by default for Qwen3 Next. V1 honors the default `GUARANTEED_NO_EVICT` policy and reserves the blocks needed to finish a request before admitting it. V2 currently replaces every non-`MAX_UTILIZATION` policy with `MAX_UTILIZATION`, budgets only the next scheduling step, and relies on suspend/resume to recover from over-admission.
- **Root cause:** the failing L40S workload admitted 485 requests although the limiting physical cache pool could keep only about 118 full-length sequences resident. Hybrid Mamba recurrent state is non-droppable and cannot be reconstructed from token IDs. With no effective host tier, over-admission eventually left every generation request suspended while no request could be evicted to free the pages needed for resume, producing the V2 no-progress deadlock.
- **Fix:** derive a conservative resident-sequence bound from full per-sequence capacity (including extra KV, draft reserve, and base decode tokens), sum lifecycle costs that share a physical pool, and enforce the bound for both context and disaggregated-generation admission. Plain attention models keep the existing unbounded behavior.
- **Distributed safety:** synchronize both the presence of non-droppable state and the minimum full-sequence capacity across ranks. Attention-only and zero-local-layer PP ranks therefore admit exactly the same request set as ranks that own Mamba state.
- Automated fix initially generated by repair-bot and completed with review follow-ups.

## Test plan

- [x] Existing direct capacity/rounding/coalesced-pool regressions (4 passed on the previous PR head)
- [x] Existing V2 scheduler regressions, including disaggregated transfer accounting (179 passed on the previous PR head)
- [x] Added attention-only, zero-capacity floor, attention-only PP-rank, and zero-local-layer PP-rank coverage
- [x] Relevant pre-commit hooks, including Ruff, Ruff format, codespell, DCO, and test-list validation
- Standard CI rerun for `ce537324a3` is in progress.

## Links

- Bug: https://nvbugs/6550275
