### PR TITLE
[None][fix] Add opt-in pinned staging for weight-load H2D copies

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -560,6 +560,20 @@ class DeepseekV4WeightLoader:
         self.is_draft_model = is_draft_model
 
     def load_weights(self, weights: Dict, skip_modules: List[str] = []):
+        # Scoped pinned staging (opt-in via TRTLLM_PINNED_WEIGHT_STAGING=1):
+        # on driver/platform combinations where pageable H2D copies degrade
+        # into a per-work-item crawl inside the CUDA driver (observed on
+        # GB300 + driver 590.48.01: one rank per node "hangs" in the load
+        # loop for 36 min to 4+ hours with zero errors), stage every
+        # CPU->CUDA weight copy through a pinned buffer for the duration of
+        # this load only. Buffers are freed and the original tensor methods
+        # restored on scope exit, so KV-cache host offloading
+        # (host_cache_size) and steady-state serving copies are untouched.
+        from tensorrt_llm._torch import pinned_weight_staging
+        with pinned_weight_staging.staging_scope():
+            return self._load_weights_impl(weights, skip_modules=skip_modules)
+
+    def _load_weights_impl(self, weights: Dict, skip_modules: List[str] = []):
         # If the checkpoint uses raw DS-V4 keys (layers.X.attn.wkv.weight,
         # mtp.0.*, embed.weight, head.weight), rewrite them to the model's
         # named-parameter keys before iterating modules. The detection is by

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -560,15 +560,9 @@ class DeepseekV4WeightLoader:
         self.is_draft_model = is_draft_model
 
     def load_weights(self, weights: Dict, skip_modules: List[str] = []):
-        # Scoped pinned staging (opt-in via TRTLLM_PINNED_WEIGHT_STAGING=1):
-        # on driver/platform combinations where pageable H2D copies degrade
-        # into a per-work-item crawl inside the CUDA driver (observed on
-        # GB300 + driver 590.48.01: one rank per node "hangs" in the load
-        # loop for 36 min to 4+ hours with zero errors), stage every
-        # CPU->CUDA weight copy through a pinned buffer for the duration of
-        # this load only. Buffers are freed and the original tensor methods
-        # restored on scope exit, so KV-cache host offloading
-        # (host_cache_size) and steady-state serving copies are untouched.
+        # Opt-in WAR (TRTLLM_PINNED_WEIGHT_STAGING=1) for drivers where
+        # pageable H2D copies stall during weight loading; staging buffers
+        # are freed on scope exit. See pinned_weight_staging.py.
         from tensorrt_llm._torch import pinned_weight_staging
         with pinned_weight_staging.staging_scope():
             return self._load_weights_impl(weights, skip_modules=skip_modules)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -564,6 +564,7 @@ class DeepseekV4WeightLoader:
         # pageable H2D copies stall during weight loading; staging buffers
         # are freed on scope exit. See pinned_weight_staging.py.
         from tensorrt_llm._torch import pinned_weight_staging
+
         with pinned_weight_staging.staging_scope():
             return self._load_weights_impl(weights, skip_modules=skip_modules)
 

