### PR TITLE
[None][perf] Qwen3.5 piecewise graphs optimization

### DIFF
--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -69,6 +69,10 @@ def inplace_info():
             1: "input",
             2: "residual"
         },
+        torch.ops.trtllm.flashinfer_gemma_fused_add_rmsnorm.default: {
+            1: "input",
+            2: "residual"
+        },
         torch.ops.trtllm.flashinfer_fused_add_rmsnorm_quant.default: {
             1: "out",
             2: "residual"

--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -84,6 +84,9 @@ def inplace_info():
         torch.ops.trtllm.fused_qk_norm_rope.default: {
             1: "qkv"
         },
+        torch.ops.trtllm.fused_sigmoid_mul.default: {
+            1: "attention_output"
+        },
         torch.ops.trtllm.fused_dit_qk_norm_rope.default: {
             1: "qkv"
         },

--- a/tensorrt_llm/_torch/modules/fused_ops/fused_qk_norm_rope_gate.py
+++ b/tensorrt_llm/_torch/modules/fused_ops/fused_qk_norm_rope_gate.py
@@ -23,7 +23,7 @@ unchanged avoids coupling the optimization to weight loading, quantization,
 LoRA, or attention-backend fallback behavior.
 """
 
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 import triton
@@ -162,6 +162,7 @@ def _fused_qkv_gemma_rmsnorm_rope_gate_kernel(
         tl.store(output_base + head_offsets, value, mask=head_mask)
 
 
+@torch.library.custom_op("trtllm::fused_qkv_gemma_rmsnorm_rope_gate", mutates_args=())
 def fused_qkv_gemma_rmsnorm_rope_gate(
     qkv: torch.Tensor,
     q_weight: torch.Tensor,
@@ -173,7 +174,7 @@ def fused_qkv_gemma_rmsnorm_rope_gate(
     num_kv_heads: int,
     head_dim: int,
     rotary_dim: int,
-    mrope_section: Optional[Tuple[int, int, int]] = None,
+    mrope_section: Optional[List[int]] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Prepare packed QKV and gate with one Triton kernel.
 
@@ -191,7 +192,7 @@ def fused_qkv_gemma_rmsnorm_rope_gate(
         head_dim: Per-head Q/K/V dimension.
         rotary_dim: Prefix dimension receiving NeoX RoPE.
         mrope_section: Temporal/height/width rotary-half dimensions. ``None``
-            selects plain RoPE; a tuple selects Qwen-style interleaved MRoPE.
+            selects plain RoPE; a list selects Qwen-style interleaved MRoPE.
 
     Returns:
         Packed QKV ``[num_tokens, q_size + 2 * kv_size]`` and gate
@@ -265,6 +266,28 @@ def fused_qkv_gemma_rmsnorm_rope_gate(
     return qkv_out, gate_out
 
 
+@fused_qkv_gemma_rmsnorm_rope_gate.register_fake
+def _(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    mrope_section: Optional[List[int]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = qkv.shape[0]
+    q_size = num_q_heads * head_dim
+    kv_size = num_kv_heads * head_dim
+    qkv_out = qkv.new_empty((num_tokens, q_size + 2 * kv_size))
+    gate_out = qkv.new_empty((num_tokens, num_q_heads, head_dim))
+    return qkv_out, gate_out
+
+
 @triton.jit
 def _fused_sigmoid_mul_kernel(
     output_ptr,
@@ -302,13 +325,9 @@ def _fused_sigmoid_mul_kernel(
     )
 
 
-def fused_sigmoid_mul(
-    attention_output: torch.Tensor,
-    gate: torch.Tensor,
-    *,
-    inplace: bool = False,
-) -> torch.Tensor:
-    """Compute ``attention_output * sigmoid(gate)`` in one kernel."""
+@torch.library.custom_op("trtllm::fused_sigmoid_mul", mutates_args=("attention_output",))
+def fused_sigmoid_mul(attention_output: torch.Tensor, gate: torch.Tensor) -> None:
+    """Compute ``attention_output *= sigmoid(gate)`` in one kernel, in place."""
     assert attention_output.dim() == 2 and attention_output.stride(-1) == 1
     num_tokens, hidden_size = attention_output.shape
     if gate.dim() == 3:
@@ -325,18 +344,17 @@ def fused_sigmoid_mul(
         gate_stride_token = gate.stride(0)
         gate_stride_head = hidden_size
 
-    output = attention_output if inplace else torch.empty_like(attention_output)
     if num_tokens == 0:
-        return output
+        return
 
     max_block_size = 1024 if num_tokens < 1024 else 2048
     block_size = min(triton.next_power_of_2(hidden_size), max_block_size)
     grid = (num_tokens, triton.cdiv(hidden_size, block_size))
     _fused_sigmoid_mul_kernel[grid](
-        output,
+        attention_output,
         attention_output,
         gate,
-        output.stride(0),
+        attention_output.stride(0),
         attention_output.stride(0),
         gate_stride_token,
         gate_stride_head,
@@ -345,4 +363,8 @@ def fused_sigmoid_mul(
         block_size=block_size,
         num_warps=4,
     )
-    return output
+
+
+@fused_sigmoid_mul.register_fake
+def _(attention_output: torch.Tensor, gate: torch.Tensor) -> None:
+    return None

--- a/tensorrt_llm/_torch/modules/mamba/layernorm_gated.py
+++ b/tensorrt_llm/_torch/modules/mamba/layernorm_gated.py
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
@@ -189,7 +191,7 @@ def _multirow_gated_rmsnorm_eligible(N, ngroups, bias, z, norm_before_gate,
             and ngroups == 1 and N <= _MULTIROW_MAX_N and (N & (N - 1)) == 0)
 
 
-def rms_norm_gated_token_major(x, z, weight, eps, out=None, fp8_scale=None):
+def _rms_norm_gated_token_major(x, z, weight, eps, out=None, fp8_scale=None):
     """rmsnorm(x) * silu(z) with z read in place from a 3D token-major view.
 
     x: [num_tokens * heads, N] with contiguous rows. z: [num_tokens, heads, N]
@@ -246,6 +248,34 @@ def rms_norm_gated_token_major(x, z, weight, eps, out=None, fp8_scale=None):
             num_warps=_MULTIROW_NUM_WARPS,
         )
     return out
