### PR TITLE
[https://nvbugs/6550708][fix] initialize profiler in Cosmos3 test fixture

### DIFF
--- a/tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py
+++ b/tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py
@@ -24,6 +24,7 @@ from tensorrt_llm._torch.visual_gen.models.cosmos3.sampling import (
     load_scheduler,
 )
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PIPELINE_REGISTRY, AutoPipeline
+from tensorrt_llm._torch.visual_gen.profiler import VisualGenProfiler
 
 pytestmark = [pytest.mark.cosmos3, pytest.mark.usefixtures("disable_cosmos3_guardrails")]
 
@@ -527,10 +528,8 @@ def _denoise_ready_pipeline() -> Cosmos3OmniMoTPipeline:
     return _bare_pipeline(
         pipeline_config=SimpleNamespace(visual_gen_mapping=None),
         cache_accelerator=None,
-        _predenoise_pending=False,
-        _postdenoise_pending=False,
         _is_warmup=False,
-        _profile_range=None,
+        _profiler=VisualGenProfiler(),
     )
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Updated `tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py`.
- Initialized `_denoise_ready_pipeline` with `VisualGenProfiler`.
- Removed obsolete profiler state fields.
- The fixture now matches the current `BasePipeline` contract and the equivalent Qwen fixture.
- The change is test-only and has low regression risk.
- No public entities, configuration files, or test-list files changed.

## QA Engineer Review

- Modified the Cosmos3 distilled denoise test fixture.
- No test functions were added, modified, or removed.
- The existing four Cosmos3 denoise unit tests now receive the required `_profiler` dependency.
- No `tests/integration/test_lists/` coverage entry was changed.
- Validation reported 87 tests passing.
- Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes NVBug 6550708, which causes four Cosmos3 distilled denoise unit tests to fail after the VisualGen profiler refactor.

The test fixture constructs `Cosmos3OmniMoTPipeline` with `object.__new__`, bypassing `BasePipeline.__init__`. It still initialized the removed `_predenoise_pending`, `_postdenoise_pending`, and `_profile_range` fields, while the denoise path now expects `_profiler` to exist.

Initialize the fixture with `VisualGenProfiler`, matching the current pipeline contract and the equivalent Qwen test fixture. This is a test-only change and does not affect runtime behavior.

## Test Coverage

- H100, tekit container:
  - `python3 -m pytest -q tests/unittest/_torch/visual_gen/test_cosmos3_distilled.py`
  - `87 passed, 3 warnings in 1.88s`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