--- a/tensorrt_llm/_torch/pinned_weight_staging.py
+++ b/tensorrt_llm/_torch/pinned_weight_staging.py
@@ -12,11 +12,13 @@ per-dtype pinned buffer for the duration of the scope. On exit the original
 methods are restored and the buffers are freed, leaving no pinned-memory
 footprint behind. Default off: without the env var the scope is a no-op.
 """
+
 import os
 import threading
 
 import torch
 
+from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.logger import logger
 
 _lock = threading.RLock()
@@ -27,7 +29,7 @@ _orig_copy = None
 
 
 def _enabled() -> bool:
-    return os.environ.get("TRTLLM_PINNED_WEIGHT_STAGING", "0") == "1"
+    return os.environ.get("TRTLLM_PINNED_WEIGHT_STAGING", "0") == "1" and prefer_pinned()
 
 
 def _pinned_clone(src: torch.Tensor) -> torch.Tensor:
@@ -35,9 +37,7 @@ def _pinned_clone(src: torch.Tensor) -> torch.Tensor:
     n = s.numel()
     b = _bufs.get(s.dtype)
     if b is None or b.numel() < n:
-        _bufs[s.dtype] = b = torch.empty(n,
-                                         dtype=s.dtype,
-                                         pin_memory=True)
+        _bufs[s.dtype] = b = torch.empty(n, dtype=s.dtype, pin_memory=prefer_pinned())
     v = b[:n].view(s.shape)
     v.copy_(s)
     return v
@@ -69,36 +69,50 @@ def _target_is_cuda(args, kwargs) -> bool:
 
 def _staged_to(self, *args, **kwargs):
     try:
-        if (self.device.type == "cpu" and self.layout == torch.strided
-                and self.numel() > 0 and not self.is_pinned()
-                and _target_is_cuda(args, kwargs)):
-            # The staging buffer is reused; the copy must stay synchronous.
+        if (
+            self.device.type == "cpu"
+            and self.layout == torch.strided
+            and self.numel() > 0
+            and not self.is_pinned()
+            and _target_is_cuda(args, kwargs)
+        ):
+            # The staging buffer is reused, so the copy must stay
+            # synchronous. non_blocking/copy may be passed positionally as
+            # bools; force them to False.
+            args = tuple(False if isinstance(a, bool) else a for a in args)
             kwargs.pop("non_blocking", None)
             with _lock:
                 return _orig_to(_pinned_clone(self), *args, **kwargs)
-    except Exception:
-        pass
+    except (RuntimeError, TypeError, ValueError, AttributeError) as e:
+        logger.debug(f"[pinned_weight_staging] to() fallback: {e}")
     return _orig_to(self, *args, **kwargs)
 
 
 def _staged_copy(self, src, non_blocking=False):
     try:
-        if (self.device.type == "cuda" and isinstance(src, torch.Tensor)
-                and src.device.type == "cpu" and src.layout == torch.strided
-                and src.numel() > 0 and not src.is_pinned()):
+        if (
+            self.device.type == "cuda"
+            and isinstance(src, torch.Tensor)
+            and src.device.type == "cpu"
+            and src.layout == torch.strided
+            and src.numel() > 0
+            and not src.is_pinned()
+        ):
             with _lock:
                 return _orig_copy(self, _pinned_clone(src), False)
-    except Exception:
-        pass
+    except (RuntimeError, TypeError, ValueError, AttributeError) as e:
+        logger.debug(f"[pinned_weight_staging] copy_() fallback: {e}")
     return _orig_copy(self, src, non_blocking)
 
 
-class staging_scope:
+class _StagingScope:
     """Re-entrant: nested scopes share one installation, freed at depth 0."""
 
     def __enter__(self):
         global _depth, _orig_to, _orig_copy
-        if not _enabled():
+        # Record activation so a mid-scope env change cannot skip cleanup.
+        self._active = _enabled()
+        if not self._active:
             return self
         with _lock:
             _depth += 1
@@ -109,12 +123,13 @@ class staging_scope:
                 torch.Tensor.copy_ = _staged_copy
                 logger.info(
                     "[pinned_weight_staging] staging scope enter: pageable "
-                    "CPU->CUDA weight copies go through pinned buffers")
+                    "CPU->CUDA weight copies go through pinned buffers"
+                )
         return self
 
     def __exit__(self, exc_type, exc, tb):
         global _depth, _orig_to, _orig_copy
-        if not _enabled():
+        if not getattr(self, "_active", False):
             return False
         with _lock:
             _depth -= 1
@@ -124,19 +139,24 @@ class staging_scope:
                     torch.Tensor.to = _orig_to
                 if _orig_copy is not None:
                     torch.Tensor.copy_ = _orig_copy
-                freed = sum(b.numel() * b.element_size()
-                            for b in _bufs.values())
+                freed = sum(b.numel() * b.element_size() for b in _bufs.values())
                 _bufs.clear()
                 # Return freed pinned pages to the OS, not just to torch's
                 # caching host allocator.
-                hec = (getattr(torch.cuda, "host_empty_cache", None)
-                       or getattr(torch._C, "_host_emptyCache", None))
+                hec = getattr(torch.cuda, "host_empty_cache", None) or getattr(
+                    torch._C, "_host_emptyCache", None
+                )
                 if hec is not None:
                     try:
                         hec()
-                    except Exception:
-                        pass
+                    except (RuntimeError, AttributeError) as e:
+                        logger.debug(f"[pinned_weight_staging] host_empty_cache: {e}")
                 logger.info(
                     "[pinned_weight_staging] staging scope exit: released "
-                    f"{freed / (1 << 30):.2f} GiB of pinned staging buffers")
+                    f"{freed / (1 << 30):.2f} GiB of pinned staging buffers"
+                )
         return False
+
+
+def staging_scope() -> _StagingScope:
+    return _StagingScope()

--- a/tensorrt_llm/_torch/pinned_weight_staging.py
+++ b/tensorrt_llm/_torch/pinned_weight_staging.py
@@ -1,29 +1,16 @@
-"""Scoped pinned staging for weight-load host-to-device copies.
+"""Opt-in pinned staging for weight-load host-to-device copies.
 
-On some platform/driver configurations (observed on GB300 NVL72 with driver
-590.48.01 under specific per-node profiling configurations), pageable
-host-to-device copies issued during checkpoint materialization can degrade
-into a pathological per-work-item polling crawl inside the CUDA driver,
-stretching sub-second copies to tens of minutes. The visible symptom is a
-weight-load "hang": typically one rank per node stops making progress in the
-``Loading weights`` phase with zero errors, and eventually completes after
-36 min to 4+ hours. Staging the copies through a pinned buffer routes them
-onto the pinned-DMA path, which is unaffected.
+Some driver/platform combinations degrade pageable H2D copies during
+checkpoint loading into extreme slowdowns (observed on GB300 with driver
+590.48.01: one rank per node stalls in ``Loading weights`` for 36 min to
+4+ hours, no errors). Staging through pinned memory avoids the affected
+driver path.
 
-Usage (gated by ``TRTLLM_PINNED_WEIGHT_STAGING=1``, default off):
-
-    from tensorrt_llm._torch import pinned_weight_staging
-    with pinned_weight_staging.staging_scope():
-        ...load weights...
-
-Inside the scope, every pageable CPU->CUDA ``Tensor.to`` / ``Tensor.copy_``
-is rerouted through a per-dtype pinned staging buffer. The staged copy is
-forced synchronous and lock-protected because the buffer is reused. On scope
-exit the original tensor methods are restored and all staging buffers are
-freed (best-effort ``host_empty_cache`` so the pinned pages actually return
-to the OS), so pinned-host consumers that come up later -- e.g. the KV-cache
-host offload pool sized by ``host_cache_size`` -- see zero residual
-footprint, and steady-state serving copies are untouched.
+With ``TRTLLM_PINNED_WEIGHT_STAGING=1``, ``staging_scope()`` reroutes
+pageable CPU->CUDA ``Tensor.to``/``Tensor.copy_`` through a reusable
+per-dtype pinned buffer for the duration of the scope. On exit the original
+methods are restored and the buffers are freed, leaving no pinned-memory
+footprint behind. Default off: without the env var the scope is a no-op.
 """
 import os
 import threading