+
+
+@torch.library.custom_op("trtllm::rms_norm_gated_token_major", mutates_args=())
+def rms_norm_gated_token_major(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    fp8_scale: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return _rms_norm_gated_token_major(x,
+                                       z,
+                                       weight,
+                                       eps,
+                                       out=None,
+                                       fp8_scale=fp8_scale)
+
+
+@rms_norm_gated_token_major.register_fake
+def _(
+    x: torch.Tensor,
+    z: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    fp8_scale: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    out_dtype = torch.float8_e4m3fn if fp8_scale is not None else x.dtype
+    return torch.empty_like(x, dtype=out_dtype)
 
 
 def _layer_norm_fwd(

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -29,7 +29,6 @@ from ..modules.fused_ops.fused_qk_norm_rope_gate import (
     fused_qkv_gemma_rmsnorm_rope_gate, fused_sigmoid_mul)
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
-from ..utils import is_torch_compiling
 
 
 # Move out from this class
@@ -225,7 +224,7 @@ class QKNormRoPEAttention(Attention):
     def _can_use_fused_qk_norm_rope_gate(
             self, qkv: torch.Tensor,
             position_ids: Optional[torch.Tensor]) -> bool:
-        if not self._fuse_qk_norm_rope_gate or is_torch_compiling():
+        if not self._fuse_qk_norm_rope_gate:
             return False
         if torch.version.hip is not None or qkv.device.type != "cuda":
             return False
@@ -283,19 +282,19 @@ class QKNormRoPEAttention(Attention):
             self.num_key_value_heads,
             self.head_dim,
             self._get_qk_norm_rotary_dim(),
-            tuple(self.pos_embd_params.mrope_section) if use_mrope else None,
+            list(self.pos_embd_params.mrope_section) if use_mrope else None,
         )
         return qkv, None, None, gate
 
     def apply_output_gate(self, attention_output, gate):
-        if (self._fuse_qk_norm_rope_gate and not is_torch_compiling()
-                and torch.version.hip is None
+        if (self._fuse_qk_norm_rope_gate and torch.version.hip is None
                 and attention_output.device.type == "cuda"
                 and attention_output.dim() == 2
                 and attention_output.stride(-1) == 1 and gate.dim() in (2, 3)
                 and gate.stride(-1) == 1
                 and gate.numel() == attention_output.numel()):
-            return fused_sigmoid_mul(attention_output, gate, inplace=True)
+            fused_sigmoid_mul(attention_output, gate)
+            return attention_output
         return super().apply_output_gate(attention_output, gate)
 
     def apply_qk_norm(self, q, k):

--- a/tests/unittest/_torch/modules/fused_ops/test_fused_qk_norm_rope_gate.py
+++ b/tests/unittest/_torch/modules/fused_ops/test_fused_qk_norm_rope_gate.py
@@ -144,8 +144,7 @@ def test_fused_qkv_gemma_rmsnorm_rope_gate_matches_reference(
     torch.testing.assert_close(actual_qkv[:, q_size + kv_size :], qkv[:, 2 * q_size + kv_size :])
 
 
-@pytest.mark.parametrize("inplace", (False, True))
-def test_fused_sigmoid_mul_supports_strided_gate(inplace):
+def test_fused_sigmoid_mul_supports_strided_gate():
     torch.manual_seed(7)
     num_tokens, num_heads, head_dim = 17, 8, 128
     attention = torch.randn((num_tokens, num_heads * head_dim), dtype=torch.bfloat16, device="cuda")
@@ -154,7 +153,8 @@ def test_fused_sigmoid_mul_supports_strided_gate(inplace):
     )
     gate = gate_storage[..., :head_dim]
     expected = attention.float() * torch.sigmoid(gate.reshape(num_tokens, -1).float())
-    actual = fused_sigmoid_mul(attention.clone(), gate, inplace=inplace)
+    actual = attention.clone()
+    fused_sigmoid_mul(actual, gate)  # modifies `actual` in-place
     torch.testing.assert_close(actual.float(), expected, atol=0.02, rtol=0.02)
 
 
@@ -290,5 +290,6 @@ def test_fused_sigmoid_mul_supports_flat_gate():
     attention = torch.randn((9, 512), dtype=torch.float16, device="cuda")
     gate = torch.randn_like(attention)
     expected = attention.float() * torch.sigmoid(gate.float())
-    actual = fused_sigmoid_mul(attention, gate)
+    actual = attention.clone()
+    fused_sigmoid_mul(actual, gate)  # modifies `actual` in-place
     torch.testing.assert_close(actual.float(), expected, atol=0.005, rtol=0.005)


### PR DESCRIPTION
@coderabbitai summary

## Description

This PR has two fixes under `torch.compile` + piecewise graphs for Qwen3.5 models:
1. Register custom ops with in-place semantics in `inplace_info`. This avoids input clones and wasteful D2D copies. 
2. Wrap fused kernels in custom ops and register fake ops. This avoids falling back to unfused pytorch kernels.

***Median ITL for Qwen3.5-4B-FP8, H100 NVL 400W, ISL 10K / OSL 1K, reqs = 5 * concurrency***

| Concurrency |  piecewise=off | piecewise=on pre-PR | piecewise=on post-PR | Speedup with PR (%) |
|---|---|---|---|---|
| 1  | 3.24 | 3.75 | 3.31 | 13.2 |
| 4  | 3.57 | 4.05 | 3.63 | 11.5 |
| 8  | 3.93 | 4.45 | 4.00 | 11.3 |
| 16 | 4.49 | 5.01 | 4.61 | 8.7 |

After this PR, there is still about 2% increase in ITL with piecewise=on.

trllm-serve config:

```max_seq_len: 11000
max_num_tokens: 10100
enable_chunked_prefill: false
enable_attention_dp: false
kv_cache_config:
  free_gpu_memory_fraction: 0.85
  enable_block_reuse: false
cuda_graph_config:
  enable_padding: true
  batch_sizes: [1, 2, 4, 8, 16]
torch_compile_config:         # remove this section to disable piecewise graphs
  enable_fullgraph: true
  enable_piecewise_cuda_graph: true
  max_num_streams: 2
  capture_num_tokens: [10100] # matches max_num_tokens so mixed prefill+decode iters are graph-captured
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

`TestQwen3_5_4B::test_fp8_piecewise_cuda_graph`. Accuracy is unchanged.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
