### PR TITLE
[None][test] Handle MiniMax-M3 FP8 rounding variance

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200_m3.yml
+++ b/tests/integration/test_lists/test-db/l0_b200_m3.yml
@@ -17,3 +17,6 @@ l0_b200_m3:
   - unittest/_torch/attention/sparse/test_minimax_m3_msa_selector.py
   - unittest/_torch/models/test_minimax_m3.py
   - unittest/_torch/models/checkpoints/hf/test_minimaxm3_weight_mapper.py
+  - unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_horizontal_producer.py
+  - unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_indexer.py
+  - unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_main_kv_insert.py

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_indexer.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_indexer.py
@@ -85,8 +85,11 @@ def test_minimax_m3_fp8_indexer_matches_bf16_then_cast(num_tokens):
     q_ref, k_ref = _reference(qk, num_heads_q, q_weight, k_weight, position_ids)
     k_out = cache[pages.long(), 0, within.long()]
 
-    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
-    assert torch.equal(k_out.view(torch.uint8), k_ref.contiguous().view(torch.uint8))
+    # The specialized kernel uses powf while fused_qk_norm_rope uses the
+    # exp2f/log2f equivalent, so values at an FP8 boundary can round to
+    # adjacent E4M3 values.
+    torch.testing.assert_close(q_out.float(), q_ref.float(), rtol=0.13, atol=0.05)
+    torch.testing.assert_close(k_out.float(), k_ref.float(), rtol=0.13, atol=0.05)
 
 
 def test_minimax_m3_fp8_indexer_cuda_graph_replay_updates_outputs():
@@ -122,5 +125,5 @@ def test_minimax_m3_fp8_indexer_cuda_graph_replay_updates_outputs():
     k_out = cache[pages.long(), 0, within.long()]
 
     assert not torch.equal(q_out.view(torch.uint8), first_q.view(torch.uint8))
-    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
-    assert torch.equal(k_out.view(torch.uint8), k_ref.contiguous().view(torch.uint8))
+    torch.testing.assert_close(q_out.float(), q_ref.float(), rtol=0.13, atol=0.05)
+    torch.testing.assert_close(k_out.float(), k_ref.float(), rtol=0.13, atol=0.05)

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_main_kv_insert.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_minimax_m3_fp8_main_kv_insert.py
@@ -112,10 +112,15 @@ def test_minimax_m3_fp8_main_kv_insert_matches_materialize_then_scatter(
     pages = slots.long() // page_size
     within = slots.long() % page_size
 
-    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
-    assert torch.equal(
-        kv_cache[:, 0][pages, :, within, :].view(torch.uint8),
-        k_ref.contiguous().view(torch.uint8),
+    # The specialized kernel uses powf while fused_qk_norm_rope_to_fp8 uses
+    # the exp2f/log2f equivalent, so values at an FP8 boundary can round to
+    # adjacent E4M3 values.
+    torch.testing.assert_close(q_out.float(), q_ref.float(), rtol=0.13, atol=0.05)
+    torch.testing.assert_close(
+        kv_cache[:, 0][pages, :, within, :].float(),
+        k_ref.float(),
+        rtol=0.13,
+        atol=0.05,
     )
     assert torch.equal(
         kv_cache[:, 1][pages, :, within, :].view(torch.uint8),
@@ -155,10 +160,12 @@ def test_minimax_m3_fp8_main_kv_insert_uses_64bit_cache_offsets():
     q_ref, k_ref, v_ref = _reference(qkv, 8, 1, q_weight, k_weight, position_ids)
     torch.cuda.synchronize()
 
-    assert torch.equal(q_out.view(torch.uint8), q_ref.contiguous().view(torch.uint8))
-    assert torch.equal(
-        kv_cache[page, 0, :, 0, :].view(torch.uint8),
-        k_ref[0].contiguous().view(torch.uint8),
+    torch.testing.assert_close(q_out.float(), q_ref.float(), rtol=0.13, atol=0.05)
+    torch.testing.assert_close(
+        kv_cache[page, 0, :, 0, :].float(),
+        k_ref[0].float(),
+        rtol=0.13,
+        atol=0.05,
     )
     assert torch.equal(
         kv_cache[page, 1, :, 0, :].view(torch.uint8),


### PR DESCRIPTION
@coderabbitai summary

## Description

The MiniMax-M3 FP8 indexer and direct KV-insertion tests compared Q/K outputs byte-for-byte with the general fused QK-norm/RoPE reference. The specialized kernels use `powf` for RoPE frequencies, while the optimized reference uses the mathematically equivalent `exp2f`/`log2f` formulation. A small number of values can consequently round to adjacent E4M3 values and fail byte equality despite satisfying the intended FP8 numerical contract.

Compare only normalized/RoPE Q and K numerically using the tolerance already established by the horizontal-producer test. V conversion, cache destinations, guard pages, and CUDA Graph replay updates remain exact. Add the standalone indexer, direct KV-insertion, and active horizontal-producer tests to the B200 MiniMax-M3 pre-merge test list.

## Test Coverage

- Focused B300 validation reproduced every reported shape and confirmed that Q/K differences remain within the established FP8 tolerance; V outputs and cache guard pages remain byte-exact, with no NaNs.
- CUDA Graph replay validation confirms outputs update from replay inputs and cache writes remain correct.
- Changed-files pre-commit checks pass, including Python formatting/linting, YAML validation, and test-list entry validation.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