@@ -107,12 +94,7 @@ def _staged_copy(self, src, non_blocking=False):
 
 
 class staging_scope:
-    """Reroute pageable CPU->CUDA copies through pinned staging for the
-    dynamic extent of a weight load; restore and free everything on exit.
-
-    Re-entrant: nested scopes share one installation, freed at depth 0.
-    A no-op unless ``TRTLLM_PINNED_WEIGHT_STAGING=1``.
-    """
+    """Re-entrant: nested scopes share one installation, freed at depth 0."""
 
     def __enter__(self):
         global _depth, _orig_to, _orig_copy
@@ -145,8 +127,8 @@ class staging_scope:
                 freed = sum(b.numel() * b.element_size()
                             for b in _bufs.values())
                 _bufs.clear()
-                # Best-effort: push the freed pinned blocks out of torch's
-                # caching host allocator so the pages return to the OS.
+                # Return freed pinned pages to the OS, not just to torch's
+                # caching host allocator.
                 hec = (getattr(torch.cuda, "host_empty_cache", None)
                        or getattr(torch._C, "_host_emptyCache", None))
                 if hec is not None:

--- a/tensorrt_llm/_torch/pinned_weight_staging.py
+++ b/tensorrt_llm/_torch/pinned_weight_staging.py
@@ -1,0 +1,160 @@
+"""Scoped pinned staging for weight-load host-to-device copies.
+
+On some platform/driver configurations (observed on GB300 NVL72 with driver
+590.48.01 under specific per-node profiling configurations), pageable
+host-to-device copies issued during checkpoint materialization can degrade
+into a pathological per-work-item polling crawl inside the CUDA driver,
+stretching sub-second copies to tens of minutes. The visible symptom is a
+weight-load "hang": typically one rank per node stops making progress in the
+``Loading weights`` phase with zero errors, and eventually completes after
+36 min to 4+ hours. Staging the copies through a pinned buffer routes them
+onto the pinned-DMA path, which is unaffected.
+
+Usage (gated by ``TRTLLM_PINNED_WEIGHT_STAGING=1``, default off):
+
+    from tensorrt_llm._torch import pinned_weight_staging
+    with pinned_weight_staging.staging_scope():
+        ...load weights...
+
+Inside the scope, every pageable CPU->CUDA ``Tensor.to`` / ``Tensor.copy_``
+is rerouted through a per-dtype pinned staging buffer. The staged copy is
+forced synchronous and lock-protected because the buffer is reused. On scope
+exit the original tensor methods are restored and all staging buffers are
+freed (best-effort ``host_empty_cache`` so the pinned pages actually return
+to the OS), so pinned-host consumers that come up later -- e.g. the KV-cache
+host offload pool sized by ``host_cache_size`` -- see zero residual
+footprint, and steady-state serving copies are untouched.
+"""
+import os
+import threading
+
+import torch
+
+from tensorrt_llm.logger import logger
+
+_lock = threading.RLock()
+_depth = 0
+_bufs = {}
+_orig_to = None
+_orig_copy = None
+
+
+def _enabled() -> bool:
+    return os.environ.get("TRTLLM_PINNED_WEIGHT_STAGING", "0") == "1"
+
+
+def _pinned_clone(src: torch.Tensor) -> torch.Tensor:
+    s = src.contiguous()
+    n = s.numel()
+    b = _bufs.get(s.dtype)
+    if b is None or b.numel() < n:
+        _bufs[s.dtype] = b = torch.empty(n,
+                                         dtype=s.dtype,
+                                         pin_memory=True)
+    v = b[:n].view(s.shape)
+    v.copy_(s)
+    return v
+
+
+def _target_is_cuda(args, kwargs) -> bool:
+    d = kwargs.get("device", None)
+    if d is None:
+        for a in args:
+            if isinstance(a, torch.device):
+                d = a
+                break
+            if isinstance(a, str):
+                try:
+                    d = torch.device(a)
+                except (RuntimeError, ValueError):
+                    d = None
+                break
+            if isinstance(a, torch.Tensor):
+                d = a.device
+                break
+    elif not isinstance(d, torch.device):
+        try:
+            d = torch.device(d)
+        except (RuntimeError, ValueError, TypeError):
+            d = None
+    return d is not None and getattr(d, "type", None) == "cuda"
+
+
+def _staged_to(self, *args, **kwargs):
+    try:
+        if (self.device.type == "cpu" and self.layout == torch.strided
+                and self.numel() > 0 and not self.is_pinned()
+                and _target_is_cuda(args, kwargs)):
+            # The staging buffer is reused; the copy must stay synchronous.
+            kwargs.pop("non_blocking", None)
+            with _lock:
+                return _orig_to(_pinned_clone(self), *args, **kwargs)
+    except Exception:
+        pass
+    return _orig_to(self, *args, **kwargs)
+
+
+def _staged_copy(self, src, non_blocking=False):
+    try:
+        if (self.device.type == "cuda" and isinstance(src, torch.Tensor)
+                and src.device.type == "cpu" and src.layout == torch.strided
+                and src.numel() > 0 and not src.is_pinned()):
+            with _lock:
+                return _orig_copy(self, _pinned_clone(src), False)
+    except Exception:
+        pass
+    return _orig_copy(self, src, non_blocking)
+
+
+class staging_scope:
+    """Reroute pageable CPU->CUDA copies through pinned staging for the
+    dynamic extent of a weight load; restore and free everything on exit.
+
+    Re-entrant: nested scopes share one installation, freed at depth 0.
+    A no-op unless ``TRTLLM_PINNED_WEIGHT_STAGING=1``.
+    """
+
+    def __enter__(self):
+        global _depth, _orig_to, _orig_copy
+        if not _enabled():
+            return self
+        with _lock:
+            _depth += 1
+            if _depth == 1:
+                _orig_to = torch.Tensor.to
+                _orig_copy = torch.Tensor.copy_
+                torch.Tensor.to = _staged_to
+                torch.Tensor.copy_ = _staged_copy
+                logger.info(
+                    "[pinned_weight_staging] staging scope enter: pageable "
+                    "CPU->CUDA weight copies go through pinned buffers")
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        global _depth, _orig_to, _orig_copy
+        if not _enabled():
+            return False
+        with _lock:
+            _depth -= 1
+            if _depth <= 0:
+                _depth = 0
+                if _orig_to is not None:
+                    torch.Tensor.to = _orig_to
+                if _orig_copy is not None:
+                    torch.Tensor.copy_ = _orig_copy
+                freed = sum(b.numel() * b.element_size()
+                            for b in _bufs.values())
+                _bufs.clear()
+                # Best-effort: push the freed pinned blocks out of torch's
+                # caching host allocator so the pages return to the OS.
+                hec = (getattr(torch.cuda, "host_empty_cache", None)
+                       or getattr(torch._C, "_host_emptyCache", None))
+                if hec is not None:
+                    try:
+                        hec()
+                    except Exception:
+                        pass
+                logger.info(
+                    "[pinned_weight_staging] staging scope exit: released "
+                    f"{freed / (1 << 30):.2f} GiB of pinned staging buffers")
+        return False

--- a/tests/unittest/_torch/misc/test_pinned_weight_staging.py
+++ b/tests/unittest/_torch/misc/test_pinned_weight_staging.py
@@ -21,11 +21,11 @@ class TestPinnedWeightStaging(unittest.TestCase):
         self.assertIs(torch.Tensor.to, orig_to)
         self.assertIs(torch.Tensor.copy_, orig_copy)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
     def test_enabled_installs_and_restores(self):
         orig_to = torch.Tensor.to
         orig_copy = torch.Tensor.copy_
-        with mock.patch.dict(os.environ,
-                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+        with mock.patch.dict(os.environ, {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
             with pinned_weight_staging.staging_scope():
                 self.assertIsNot(torch.Tensor.to, orig_to)
                 self.assertIsNot(torch.Tensor.copy_, orig_copy)
@@ -37,8 +37,9 @@ class TestPinnedWeightStaging(unittest.TestCase):
             self.assertEqual(len(pinned_weight_staging._bufs), 0)
 
     def test_cpu_paths_unaffected_inside_scope(self):
-        with mock.patch.dict(os.environ,
-                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+        # Also covers the CPU-only case where prefer_pinned() disables
+        # staging and the scope is a no-op.
+        with mock.patch.dict(os.environ, {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
             with pinned_weight_staging.staging_scope():
                 x = torch.randn(8, 8)
                 y = x.to(torch.float64)
@@ -49,8 +50,7 @@ class TestPinnedWeightStaging(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
     def test_staged_h2d_correctness_and_release(self):
-        with mock.patch.dict(os.environ,
-                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+        with mock.patch.dict(os.environ, {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
             with pinned_weight_staging.staging_scope():
                 for dtype in (torch.float32, torch.bfloat16, torch.uint8):
                     if dtype.is_floating_point:
@@ -73,8 +73,7 @@ class TestPinnedWeightStaging(unittest.TestCase):
 
     @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
     def test_pinned_source_bypasses_staging(self):
-        with mock.patch.dict(os.environ,
-                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+        with mock.patch.dict(os.environ, {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
             with pinned_weight_staging.staging_scope():
                 src = torch.randn(32, 32).pin_memory()
                 dev = src.to("cuda")

--- a/tests/unittest/_torch/misc/test_pinned_weight_staging.py
+++ b/tests/unittest/_torch/misc/test_pinned_weight_staging.py
@@ -1,0 +1,86 @@
+import os
+import unittest
+from unittest import mock
+
+import torch
+
+from tensorrt_llm._torch import pinned_weight_staging
+
+
+class TestPinnedWeightStaging(unittest.TestCase):
+    """Tests for the scoped pinned-staging weight-load path."""
+
+    def test_disabled_by_default_is_noop(self):
+        orig_to = torch.Tensor.to
+        orig_copy = torch.Tensor.copy_
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TRTLLM_PINNED_WEIGHT_STAGING", None)
+            with pinned_weight_staging.staging_scope():
+                self.assertIs(torch.Tensor.to, orig_to)
+                self.assertIs(torch.Tensor.copy_, orig_copy)
+        self.assertIs(torch.Tensor.to, orig_to)
+        self.assertIs(torch.Tensor.copy_, orig_copy)
+
+    def test_enabled_installs_and_restores(self):
+        orig_to = torch.Tensor.to
+        orig_copy = torch.Tensor.copy_
+        with mock.patch.dict(os.environ,
+                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+            with pinned_weight_staging.staging_scope():
+                self.assertIsNot(torch.Tensor.to, orig_to)
+                self.assertIsNot(torch.Tensor.copy_, orig_copy)
+                # Nested scopes share one installation.
+                with pinned_weight_staging.staging_scope():
+                    self.assertIsNot(torch.Tensor.to, orig_to)
+            self.assertIs(torch.Tensor.to, orig_to)
+            self.assertIs(torch.Tensor.copy_, orig_copy)
+            self.assertEqual(len(pinned_weight_staging._bufs), 0)
+
+    def test_cpu_paths_unaffected_inside_scope(self):
+        with mock.patch.dict(os.environ,
+                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+            with pinned_weight_staging.staging_scope():
+                x = torch.randn(8, 8)
+                y = x.to(torch.float64)
+                self.assertEqual(y.dtype, torch.float64)
+                z = torch.empty(8, 8)
+                z.copy_(x)
+                torch.testing.assert_close(z, x)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
+    def test_staged_h2d_correctness_and_release(self):
+        with mock.patch.dict(os.environ,
+                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+            with pinned_weight_staging.staging_scope():
+                for dtype in (torch.float32, torch.bfloat16, torch.uint8):
+                    if dtype.is_floating_point:
+                        src = torch.randn(257, 129).to(dtype)
+                    else:
+                        src = torch.randint(0, 255, (257, 129), dtype=dtype)
+                    dev = src.to("cuda")
+                    torch.testing.assert_close(dev.cpu(), src)
+                    dst = torch.empty_like(src, device="cuda")
+                    dst.copy_(src)
+                    torch.testing.assert_close(dst.cpu(), src)
+                # Non-contiguous and sliced sources.
+                base = torch.randn(64, 64)
+                view = base[::2, 1:33]
+                torch.testing.assert_close(view.to("cuda").cpu(), view)
+                # Buffers exist while the scope is open...
+                self.assertGreater(len(pinned_weight_staging._bufs), 0)
+            # ...and are freed on exit.
+            self.assertEqual(len(pinned_weight_staging._bufs), 0)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
+    def test_pinned_source_bypasses_staging(self):
+        with mock.patch.dict(os.environ,
+                             {"TRTLLM_PINNED_WEIGHT_STAGING": "1"}):
+            with pinned_weight_staging.staging_scope():
+                src = torch.randn(32, 32).pin_memory()
+                dev = src.to("cuda")
+                torch.testing.assert_close(dev.cpu(), src)
+                self.assertEqual(len(pinned_weight_staging._bufs), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

**Problem.** On some platform/driver configurations, pageable host-to-device copies issued during checkpoint materialization degrade into a pathological per-work-item polling crawl inside the CUDA driver. Observed on a GB300 NVL72 cluster with driver 590.48.01: during DeepSeek-V4 weight loading (TP4, ~200 GiB H2D per rank), typically exactly one rank per node stops making visible progress in the `Loading weights` loop — no exception, no OOM, no Xid — and completes only after 36 minutes to 4+ hours (vs ~3 minutes healthy), turning into multi-hour CI timeouts.

Instruction-level forensics on a live occurrence: py-spy pins the affected rank inside a single `tensor.to(device)` (`linear.py::load_weight_shard`); PC sampling + disassembly show a per-work-item completion-poll loop inside libcuda with a ~260 µs backoff per item (the loop *advances*, pathologically slowly). During the crawl, thread page faults, process `read_bytes`, and node reclaim counters are all exactly zero — host memory, page cache, disk, NUMA and MPI were each ruled out by direct measurement. Two control clusters on driver 580.x never reproduce with identical configs, so the driver-side root cause is being pursued separately; this PR adds a load-time mitigation.

**Fix (opt-in, default off).** New `tensorrt_llm/_torch/pinned_weight_staging.py` provides `staging_scope()`: when `TRTLLM_PINNED_WEIGHT_STAGING=1`, pageable CPU→CUDA `Tensor.to` / `Tensor.copy_` are rerouted through a reusable per-dtype **pinned staging buffer** for the dynamic extent of a weight load, moving the copies onto the pinned-DMA path, which is unaffected. `DeepseekV4WeightLoader.load_weights` is wrapped in the scope (one wrap covers all ~30 copy sites in the loader). Staged copies are forced synchronous and lock-protected because the buffer is reused.

**Lifecycle guarantees**: on scope exit the original tensor methods are restored and all staging buffers are freed (best-effort `host_empty_cache` so the pinned pages return to the OS) — later pinned-host consumers such as the KV-cache host offload pool (`host_cache_size`) see zero residual footprint, and steady-state serving copies are untouched. Without the env var the scope is a no-op.

**Validation** — A/B on the affected cluster (3-node jobs, 4 ranks/node, DeepSeek-V4 ~805 GiB checkpoint; verdict: a node "stalls" when a rank makes no load progress for 5+ minutes):

| arm | jobs | node instances | stalled |
|---|---|---|---|
| control (pageable, stock) | 4/4 FAIL | 12 | **7 (58%)** — matches the 60%/node historical baseline (29/48) on the same rack |
| staged, process-wide prototype | 4/4 PASS | 12 | **0** |
| staged, this PR's scoped variant | 4/4 PASS | 12 | **0** |

All arms ran interleaved in the same time window on the same rack. Fisher exact, staged combined vs control (0/24 vs 7/12): p ≈ 1e-4; against the 60%/node historical baseline, P(0/24 staged) ≈ 3e-10. Buffer release verified in logs: every rank prints `RELEASED 1.85 GiB staging (returned to OS)` at scope exit, so peak staging cost was 1.85 GiB pinned per rank, held only during the load. Overhead of the extra CPU→pinned memcpy: ~10–15% on the weight-load phase (inits 154–236 s staged vs 149–212 s on control nodes that did not crawl; stalled control nodes ran 500–850+ s and were still incomplete when cancelled).

## Test Coverage

- `tests/unittest/_torch/misc/test_pinned_weight_staging.py`:
  - disabled-by-default is a strict no-op (methods untouched)
  - install/restore semantics incl. re-entrant nesting; buffers freed at scope exit
  - CPU-only paths unaffected inside the scope
  - staged H2D correctness across dtypes (fp32/bf16/uint8), non-contiguous and sliced sources (CUDA)
  - pinned sources bypass staging (CUDA)

## PR Checklist

- [x] PR description explains what and why
- [x] Follows TRT-LLM coding guidelines to the best of my knowledge
- [x] Test cases provided for the new code path
- [x] No API changes (opt-in env var, default off)
- [x] No new dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added opt-in pinned staging for pageable host-to-device weight-load copies.
- `TRTLLM_PINNED_WEIGHT_STAGING=1` enables the behavior. Default behavior remains unchanged.
- Staged copies are synchronous and lock-protected.
- The scope restores patched tensor methods and releases staging buffers on exit.
- Nested scopes share one installation.
- Staging is disabled when pinned memory is unavailable.
- No configuration-file or test-list changes were found.
- No correctness or API issues were identified from the reviewed changes.

## QA Engineer Review

- Added tests for disabled behavior, installation and restoration, nested scopes, CPU-only operations, multiple data types, non-contiguous sources, pinned-source bypasses, buffer cleanup, and CUDA host-to-device staging.
- The test functions are not listed in `tests/integration/test_lists/`, `test-db/`, or `qa/`.
- Verdict: **insufficient**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->